### PR TITLE
Remove duplicate yaml deployment from kubectl_test

### DIFF
--- a/api/pkg/apis/v1alpha1/providers/target/helm/helm_test.go
+++ b/api/pkg/apis/v1alpha1/providers/target/helm/helm_test.go
@@ -543,6 +543,7 @@ func TestDownloadFile(t *testing.T) {
 
 	err := downloadFile(ts.URL, "test")
 	assert.Nil(t, err)
+	_ = os.Remove("test")
 }
 
 func TestGetActionConfig(t *testing.T) {

--- a/api/pkg/apis/v1alpha1/providers/target/kubectl/kubectl_test.go
+++ b/api/pkg/apis/v1alpha1/providers/target/kubectl/kubectl_test.go
@@ -565,7 +565,7 @@ func TestConformanceSuite(t *testing.T) {
 	conformance.ConformanceSuite(t, provider)
 }
 
-func TestKubectlTargetProviderApply(t *testing.T) {
+func TestKubectlTargetProviderApplyFailed(t *testing.T) {
 	testGatekeeper := os.Getenv("TEST_KUBECTL")
 	if testGatekeeper == "" {
 		t.Skip("Skipping because TEST_KUBECTL environment variable is not set")
@@ -585,43 +585,6 @@ func TestKubectlTargetProviderApply(t *testing.T) {
 	provider.DynamicClient = dynamicClient
 
 	component := model.ComponentSpec{
-		Name: "gatekeeper",
-		Type: "yaml.k8s",
-		Properties: map[string]interface{}{
-			"yaml": "https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/deploy/gatekeeper.yaml",
-		},
-	}
-	deployment := model.DeploymentSpec{
-		Instance: model.InstanceSpec{
-			Name:  "gatekeeper",
-			Scope: "gatekeeper-system",
-		},
-		Solution: model.SolutionSpec{
-			Components: []model.ComponentSpec{component},
-		},
-	}
-	step := model.DeploymentStep{
-		Components: []model.ComponentStep{
-			{
-				Action:    "update",
-				Component: component,
-			},
-		},
-	}
-	_, err = provider.Apply(context.Background(), deployment, step, false)
-	assert.Nil(t, err)
-	step = model.DeploymentStep{
-		Components: []model.ComponentStep{
-			{
-				Action:    "delete",
-				Component: component,
-			},
-		},
-	}
-	_, err = provider.Apply(context.Background(), deployment, step, false)
-	assert.Nil(t, err)
-
-	component = model.ComponentSpec{
 		Name: "nginx",
 		Type: "yaml.k8s",
 		Properties: map[string]interface{}{
@@ -634,7 +597,7 @@ func TestKubectlTargetProviderApply(t *testing.T) {
 			},
 		},
 	}
-	deployment = model.DeploymentSpec{
+	deployment := model.DeploymentSpec{
 		Instance: model.InstanceSpec{
 			Name:  "nginx",
 			Scope: "nginx-system",
@@ -643,7 +606,7 @@ func TestKubectlTargetProviderApply(t *testing.T) {
 			Components: []model.ComponentSpec{component},
 		},
 	}
-	step = model.DeploymentStep{
+	step := model.DeploymentStep{
 		Components: []model.ComponentStep{
 			{
 				Action:    "update",


### PR DESCRIPTION
- Remove duplicate deployment of yaml.k8s type in kubectl test case and it was covered `TestKubectlTargetProviderPathApply` and `TestKubectlTargetProviderDelete`. Recreation may cause namespace being terminated while running new deployment. Just test resource type Apply failure in `TestKubectlTargetProviderApplyFailed`.
-  Cleanup `test` file after running download test in helm_test