### PR TITLE
Implement cleaner that clear out old activations

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/activations/activations-cleanup-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/activations/activations-cleanup-manager.go
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package activations
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/azure/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/azure/symphony/coa/pkg/apis/v1alpha2/contexts"
+	"github.com/azure/symphony/coa/pkg/apis/v1alpha2/managers"
+	"github.com/azure/symphony/coa/pkg/apis/v1alpha2/providers"
+)
+
+const (
+	// DefaultRetentionInMinutes is the default time to cleanup completed activations
+	DefaultRetentionInMinutes = 1440
+)
+
+type ActivationsCleanupManager struct {
+	ActivationsManager
+	RetentionInMinutes int
+}
+
+func (s *ActivationsCleanupManager) Init(context *contexts.VendorContext, config managers.ManagerConfig, providers map[string]providers.IProvider) error {
+	err := s.ActivationsManager.Init(context, config, providers)
+	if err != nil {
+		return err
+	}
+
+	// Set activation cleanup interval after they are done. If not set, use default 60 minutes.
+	if val, ok := config.Properties["RetentionInMinutes"]; ok {
+		s.RetentionInMinutes, err = strconv.Atoi(val)
+		if err != nil {
+			s.RetentionInMinutes = DefaultRetentionInMinutes
+		}
+	} else {
+		s.RetentionInMinutes = DefaultRetentionInMinutes
+	}
+	log.Info("M (Activation Cleanup): Initialize RetentionInMinutes as " + fmt.Sprint(s.RetentionInMinutes))
+	return nil
+}
+
+func (s *ActivationsCleanupManager) Enabled() bool {
+	return true
+}
+
+func (s *ActivationsCleanupManager) Poll() []error {
+	log.Info("M (Activation Cleanup): Polling activations")
+	activations, err := s.ActivationsManager.ListSpec(context.Background())
+	if err != nil {
+		return []error{err}
+	}
+	ret := []error{}
+	for _, activation := range activations {
+		if activation.Status.Status != v1alpha2.Done {
+			continue
+		}
+		if activation.Status.UpdateTime == "" {
+			// Ugrade scenario: update time is not set for activations created before. Set it to now and the activation will be deleted later.
+			// UpdateTime will be set in ReportStatus function
+			err = s.ActivationsManager.ReportStatus(context.Background(), activation.Id, *activation.Status)
+			if err != nil {
+				// Delete activation immediately if update time cannot be set? Cx may be confused why activations disappeared
+				// Just leave those activations as it is and let Cx delete them manually
+				log.Error("M (Activation Cleanup): Cannot set update time for activation "+activation.Id+" since update time cannot be set: %+v", err)
+				ret = append(ret, err)
+			}
+			continue
+		}
+
+		// Check update time of completed activations.
+		updateTime, err := time.Parse(time.RFC3339, activation.Status.UpdateTime)
+		if err != nil {
+			// TODO: should not happen, force update time to Time.Now() ?
+			log.Info("M (Activation Cleanup): Cannot parse update time of " + activation.Id)
+			ret = append(ret, err)
+		}
+		duration := time.Since(updateTime)
+		if duration > time.Duration(s.RetentionInMinutes)*time.Minute {
+			log.Info("M (Activation Cleanup): Deleting activation " + activation.Id + " since it has completed for " + duration.String())
+			err = s.ActivationsManager.DeleteSpec(context.Background(), activation.Id)
+			if err != nil {
+				ret = append(ret, err)
+			}
+		}
+	}
+	return ret
+}
+
+func (s *ActivationsCleanupManager) Reconcil() []error {
+	return nil
+}

--- a/api/pkg/apis/v1alpha1/managers/managerfactory.go
+++ b/api/pkg/apis/v1alpha1/managers/managerfactory.go
@@ -69,6 +69,8 @@ func (c *SymphonyManagerFactory) CreateManager(config cm.ManagerConfig) (cm.IMan
 		manager = &catalogs.CatalogsManager{}
 	case "managers.symphony.activations":
 		manager = &activations.ActivationsManager{}
+	case "managers.symphony.activationscleanup":
+		manager = &activations.ActivationsCleanupManager{}
 	case "managers.symphony.stage":
 		manager = &stage.StageManager{}
 	case "managers.symphony.configs":

--- a/api/pkg/apis/v1alpha1/model/campaign.go
+++ b/api/pkg/apis/v1alpha1/model/campaign.go
@@ -77,6 +77,7 @@ type ActivationStatus struct {
 	ErrorMessage         string                 `json:"errorMessage,omitempty"`
 	IsActive             bool                   `json:"isActive,omitempty"`
 	ActivationGeneration string                 `json:"activationGeneration,omitempty"`
+	UpdateTime           string                 `json:"updateTime,omitempty"`
 }
 
 type ActivationSpec struct {

--- a/api/pkg/apis/v1alpha1/vendors/backgroundjob-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/backgroundjob-vendor.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package vendors
+
+import (
+	"github.com/azure/symphony/api/pkg/apis/v1alpha1/managers/activations"
+	"github.com/azure/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/azure/symphony/coa/pkg/apis/v1alpha2/managers"
+	"github.com/azure/symphony/coa/pkg/apis/v1alpha2/providers"
+	"github.com/azure/symphony/coa/pkg/apis/v1alpha2/providers/pubsub"
+	"github.com/azure/symphony/coa/pkg/apis/v1alpha2/vendors"
+)
+
+type BackgroundJobVendor struct {
+	vendors.Vendor
+	// Add a new manager if you want to add another background job
+	ActivationsCleanerManager *activations.ActivationsCleanupManager
+}
+
+func (s *BackgroundJobVendor) GetInfo() vendors.VendorInfo {
+	return vendors.VendorInfo{
+		Version:  s.Vendor.Version,
+		Name:     "BackgroundJob",
+		Producer: "Microsoft",
+	}
+}
+
+func (o *BackgroundJobVendor) GetEndpoints() []v1alpha2.Endpoint {
+	return []v1alpha2.Endpoint{}
+}
+
+func (s *BackgroundJobVendor) Init(config vendors.VendorConfig, factories []managers.IManagerFactroy, providers map[string]map[string]providers.IProvider, pubsubProvider pubsub.IPubSubProvider) error {
+	err := s.Vendor.Init(config, factories, providers, pubsubProvider)
+	if err != nil {
+		return err
+	}
+	for _, m := range s.Managers {
+		if c, ok := m.(*activations.ActivationsCleanupManager); ok {
+			s.ActivationsCleanerManager = c
+		}
+		// Load a new manager if you want to add another background job
+	}
+	if s.ActivationsCleanerManager != nil {
+		log.Info("ActivationsCleanupManager is enabled")
+	} else {
+		log.Info("ActivationsCleanupManager is disabled")
+	}
+	return nil
+}

--- a/api/pkg/apis/v1alpha1/vendors/stage-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/stage-vendor.go
@@ -73,6 +73,7 @@ func (s *StageVendor) Init(config vendors.VendorConfig, factories []managers.IMa
 		return v1alpha2.NewCOAError(nil, "activations manager is not supplied", v1alpha2.MissingConfig)
 	}
 	s.Vendor.Context.Subscribe("activation", func(topic string, event v1alpha2.Event) error {
+		log.Info("V (Stage): handling activation event")
 		var actData v1alpha2.ActivationData
 		jData, _ := json.Marshal(event.Body)
 		err := json.Unmarshal(jData, &actData)
@@ -81,10 +82,12 @@ func (s *StageVendor) Init(config vendors.VendorConfig, factories []managers.IMa
 		}
 		campaign, err := s.CampaignsManager.GetSpec(context.TODO(), actData.Campaign)
 		if err != nil {
+			log.Error("V (Stage): unable to find campaign: %+v", err)
 			return err
 		}
 		activation, err := s.ActivationsManager.GetSpec(context.TODO(), actData.Activation)
 		if err != nil {
+			log.Error("V (Stage): unable to find activation: %+v", err)
 			return err
 		}
 

--- a/api/pkg/apis/v1alpha1/vendors/vendorfactory.go
+++ b/api/pkg/apis/v1alpha1/vendors/vendorfactory.go
@@ -53,6 +53,8 @@ func (c SymphonyVendorFactory) CreateVendor(config vendors.VendorConfig) (vendor
 		return &SettingsVendor{}, nil
 	case "vendors.trails":
 		return &TrailsVendor{}, nil
+	case "vendors.backgroundjob":
+		return &BackgroundJobVendor{}, nil
 	default:
 		return nil, nil //Can't throw errors as other factories may create it...
 	}

--- a/api/symphony-api-no-k8s.json
+++ b/api/symphony-api-no-k8s.json
@@ -126,6 +126,28 @@
         ]
       },
       {
+        "type": "vendors.backgroundjob",
+        "route": "backgroundjob",
+        "loopInterval": 60,
+        "managers": [
+          {
+            "name": "activations-cleanup-manager",
+            "type": "managers.symphony.activationscleanup",
+            "properties": {
+              "providers.state": "k8s-state",
+              "singleton": "true",
+              "RetentionInMinutes": "1440"
+            },
+            "providers": {
+              "k8s-state": {
+                "type": "providers.state.memory",
+                "config": {}
+              }
+            }
+          }
+        ]
+      },
+      {
         "type": "vendors.campaigns",
         "route": "campaigns",
         "managers": [

--- a/k8s/config/oss/crd/bases/workflow.symphony_activations.yaml
+++ b/k8s/config/oss/crd/bases/workflow.symphony_activations.yaml
@@ -27,6 +27,9 @@ spec:
     - jsonPath: .status.status
       name: Status
       type: string
+    - jsonPath: .status.updateTime
+      name: Update Time
+      type: string
     name: v1
     schema:
       openAPIV3Schema:

--- a/packages/helm/symphony/files/symphony-api.json
+++ b/packages/helm/symphony/files/symphony-api.json
@@ -139,7 +139,32 @@
             "name": "activations-manager",
             "type": "managers.symphony.activations",
             "properties": {
-              "providers.state": "k8s-state"
+              "providers.state": "k8s-state",
+              "cleanupInterval": "15"
+            },
+            "providers": {
+              "k8s-state": {
+                "type": "providers.state.k8s",
+                "config": {
+                  "inCluster": true
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "vendors.backgroundjob",
+        "route": "backgroundjob",
+        "loopInterval": 60,
+        "managers": [
+          {
+            "name": "activations-cleanup-manager",
+            "type": "managers.symphony.activationscleanup",
+            "properties": {
+              "providers.state": "k8s-state",
+              "singleton": "true",
+              "RetentionInMinutes": "1440"
             },
             "providers": {
               "k8s-state": {

--- a/packages/helm/symphony/templates/symphony.yaml
+++ b/packages/helm/symphony/templates/symphony.yaml
@@ -32,6 +32,9 @@ spec:
     - jsonPath: .status.status
       name: Status
       type: string
+    - jsonPath: .status.updateTime
+      name: Update Time
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -81,6 +84,9 @@ spec:
               status:
                 description: State represents a response state
                 type: integer
+              updateTime:
+                description: Update Time of the actication
+                type: string
             required:
             - stage
             type: object


### PR DESCRIPTION
Issue: https://github.com/Azure/symphony/issues/92

1. Add a new field "UpdateTime" in ActivationStatus, symphony response and k8s activation CRD. New response from symphony core API and k8s activation appearance examples are listed at the end.
2. Leverage existing looping jobs for managers to periodically check activation status and update time and delete old ones from state provider. The frequency of looping jobs can be changed via "loopInterval" and the definition of old activations can be changed via cleanupInterval. Both are defined in symphony core configuration. Currently, we don't support changing it at runtime.
3. Unit test

Test plan:

Unit test. Coverage of activation managers increases from 29.9% to 70.1%
Before
ok github.com/azure/symphony/api/pkg/apis/v1alpha1/managers/activations (cached) coverage: 29.9% of statements
After
ok github.com/azure/symphony/api/pkg/apis/v1alpha1/managers/activations 0.005s coverage: 70.1% of statements

Manual testing on standalone symphony including new update time field and cleanup logic

Manual testing on K8S including new update time field and cleanup logic

Examples:

Symphony core GET activation response appearance
![image](https://github.com/eclipse-symphony/symphony/assets/9944145/980641ae-3916-42dc-befc-bfb4439f83c1)
k8s activation CRD example
![image](https://github.com/eclipse-symphony/symphony/assets/9944145/e593aec5-1d25-471b-aaf0-1d641b1ed251)