### PR TITLE
Fix error in target manager ReportStatus function and add test coverage

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/targets/targets-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/targets/targets-manager.go
@@ -114,14 +114,12 @@ func (t *TargetsManager) ReportState(ctx context.Context, current model.TargetSt
 
 	dict := target.Body.(map[string]interface{})
 
-	specCol := dict["spec"].(map[string]interface{})
-	var metadata map[string]string
-	if m, ok := specCol["metadata"]; ok {
-		jm, _ := json.Marshal(m)
-		json.Unmarshal(jm, &metadata)
-	}
+	specCol := dict["spec"].(model.TargetSpec)
 
 	delete(dict, "spec")
+	if dict["status"] == nil {
+		dict["status"] = make(map[string]interface{})
+	}
 	status := dict["status"]
 
 	j, _ := json.Marshal(status)
@@ -136,7 +134,9 @@ func (t *TargetsManager) ReportState(ctx context.Context, current model.TargetSt
 	if err != nil {
 		return model.TargetState{}, err
 	}
-
+	if rProperties == nil {
+		rProperties = make(map[string]string)
+	}
 	for k, v := range current.Status {
 		rProperties[k] = v
 	}
@@ -157,7 +157,7 @@ func (t *TargetsManager) ReportState(ctx context.Context, current model.TargetSt
 
 	return model.TargetState{
 		Id:       current.Id,
-		Metadata: metadata,
+		Metadata: specCol.Metadata,
 		Status:   rProperties,
 	}, nil
 }

--- a/api/pkg/apis/v1alpha1/managers/targets/targets-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/targets/targets-manager_test.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package targets
+
+import (
+	"context"
+	"testing"
+
+	"github.com/azure/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/azure/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
+	"github.com/stretchr/testify/assert"
+)
+
+// write test case to create a TargetSpec using the manager
+func TestCreateGetDeleteTargetsSpec(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	manager := TargetsManager{
+		StateProvider: stateProvider,
+	}
+	err := manager.UpsertSpec(context.Background(), "test", "default", model.TargetSpec{})
+	assert.Nil(t, err)
+	spec, err := manager.GetSpec(context.Background(), "test", "default")
+	assert.Nil(t, err)
+	assert.Equal(t, "test", spec.Id)
+	specLists, err := manager.ListSpec(context.Background(), "default")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(specLists))
+	assert.Equal(t, "test", specLists[0].Id)
+	err = manager.DeleteSpec(context.Background(), "test", "default")
+	assert.Nil(t, err)
+	spec, err = manager.GetSpec(context.Background(), "test", "default")
+	assert.NotNil(t, err)
+}
+
+func TestUpdateTargetStatus(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	manager := TargetsManager{
+		StateProvider: stateProvider,
+	}
+	err := manager.UpsertSpec(context.Background(), "test", "default", model.TargetSpec{})
+	assert.Nil(t, err)
+	var state model.TargetState
+	state.Id = "test"
+	state.Scope = "default"
+	state.Status = map[string]string{"label": "test"}
+	_, err = manager.ReportState(context.Background(), state)
+	assert.Nil(t, err)
+	spec, err := manager.GetSpec(context.Background(), "test", "default")
+	assert.Nil(t, err)
+	assert.Equal(t, "test", spec.Id)
+	assert.Equal(t, "test", spec.Status["label"])
+}


### PR DESCRIPTION
https://github.com/Azure/symphony/issues/206


- dict["spec"] is model.TargetSpec type rather than map[string]interface{}
- Initialize map instance if it's nil. Otherwise, null exception can be hit when adding values.
- Add unit tests