### PR TITLE
Fix go.yaml badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Symphony
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-![build](https://github.com/Azure/symphony/actions/workflows/go.yml/badge.svg)
+![build](https://github.com/eclipse-symphony/symphony/actions/workflows/go.yml/badge.svg)
 
 _(last edit: 4/11/2023)_
 


### PR DESCRIPTION
**Changes**

- Fix badge link in README. Now it's broken.

<img width="241" alt="image" src="https://github.com/eclipse-symphony/symphony/assets/59427055/016ac872-c5a4-4baa-b90b-24da17366ca0">
