### PR TITLE
Improve check minikube in error cases, fix install.ps1 error, only start tunnel in minikube

### DIFF
--- a/cli/cmd/up.go
+++ b/cli/cmd/up.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const SymphonyAPIVersion = "0.47.2"
+const SymphonyAPIVersion = "{VERSION}"
 const KANPortalVersion = "0.39.0-main-603f4b9-amd64"
 const GITHUB_PAT = "CR_PAT"
 

--- a/cli/cmd/up.go
+++ b/cli/cmd/up.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const SymphonyAPIVersion = "{VERSION}"
+const SymphonyAPIVersion = "0.47.2"
 const KANPortalVersion = "0.39.0-main-603f4b9-amd64"
 const GITHUB_PAT = "CR_PAT"
 
@@ -401,17 +401,6 @@ func handleKubectl() bool {
 	return true
 }
 func handleK8sConnection() (string, bool) {
-	// We need to test and configure minikube path here because if when minikube is installed in this session,
-	// PATH environment cannot take effect util restarting a new session
-	osName := runtime.GOOS
-	if strings.EqualFold(osName, "windows") {
-		var des = filepath.Join(os.Getenv("programfiles"), "maestro", "minikube")
-		path := utils.AddtoPath(des)
-		if err := os.Setenv("path", path); err != nil {
-			fmt.Printf("\n%s  Failed to setting path for minikube.%s\n\n", utils.ColorRed(), utils.ColorReset())
-			return "", false
-		}
-	}
 	address, ok := utils.CheckK8sConnection(verbose)
 	if !ok {
 		input := utils.GetInput("kubectl is not connected to a Kubernetes cluster, what do you want to do?", []string{"Install a local cluster (Minukube)", "Connect to a remote cluster (AKS)"}, utils.Choice)

--- a/cli/cmd/up.go
+++ b/cli/cmd/up.go
@@ -92,9 +92,12 @@ var UpCmd = &cobra.Command{
 			}
 			var tunnelCMD *exec.Cmd
 			if !noRestApi {
-				tunnelCMD, err = handleMinikubeTunnel()
-				if err != nil {
-					return
+				// only start tunnel for minikube
+				if k8sContext == "minikube" {
+					tunnelCMD, err = handleMinikubeTunnel()
+					if err != nil {
+						return
+					}
 				}
 
 				ret, apiAddress := checkSymphonyAddress()
@@ -398,20 +401,22 @@ func handleKubectl() bool {
 	return true
 }
 func handleK8sConnection() (string, bool) {
+	// We need to test and configure minikube path here because if when minikube is installed in this session,
+	// PATH environment cannot take effect util restarting a new session
+	osName := runtime.GOOS
+	if strings.EqualFold(osName, "windows") {
+		var des = filepath.Join(os.Getenv("programfiles"), "maestro", "minikube")
+		path := utils.AddtoPath(des)
+		if err := os.Setenv("path", path); err != nil {
+			fmt.Printf("\n%s  Failed to setting path for minikube.%s\n\n", utils.ColorRed(), utils.ColorReset())
+			return "", false
+		}
+	}
 	address, ok := utils.CheckK8sConnection(verbose)
 	if !ok {
 		input := utils.GetInput("kubectl is not connected to a Kubernetes cluster, what do you want to do?", []string{"Install a local cluster (Minukube)", "Connect to a remote cluster (AKS)"}, utils.Choice)
 		switch input {
 		case 0:
-			osName := runtime.GOOS
-			if strings.EqualFold(osName, "windows") {
-				var des = filepath.Join(os.Getenv("programfiles"), "maestro", "minikube")
-				path := utils.AddtoPath(des)
-				if err := os.Setenv("path", path); err != nil {
-					fmt.Printf("\n%s  Failed to setting path for minikube.%s\n\n", utils.ColorRed(), utils.ColorReset())
-					return "", false
-				}
-			}
 			ok := utils.CheckMinikube(false)
 			if ok {
 				_, err := utils.RunCommand("Creating Kubernetes cluster", "done", verbose, "minikube", "start")
@@ -438,6 +443,11 @@ func setupK8sConnection() bool {
 	return true
 }
 func handleMinikubeTunnel() (*exec.Cmd, error) {
+	// ensure we can run minikube tunnel given users have a connected k8s context which is minikube K8S but not prepared by maestro
+	ok := utils.CheckMinikube(false)
+	if !ok {
+		installMinikube()
+	}
 	cmd := exec.Command("minikube", "tunnel")
 	err := cmd.Start()
 	if err != nil {

--- a/cli/install/install.ps1
+++ b/cli/install/install.ps1
@@ -47,7 +47,7 @@ if ((Get-ExecutionPolicy) -gt 'RemoteSigned' -or (Get-ExecutionPolicy) -eq 'ByPa
 # Check if Dapr CLI is installed.
 if (Test-Path $SymphonyCliFilePath -PathType Leaf) {
     Write-Warning "Maestro is detected - $SymphonyCliFilePath"
-    Invoke-Expression "$SymphonyCliFilePath --version"
+    Invoke-Expression "$SymphonyCliFilePath version"
     Write-Output "Reinstalling Maestro..."
 }
 else {

--- a/cli/utils/runcmd.go
+++ b/cli/utils/runcmd.go
@@ -154,7 +154,25 @@ func CheckKubectl(verbose bool) bool {
 
 func CheckMinikube(verbose bool) bool {
 	_, err := RunCommand("Checking minikube", "found", verbose, "minikube", "version")
-	return err == nil
+	if err != nil {
+		// try to check if it is related to env:PATH not configured on Windows
+		osName := runtime.GOOS
+		if strings.EqualFold(osName, "windows") {
+			var des = filepath.Join(os.Getenv("programfiles"), "maestro", "minikube")
+			path := AddtoPath(des)
+			if err := os.Setenv("path", path); err != nil {
+				fmt.Printf("\n%s  Failed to setting path for minikube.%s\n\n", ColorRed(), ColorReset())
+				return false
+			} else {
+				_, err = RunCommand("Checking minikube", "found", verbose, "minikube", "version")
+				return err == nil
+			}
+		} else {
+			return false
+		}
+	} else {
+		return true
+	}
 }
 
 func CheckK8sConnection(verbose bool) (string, bool) {

--- a/cli/utils/runcmd.go
+++ b/cli/utils/runcmd.go
@@ -153,26 +153,17 @@ func CheckKubectl(verbose bool) bool {
 }
 
 func CheckMinikube(verbose bool) bool {
-	_, err := RunCommand("Checking minikube", "found", verbose, "minikube", "version")
-	if err != nil {
-		// try to check if it is related to env:PATH not configured on Windows
-		osName := runtime.GOOS
-		if strings.EqualFold(osName, "windows") {
-			var des = filepath.Join(os.Getenv("programfiles"), "maestro", "minikube")
-			path := AddtoPath(des)
-			if err := os.Setenv("path", path); err != nil {
-				fmt.Printf("\n%s  Failed to setting path for minikube.%s\n\n", ColorRed(), ColorReset())
-				return false
-			} else {
-				_, err = RunCommand("Checking minikube", "found", verbose, "minikube", "version")
-				return err == nil
-			}
-		} else {
-			return false
+	// on Windows, add the known Windows installation path to env:PATH to avoid minikube checking error
+	osName := runtime.GOOS
+	if strings.EqualFold(osName, "windows") {
+		var des = filepath.Join(os.Getenv("programfiles"), "maestro", "minikube")
+		path := AddtoPath(des)
+		if err := os.Setenv("path", path); err != nil {
+			fmt.Printf("\n%s  Failed to setting path for minikube.%s\n\n", ColorRed(), ColorReset())
 		}
-	} else {
-		return true
 	}
+	_, err := RunCommand("Checking minikube", "found", verbose, "minikube", "version")
+	return err == nil
 }
 
 func CheckK8sConnection(verbose bool) (string, bool) {


### PR DESCRIPTION
**Changes**

1. Improve check minikube in edge cases on Windows. Suppose maestro up failed in the first time. Because the PS session is not started, in second try, even if we detect the k8s connection is connected, we cannot run minikube when starting tunnel since minikube is not found.
2. Found one issue in install.ps1. (should use maestro version, not meastro --version)
3. Only start tunnel in minikube. Also check minikube when starting tunnel. There's an edge case that minikube is not needed to be install because k8s connection is connected with existing minikube cluster. But we still need to check and install minikube in known path for starting a tunnel.

![image](https://github.com/eclipse-symphony/symphony/assets/59427055/8e9e1e39-a086-4cb8-9e11-b84b3e2a17f1)
