### PR TITLE
Remove imagePullSecrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ maestro up
 ### Using Helm
 You can also install Symphony using Helm by running the following command:
 ```Bash
-helm install symphony oci://ghcr.io/eclipse-symphony/helm/symphony --version '0.45.32' --set imagePullSecrets='{YOUR_GITHUB_PAT_TOKEN}'
+helm install symphony oci://ghcr.io/eclipse-symphony/helm/symphony --version '0.47.2'
 ```
 After Symphony is installed, you can use maestro to try out sample scenarios.
 

--- a/docs/symphony-book/build_deployment/multisite-deploy.md
+++ b/docs/symphony-book/build_deployment/multisite-deploy.md
@@ -32,7 +32,7 @@ When a child control plane launches, it automatically connects with the parent a
 When installing Symphony with Helm, you can set the site id as well as the parent site URL/credentials using `--set` switches, for example:
 
 ```bash
-helm install symphony oci://ghcr.io/eclipse-symphony/helm/symphony --version 0.47.1 --set siteId=tokyo --set parent.url=http://<parent's symphony-service-ext IP>:8080/v1alpha2/
+helm install symphony oci://ghcr.io/eclipse-symphony/helm/symphony --version 0.47.2 --set siteId=tokyo --set parent.url=http://<parent's symphony-service-ext IP>:8080/v1alpha2/
 ```
 
 If a child is successfully connected to a parent site, you should see the site registration from the parent's context with:

--- a/docs/symphony-book/build_deployment/multisite-deploy.md
+++ b/docs/symphony-book/build_deployment/multisite-deploy.md
@@ -32,7 +32,7 @@ When a child control plane launches, it automatically connects with the parent a
 When installing Symphony with Helm, you can set the site id as well as the parent site URL/credentials using `--set` switches, for example:
 
 ```bash
-helm install symphony oci://ghcr.io/eclipse-symphony/helm/symphony --version 0.45.31 --set siteId=tokyo --set parent.url=http://<parent's symphony-service-ext IP>:8080/v1alpha2/ --set imagePullSecrets='{YOUR_GITHUB_PAT_TOKEN}'
+helm install symphony oci://ghcr.io/eclipse-symphony/helm/symphony --version 0.47.1 --set siteId=tokyo --set parent.url=http://<parent's symphony-service-ext IP>:8080/v1alpha2/
 ```
 
 If a child is successfully connected to a parent site, you should see the site registration from the parent's context with:

--- a/docs/symphony-book/quick_start/quick_start_helm.md
+++ b/docs/symphony-book/quick_start/quick_start_helm.md
@@ -5,14 +5,14 @@ _(last edit: 9/18/2023)_
 To install Symphony on your Kubernetes clusters using Helm 3, use `helm install`:
 
 ```bash
-helm install symphony oci://ghcr.io/eclipse-symphony/helm/symphony --version 0.44.6 --set imagePullSecrets='{YOUR_GITHUB_PAT_TOKEN}'
+helm install symphony oci://ghcr.io/eclipse-symphony/helm/symphony --version 0.47.2
 ```
 
 Or, if you already have the **symphony** repository cloned:
 
 ```bash
 cd <path>/symphony/packages/helm
-helm install symphony ./symphony --set imagePullSecrets='{YOUR_GITHUB_PAT_TOKEN}'
+helm install symphony ./symphony
 ```
 
 If you need to install the Helm chart from a private ACR like ```ghcr.io```, you need to log in first:
@@ -25,7 +25,7 @@ PASSWORD='{YOUR_GITHUB_PAT_TOKEN}'
 helm registry login ghcr.io --username $USER_NAME --password $PASSWORD
 
 # install using Helm chart
-helm install symphony oci://ghcr.io/eclipse-symphony/helm/symphony --version 0.40.8 --set imagePullSecrets='{YOUR_GITHUB_PAT_TOKEN}'
+helm install symphony oci://ghcr.io/eclipse-symphony/helm/symphony --version 0.47.2
 ```
 
 ## Update Symphony
@@ -33,7 +33,7 @@ helm install symphony oci://ghcr.io/eclipse-symphony/helm/symphony --version 0.4
 To update your existing Symphony release to a new version, use `helm upgrade`:
 
 ```bash
-helm upgrade --install symphony oci://ghcr.io/eclipse-symphony/helm/symphony --version 0.45.31 --set imagePullSecrets='{YOUR_GITHUB_PAT_TOKEN}'
+helm upgrade --install symphony oci://ghcr.io/eclipse-symphony/helm/symphony --version 0.47.2
 ```
 
 ## Customize Helm deployment

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -57,7 +57,7 @@ If you would like to start with a fresh cluster and test out the arc-extension y
 However if you are just interested in installing symphony not as an arc-extension, you can just install it directly from the repo. Assuming you're in the root of the symphony-k8s directory you can run
 ```bash
 cd ../packages/helm/
-helm install symphony symphony/ --set imagePullSecrets='{YOUR_GITHUB_PAT_TOKEN}'
+helm install symphony symphony/
 ```
 
 ## Route 2: Updating CRDs
@@ -93,7 +93,7 @@ At this step you have a new helm chart and need to update the existing one. Depe
 If you are just interested in locally installing symphony with no RP connection you can install symphony directly using
 ```bash
 cd ../packages/helm/
-helm install symphony symphony/ --set imagePullSecrets='{YOUR_GITHUB_PAT_TOKEN}'
+helm install symphony symphony/
 ```
 assuming you're in the root of symphony-k8s directory
 ### 2.6.2 Symphony Helm Chart with RP and as an arc-extension

--- a/k8s/config/oss/helm/manager-patch.yaml
+++ b/k8s/config/oss/helm/manager-patch.yaml
@@ -19,8 +19,6 @@ spec:
       labels:
         control-plane: '{{ include "symphony.name" . }}-controller-manager'
     spec:
-      imagePullSecrets:
-      - name: '{{ include "symphony.fullname" . }}-regcred'
       containers:
       - image: "{{ .Values.symphonyImage.repository }}:{{ .Values.symphonyImage.tag }}"
         imagePullPolicy: "{{ .Values.symphonyImage.pullPolicy }}"

--- a/packages/helm/symphony/templates/secret.yaml
+++ b/packages/helm/symphony/templates/secret.yaml
@@ -5,13 +5,3 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   CUSTOM_VISION_KEY: {{ .Values.CUSTOM_VISION_KEY | b64enc }}  
----
-{{- if .Values.imagePullSecrets }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "symphony.fullname" . }}-regcred
-data:
-  .dockerconfigjson: {{ printf "{\"auths\":{\"%s\":{\"username\":\"USERNAME\",\"password\":\"%s\"}}}" .Values.imagePrivateRegistryUrl .Values.imagePullSecrets | b64enc }}
-type: kubernetes.io/dockerconfigjson
-{{- end }}

--- a/packages/helm/symphony/templates/symphony-api.yaml
+++ b/packages/helm/symphony/templates/symphony-api.yaml
@@ -46,10 +46,6 @@ spec:
           value: {{ .Release.Namespace }}
         {{- .Values.global.azure.identity.mSIAdapterYaml | nindent 8 }}
       {{- end }}
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      - name: {{ include "symphony.fullname" . }}-regcred
-      {{- end }}
       volumes:
         - name: symphony-api-config
           configMap:

--- a/packages/helm/symphony/templates/symphony.yaml
+++ b/packages/helm/symphony/templates/symphony.yaml
@@ -2090,8 +2090,6 @@ spec:
           requests:
             cpu: 5m
             memory: 64Mi
-      imagePullSecrets:
-      - name: '{{ include "symphony.fullname" . }}-regcred'
       securityContext:
         runAsNonRoot: true
       serviceAccountName: '{{ include "symphony.fullname" . }}-controller-manager'

--- a/test/localenv/magefile.go
+++ b/test/localenv/magefile.go
@@ -51,13 +51,8 @@ type License mg.Namespace
 
 // Deploys the symphony ecosystem to your local Minikube cluster.
 func (Cluster) Deploy() error {
-	// Make sure users have PAT token for GitHub container registry configured
-	if err := GhcrLogin(); err != nil {
-		return err
-	}
-	CR_PAT := os.Getenv(GITHUB_PAT)
-	fmt.Printf("Deploying symphony to minikube, imagePullSecrets: %s\n", CR_PAT)
-	helmUpgrade := fmt.Sprintf("helm upgrade %s %s --install -n %s --create-namespace --wait -f ../../packages/helm/symphony/values.yaml -f symphony-ghcr-values.yaml --set symphonyImage.tag=%s --set paiImage.tag=%s --set imagePullSecrets='%s'", RELEASE_NAME, CHART_PATH, NAMESPACE, DOCKER_TAG, DOCKER_TAG, CR_PAT)
+	fmt.Printf("Deploying symphony to minikube\n")
+	helmUpgrade := fmt.Sprintf("helm upgrade %s %s --install -n %s --create-namespace --wait -f ../../packages/helm/symphony/values.yaml -f symphony-ghcr-values.yaml --set symphonyImage.tag=%s --set paiImage.tag=%s", RELEASE_NAME, CHART_PATH, NAMESPACE, DOCKER_TAG, DOCKER_TAG)
 	return shellcmd.Command(helmUpgrade).Run()
 }
 


### PR DESCRIPTION
Symphony container images and helm charts are public available now. We don't need imagePullSecrets in deployment.

**Validations**
- Integration tests passed.
- Deployment passed. 
_Warning  FailedToRetrieveImagePullSecret  24m (x39 over 70m)  kubelet            Unable to retrieve some image pull secrets (symphony-regcred); attempting to pull the image may not succeed._ is gone in symphony-controller-manager pod.
<img width="1656" alt="image" src="https://github.com/eclipse-symphony/symphony/assets/59427055/e8f5e427-eccb-44d7-8365-459e1922df24">
- Tested docs/samples/k8s/hello-world sample, passed.
<img width="893" alt="image" src="https://github.com/eclipse-symphony/symphony/assets/59427055/bc2cba1f-41f3-4a20-aebe-58046fb25431">
