### PR TITLE
api managers test coverage improvement

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/instances/instances-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/instances/instances-manager_test.go
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-package campaigns
+package instances
 
 import (
 	"context"
@@ -15,22 +15,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// write test case to create a CampaignSpec using the manager
-func TestCreateGetDeleteCampaignSpec(t *testing.T) {
+// write test case to create a InstanceSpec using the manager
+func TestCreateGetDeleteInstancesSpec(t *testing.T) {
 	stateProvider := &memorystate.MemoryStateProvider{}
 	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
-	manager := CampaignsManager{
+	manager := InstancesManager{
 		StateProvider: stateProvider,
 	}
-	err := manager.UpsertSpec(context.Background(), "test", model.CampaignSpec{})
+	err := manager.UpsertSpec(context.Background(), "test", model.InstanceSpec{}, "default")
 	assert.Nil(t, err)
-	spec, err := manager.GetSpec(context.Background(), "test")
+	spec, err := manager.GetSpec(context.Background(), "test", "default")
 	assert.Nil(t, err)
 	assert.Equal(t, "test", spec.Id)
-	specLists, err := manager.ListSpec(context.Background())
+	specLists, err := manager.ListSpec(context.Background(), "default")
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(specLists))
 	assert.Equal(t, "test", specLists[0].Id)
-	err = manager.DeleteSpec(context.Background(), "test")
+	err = manager.DeleteSpec(context.Background(), "test", "default")
 	assert.Nil(t, err)
+	spec, err = manager.GetSpec(context.Background(), "test", "default")
+	assert.NotNil(t, err)
 }

--- a/api/pkg/apis/v1alpha1/managers/jobs/jobs-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/jobs/jobs-manager_test.go
@@ -8,25 +8,77 @@ package jobs
 
 import (
 	"context"
-	"os"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestHandleEvent(t *testing.T) {
-	testInstanceId := os.Getenv("TEST_INSTANCE_ID")
-	if testInstanceId == "" {
-		t.Skip("Skipping becasue TEST_INSTANCE_ID is missing")
-	}
 	stateProvider := &memorystate.MemoryStateProvider{}
 	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
-	manager := JobsManager{}
-	err := manager.Init(nil, managers.ManagerConfig{
+
+	ts := InitializeMockSymphonyAPI()
+	defer ts.Close()
+
+	jobManager := JobsManager{}
+	err := jobManager.Init(nil, managers.ManagerConfig{
+		Properties: map[string]string{
+			"providers.state": "state",
+			"baseUrl":         ts.URL + "/",
+			"password":        "",
+			"user":            "admin",
+			"interval":        "#15",
+		},
+	}, map[string]providers.IProvider{
+		"state": stateProvider,
+	})
+	assert.Nil(t, err)
+
+	errs := jobManager.HandleJobEvent(context.Background(), v1alpha2.Event{
+		Metadata: map[string]string{
+			"objectType": "instance",
+		},
+		Body: v1alpha2.JobData{
+			Id:     "instance1",
+			Action: "UPDATE",
+		},
+	})
+	assert.Nil(t, errs)
+	instance, err := stateProvider.Get(context.Background(), states.GetRequest{ID: "i_instance1"})
+	assert.Nil(t, err)
+	assert.NotNil(t, instance)
+
+	errs = jobManager.HandleJobEvent(context.Background(), v1alpha2.Event{
+		Metadata: map[string]string{
+			"objectType": "target",
+		},
+		Body: v1alpha2.JobData{
+			Id:     "target1",
+			Action: "UPDATE",
+		},
+	})
+	assert.Nil(t, errs)
+	target, err := stateProvider.Get(context.Background(), states.GetRequest{ID: "t_target1"})
+	assert.Nil(t, err)
+	assert.NotNil(t, target)
+}
+
+func TestHandleScheduleEvent(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+
+	jobManager := JobsManager{}
+	err := jobManager.Init(nil, managers.ManagerConfig{
 		Properties: map[string]string{
 			"providers.state": "state",
 			"baseUrl":         "http://localhost:8082/v1alpha2/",
@@ -38,14 +90,166 @@ func TestHandleEvent(t *testing.T) {
 		"state": stateProvider,
 	})
 	assert.Nil(t, err)
-	errs := manager.HandleJobEvent(context.Background(), v1alpha2.Event{
-		Metadata: map[string]string{
-			"objectType": "instance",
-		},
-		Body: v1alpha2.JobData{
-			Id:     testInstanceId,
-			Action: "UPDATE",
-		},
+	jobManager.HandleScheduleEvent(context.Background(), v1alpha2.Event{
+		Body: v1alpha2.ActivationData{Campaign: "campaign1", Activation: "activation1"},
 	})
-	assert.Nil(t, errs)
+
+	schedule, err := stateProvider.Get(context.Background(), states.GetRequest{ID: "sch_campaign1-activation1"})
+	assert.Nil(t, err)
+	assert.NotNil(t, schedule)
+}
+
+func TestHandleheartbeatEvent(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+
+	jobManager := JobsManager{}
+	err := jobManager.Init(nil, managers.ManagerConfig{
+		Properties: map[string]string{
+			"providers.state": "state",
+			"baseUrl":         "http://localhost:8082/v1alpha2/",
+			"password":        "",
+			"user":            "admin",
+			"interval":        "#15",
+		},
+	}, map[string]providers.IProvider{
+		"state": stateProvider,
+	})
+	assert.Nil(t, err)
+	jobManager.HandleHeartBeatEvent(context.Background(), v1alpha2.Event{
+		Body: v1alpha2.HeartBeatData{JobId: "instance1"},
+	})
+
+	heartbeat, err := stateProvider.Get(context.Background(), states.GetRequest{ID: "h_instance1"})
+	assert.Nil(t, err)
+	assert.NotNil(t, heartbeat)
+}
+
+func TestPoll(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	ts := InitializeMockSymphonyAPI()
+	defer ts.Close()
+	jobManager := JobsManager{}
+	err := jobManager.Init(nil, managers.ManagerConfig{
+		Properties: map[string]string{
+			"providers.state":  "state",
+			"baseUrl":          ts.URL + "/",
+			"password":         "",
+			"user":             "admin",
+			"interval":         "#15",
+			"poll.enabled":     "true",
+			"schedule.enabled": "true",
+		},
+	}, map[string]providers.IProvider{
+		"state": stateProvider,
+	})
+	assert.Nil(t, err)
+	jobManager.HandleScheduleEvent(context.Background(), v1alpha2.Event{
+		Body: v1alpha2.ActivationData{Campaign: "campaign1", Activation: "activation1", Schedule: &v1alpha2.ScheduleSpec{Time: "03:04:05PM", Date: "2006-01-02"}},
+	})
+	enabled := jobManager.Enabled()
+	assert.True(t, enabled)
+	errlist := jobManager.Poll()
+	assert.Nil(t, errlist)
+}
+
+func TestDelayOrSkipJobPoll(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	ts := InitializeMockSymphonyAPI()
+	defer ts.Close()
+	jobManager := JobsManager{}
+	err := jobManager.Init(nil, managers.ManagerConfig{
+		Properties: map[string]string{
+			"providers.state":  "state",
+			"baseUrl":          ts.URL + "/",
+			"password":         "",
+			"user":             "admin",
+			"interval":         "#15",
+			"poll.enabled":     "true",
+			"schedule.enabled": "true",
+		},
+	}, map[string]providers.IProvider{
+		"state": stateProvider,
+	})
+	assert.Nil(t, err)
+	jobManager.HandleHeartBeatEvent(context.Background(), v1alpha2.Event{
+		Body: v1alpha2.HeartBeatData{JobId: "instance1", Time: time.Now().Add(-time.Hour)},
+	})
+	err = jobManager.DelayOrSkipJob(context.Background(), "instances", v1alpha2.JobData{Id: "instance1", Action: "UPDATE"})
+	assert.Nil(t, err)
+
+	jobManager.HandleHeartBeatEvent(context.Background(), v1alpha2.Event{
+		Body: v1alpha2.HeartBeatData{JobId: "instance1", Time: time.Now()},
+	})
+	err = jobManager.DelayOrSkipJob(context.Background(), "instances", v1alpha2.JobData{Id: "instance1", Action: "UPDATE"})
+	assert.NotNil(t, err)
+}
+
+type AuthResponse struct {
+	AccessToken string   `json:"accessToken"`
+	TokenType   string   `json:"tokenType"`
+	Username    string   `json:"username"`
+	Roles       []string `json:"roles"`
+}
+
+func InitializeMockSymphonyAPI() *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var response interface{}
+		log.Info("Mock Symphony API called", "path", r.URL.Path)
+		switch r.URL.Path {
+		case "/instances/instance1":
+			response = model.InstanceState{
+				Id: "instance1",
+				Spec: &model.InstanceSpec{
+					Name:     "instance1",
+					Solution: "solution1",
+					Scope:    "default",
+				},
+			}
+		case "/instances":
+			response = []model.InstanceState{{
+				Id: "instance1",
+				Spec: &model.InstanceSpec{
+					Name:     "instance1",
+					Solution: "solution1",
+					Scope:    "default",
+				},
+			}}
+		case "/targets/registry":
+			response = []model.TargetState{{
+				Id: "target1",
+				Spec: &model.TargetSpec{
+					DisplayName: "target1",
+					Scope:       "default",
+				},
+			}}
+		case "/targets/registry/target1":
+			response = model.TargetState{
+				Id: "target1",
+				Spec: &model.TargetSpec{
+					DisplayName: "target1",
+					Scope:       "default",
+				},
+			}
+		case "/solutions/solution1":
+			response = model.SolutionState{
+				Id: "solution1",
+				Spec: &model.SolutionSpec{
+					Scope: "default",
+				},
+			}
+		default:
+			response = AuthResponse{
+				AccessToken: "test-token",
+				TokenType:   "Bearer",
+				Username:    "test-user",
+				Roles:       []string{"role1", "role2"},
+			}
+		}
+
+		json.NewEncoder(w).Encode(response)
+	}))
+	return ts
 }

--- a/api/pkg/apis/v1alpha1/managers/solution/solution-manager-state_test.go
+++ b/api/pkg/apis/v1alpha1/managers/solution/solution-manager-state_test.go
@@ -430,6 +430,7 @@ func TestMergeStateAddProvider(t *testing.T) {
 	state := MergeDeploymentStates(&state1, state2)
 	assert.Equal(t, 3, len(state.Components))
 	assert.Equal(t, 2, len(state.Targets))
+	assert.Equal(t, 5, len(state.TargetComponent))
 	assert.Equal(t, "instance", state.TargetComponent["a::T1"])
 	assert.Equal(t, "instance", state.TargetComponent["b::T1"])
 	assert.Equal(t, "instance", state.TargetComponent["c::T1"])

--- a/api/pkg/apis/v1alpha1/managers/solution/solution-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/solution/solution-manager_test.go
@@ -245,6 +245,9 @@ func TestMockGet(t *testing.T) {
 	assert.Equal(t, 0, len(components))
 	assert.Equal(t, 0, len(state.TargetComponent))
 
+	_, err = manager.GetSummary(context.Background(), "", "default")
+	assert.NotNil(t, err)
+
 	_, err = manager.Reconcile(context.Background(), deployment, false, "default")
 	assert.Nil(t, err)
 
@@ -256,6 +259,13 @@ func TestMockGet(t *testing.T) {
 	assert.Equal(t, 2, len(state.TargetComponent))
 	assert.Equal(t, "mock", state.TargetComponent["a::T1"])
 	assert.Equal(t, "mock", state.TargetComponent["b::T1"])
+
+	_, err = manager.GetSummary(context.Background(), "", "default")
+	assert.Nil(t, err)
+
+	// Test reconcile idempotency
+	_, err = manager.Reconcile(context.Background(), deployment, false, "default")
+	assert.Nil(t, err)
 }
 func TestMockGetTwoTargets(t *testing.T) {
 	id := uuid.New().String()
@@ -336,6 +346,10 @@ func TestMockGetTwoTargets(t *testing.T) {
 	assert.Equal(t, "mock", state.TargetComponent["b::T1"])
 	assert.Equal(t, "mock", state.TargetComponent["a::T2"])
 	assert.Equal(t, "mock", state.TargetComponent["b::T2"])
+
+	// Test reconcile idempotency
+	_, err = manager.Reconcile(context.Background(), deployment, false, "default")
+	assert.Nil(t, err)
 }
 func TestMockGetTwoTargetsTwoProviders(t *testing.T) {
 	id := uuid.New().String()
@@ -413,9 +427,13 @@ func TestMockGetTwoTargetsTwoProviders(t *testing.T) {
 	assert.Equal(t, 2, len(state.Components))
 	assert.Equal(t, "a", state.Components[0].Name)
 	assert.Equal(t, "b", state.Components[1].Name)
-	assert.Equal(t, 4, len(state.TargetComponent))
+	assert.Equal(t, 2, len(state.TargetComponent))
 	assert.Equal(t, "mock1", state.TargetComponent["a::T1"])
 	assert.Equal(t, "mock2", state.TargetComponent["b::T2"])
+
+	// Test reconcile idempotency
+	_, err = manager.Reconcile(context.Background(), deployment, false, "default")
+	assert.Nil(t, err)
 }
 func TestMockApply(t *testing.T) {
 	deployment := model.DeploymentSpec{
@@ -508,4 +526,46 @@ func TestMockApplyWithUpdateAndRemove(t *testing.T) {
 	summary, err := manager.Reconcile(context.Background(), deployment, false, "default")
 	assert.Nil(t, err)
 	assert.Equal(t, 1, summary.SuccessCount)
+}
+func TestMockApplyWithError(t *testing.T) {
+	deployment := model.DeploymentSpec{
+		Solution: model.SolutionSpec{
+			Components: []model.ComponentSpec{
+				{
+					Name: "a",
+					Type: "mock1",
+				},
+			},
+		},
+		Assignments: map[string]string{
+			"T1": "{a}",
+		},
+		Targets: map[string]model.TargetSpec{
+			"T1": {
+				Topologies: []model.TopologySpec{
+					{
+						Bindings: []model.BindingSpec{
+							{
+								Role:     "mock2",
+								Provider: "providers.target.mock",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	targetProvider := &mock.MockTargetProvider{}
+	targetProvider.Init(mock.MockTargetProviderConfig{})
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	manager := SolutionManager{
+		TargetProviders: map[string]target.ITargetProvider{
+			"mock": targetProvider,
+		},
+		StateProvider: stateProvider,
+	}
+	summary, err := manager.Reconcile(context.Background(), deployment, false, "default")
+	assert.NotNil(t, err)
+	assert.Equal(t, 0, summary.SuccessCount)
 }

--- a/api/pkg/apis/v1alpha1/managers/solutions/solutions-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/solutions/solutions-manager_test.go
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-package campaigns
+package solutions
 
 import (
 	"context"
@@ -15,22 +15,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// write test case to create a CampaignSpec using the manager
-func TestCreateGetDeleteCampaignSpec(t *testing.T) {
+// write test case to create a SolutionSpec using the manager
+func TestCreateGetDeleteSolutionsSpec(t *testing.T) {
 	stateProvider := &memorystate.MemoryStateProvider{}
 	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
-	manager := CampaignsManager{
+	manager := SolutionsManager{
 		StateProvider: stateProvider,
 	}
-	err := manager.UpsertSpec(context.Background(), "test", model.CampaignSpec{})
+	err := manager.UpsertSpec(context.Background(), "test", model.SolutionSpec{}, "default")
 	assert.Nil(t, err)
-	spec, err := manager.GetSpec(context.Background(), "test")
+	spec, err := manager.GetSpec(context.Background(), "test", "default")
 	assert.Nil(t, err)
 	assert.Equal(t, "test", spec.Id)
-	specLists, err := manager.ListSpec(context.Background())
+	specLists, err := manager.ListSpec(context.Background(), "default")
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(specLists))
 	assert.Equal(t, "test", specLists[0].Id)
-	err = manager.DeleteSpec(context.Background(), "test")
+	err = manager.DeleteSpec(context.Background(), "test", "default")
 	assert.Nil(t, err)
+	spec, err = manager.GetSpec(context.Background(), "test", "default")
+	assert.NotNil(t, err)
 }

--- a/api/pkg/apis/v1alpha1/managers/stage/stage-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/stage/stage-manager_test.go
@@ -8,12 +8,14 @@ package stage
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
 	coa_utils "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/utils"
 	"github.com/stretchr/testify/assert"
@@ -60,6 +62,7 @@ func TestCampaignWithSingleMockStageLoop(t *testing.T) {
 						"foo": "${{$output(test,foo)}}",
 					},
 					StageSelector: "${{$if($lt($output(test,foo), 5), test, '')}}",
+					Contexts:      "fake",
 				},
 			},
 		}, *activation)
@@ -836,4 +839,281 @@ func TestAccessingPreviousStageInExpression(t *testing.T) {
 			break
 		}
 	}
+}
+func TestResumeStage(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	manager := StageManager{
+		StateProvider: stateProvider,
+	}
+	manager.VendorContext = &contexts.VendorContext{
+		EvaluationContext: &coa_utils.EvaluationContext{},
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+		},
+	}
+	manager.Context = &contexts.ManagerContext{
+		VencorContext: manager.VendorContext,
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+		},
+	}
+	campaignName := "campaign1"
+	activationName := "activation1"
+	activationGen := "1"
+	output := map[string]interface{}{
+		"__campaign":             campaignName,
+		"__activation":           activationName,
+		"__activationGeneration": activationGen,
+		"__site":                 "fake",
+		"__stage":                "test",
+	}
+	stateProvider.Upsert(context.Background(), states.UpsertRequest{
+		Value: states.StateEntry{
+			ID: fmt.Sprintf("%s-%s-%s", campaignName, activationName, activationGen),
+			Body: PendingTask{
+				Sites:         []string{"fake"},
+				OutputContext: map[string]map[string]interface{}{"fake": output},
+			},
+		},
+	})
+	activation := model.ActivationStatus{
+		Status:  v1alpha2.Done,
+		Stage:   "test",
+		Outputs: output,
+	}
+	campaign := model.CampaignSpec{
+		Name:        campaignName,
+		SelfDriving: true,
+		FirstStage:  "test",
+		Stages: map[string]model.StageSpec{
+			"test": {
+				Provider:      "providers.stage.mock",
+				StageSelector: "test2",
+				Inputs: map[string]interface{}{
+					"ticket": "bar",
+				},
+			},
+			"test2": {
+				Provider:      "providers.stage.mock",
+				StageSelector: "",
+				HandleErrors:  false,
+				Inputs: map[string]interface{}{
+					"stcheck": "${{$output($input(__previousStage), __status)}}",
+					"stfoo":   "${{$output($input(__previousStage), ticket)}}",
+				},
+			},
+		},
+	}
+	nextStage, err := manager.ResumeStage(activation, campaign)
+	assert.Nil(t, err)
+	assert.Equal(t, "test2", nextStage.Stage)
+	assert.Equal(t, campaignName, nextStage.Campaign)
+	assert.Equal(t, activationName, nextStage.Activation)
+}
+func TestHandleDirectTriggerEvent(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	manager := StageManager{
+		StateProvider: stateProvider,
+	}
+	manager.VendorContext = &contexts.VendorContext{
+		EvaluationContext: &coa_utils.EvaluationContext{},
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+		},
+	}
+	manager.Context = &contexts.ManagerContext{
+		VencorContext: manager.VendorContext,
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+		},
+	}
+	activation := v1alpha2.ActivationData{
+		Campaign:             "test-campaign",
+		Activation:           "test-activation",
+		Stage:                "test",
+		ActivationGeneration: "1",
+		Inputs: map[string]interface{}{
+			"foo":     1,
+			"bar":     2,
+			"__state": map[string]interface{}{"foo": 1, "bar": 1},
+		},
+		Outputs:  nil,
+		Provider: "providers.stage.counter",
+	}
+	status := manager.HandleDirectTriggerEvent(context.Background(), activation)
+	assert.Equal(t, v1alpha2.Done, status.Status)
+	assert.Equal(t, "test-campaign", status.Outputs["__campaign"])
+	assert.Equal(t, "test-activation", status.Outputs["__activation"])
+	assert.Equal(t, "1", status.Outputs["__activationGeneration"])
+	assert.Equal(t, "fake", status.Outputs["__site"])
+	assert.Equal(t, "test", status.Outputs["__stage"])
+	assert.Equal(t, int64(2), status.Outputs["foo"])
+	assert.Equal(t, int64(3), status.Outputs["bar"])
+}
+func TestHandleDirectTriggerScheduleEvent(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	manager := StageManager{
+		StateProvider: stateProvider,
+	}
+	manager.VendorContext = &contexts.VendorContext{
+		EvaluationContext: &coa_utils.EvaluationContext{},
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+		},
+	}
+	manager.Context = &contexts.ManagerContext{
+		VencorContext: manager.VendorContext,
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+		},
+	}
+	activation := v1alpha2.ActivationData{
+		Campaign:             "test-campaign",
+		Activation:           "test-activation",
+		Stage:                "test",
+		ActivationGeneration: "1",
+		Inputs: map[string]interface{}{
+			"foo":     1,
+			"bar":     2,
+			"__state": map[string]interface{}{"foo": 1, "bar": 1},
+		},
+		Outputs:  nil,
+		Provider: "providers.stage.counter",
+		Schedule: &v1alpha2.ScheduleSpec{
+			Date: "2020-01-01",
+			Time: "12:00:00PM",
+			Zone: "PST",
+		},
+	}
+	status := manager.HandleDirectTriggerEvent(context.Background(), activation)
+	assert.Equal(t, v1alpha2.Paused, status.Status)
+
+	assert.Equal(t, v1alpha2.Delayed, status.Outputs["__status"])
+	assert.Equal(t, false, status.IsActive)
+}
+func TestHandleActivationEvent(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	manager := StageManager{
+		StateProvider: stateProvider,
+	}
+	manager.VendorContext = &contexts.VendorContext{
+		EvaluationContext: &coa_utils.EvaluationContext{},
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+		},
+	}
+	manager.Context = &contexts.ManagerContext{
+		VencorContext: manager.VendorContext,
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+		},
+	}
+
+	activationData := v1alpha2.ActivationData{
+		Campaign:             "test-campaign",
+		Activation:           "test-activation",
+		ActivationGeneration: "1",
+		Outputs:              nil,
+		Provider:             "providers.stage.mock",
+	}
+
+	campaign := model.CampaignSpec{
+		Name:        "test-campaign",
+		SelfDriving: true,
+		FirstStage:  "test",
+		Stages: map[string]model.StageSpec{
+			"test": {
+				Provider:      "providers.stage.mock",
+				StageSelector: "test2",
+				Inputs: map[string]interface{}{
+					"ticket": "bar",
+				},
+			},
+			"test2": {
+				Provider:      "providers.stage.mock",
+				StageSelector: "",
+				HandleErrors:  false,
+				Inputs: map[string]interface{}{
+					"stcheck": "${{$output($input(__previousStage), __status)}}",
+					"stfoo":   "${{$output($input(__previousStage), ticket)}}",
+				},
+			},
+		},
+	}
+
+	activationState := model.ActivationState{
+		Spec: &model.ActivationSpec{
+			Inputs: map[string]interface{}{
+				"foo":     1,
+				"bar":     2,
+				"__state": map[string]interface{}{"foo": 1, "bar": 1},
+			},
+		},
+	}
+	output, err := manager.HandleActivationEvent(context.Background(), activationData, campaign, activationState)
+	assert.Nil(t, err)
+	assert.Equal(t, "test-campaign", output.Campaign)
+	assert.Equal(t, "test-activation", output.Activation)
+	assert.Equal(t, "1", output.ActivationGeneration)
+	assert.Equal(t, "test", output.Stage)
+	assert.Equal(t, int(1), output.Inputs["foo"])
+	assert.Equal(t, int(2), output.Inputs["bar"])
+	assert.Equal(t, "providers.stage.mock", output.Provider)
+}
+func TestTriggerEventWithSchedule(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	manager := StageManager{
+		StateProvider: stateProvider,
+	}
+	manager.VendorContext = &contexts.VendorContext{
+		EvaluationContext: &coa_utils.EvaluationContext{},
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+		},
+	}
+	manager.Context = &contexts.ManagerContext{
+		VencorContext: manager.VendorContext,
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+		},
+	}
+
+	activation := &v1alpha2.ActivationData{
+		Campaign:   "test-campaign",
+		Activation: "test-activation",
+		Stage:      "test",
+		Inputs: map[string]interface{}{
+			"foo": 0,
+		},
+		Outputs:  nil,
+		Provider: "providers.stage.mock",
+		Schedule: &v1alpha2.ScheduleSpec{
+			Date: "2020-01-01",
+			Time: "12:00:00PM",
+			Zone: "PST",
+		},
+	}
+
+	status, _ := manager.HandleTriggerEvent(context.Background(), model.CampaignSpec{
+		Name:        "test-campaign",
+		SelfDriving: true,
+		FirstStage:  "test",
+		Stages: map[string]model.StageSpec{
+			"test": {
+				Provider: "providers.stage.mock",
+				Inputs: map[string]interface{}{
+					"foo": "${{$output(test,foo)}}",
+				},
+				StageSelector: "${{$if($lt($output(test,foo), 5), test, '')}}",
+				Contexts:      "fake",
+			},
+		},
+	}, *activation)
+	assert.Equal(t, v1alpha2.Paused, status.Status)
+	assert.Equal(t, false, status.IsActive)
 }

--- a/api/pkg/apis/v1alpha1/managers/staging/staging-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/staging/staging-manager_test.go
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package staging
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
+	memoryqueue "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/queue/memory"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPoll(t *testing.T) {
+	ts := InitializeMockSymphonyAPI()
+	queueProvider := &memoryqueue.MemoryQueueProvider{}
+	queueProvider.Init(memoryqueue.MemoryQueueProviderConfig{})
+
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+
+	manager := StagingManager{
+		StateProvider: stateProvider,
+		QueueProvider: queueProvider,
+	}
+	manager.VendorContext = &contexts.VendorContext{
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+			CurrentSite: v1alpha2.SiteConnection{
+				BaseUrl:  ts.URL + "/",
+				Username: "admin",
+				Password: "",
+			},
+		},
+	}
+	queueProvider.Enqueue("site-job-queue", "fake")
+	errList := manager.Poll()
+	assert.Nil(t, errList)
+
+	jobData, err := queueProvider.Dequeue("fake")
+	assert.Nil(t, err)
+	assert.NotNil(t, jobData)
+	assert.Equal(t, "catalog1", jobData.(v1alpha2.JobData).Id)
+	assert.Equal(t, "UPDATE", jobData.(v1alpha2.JobData).Action)
+
+	item, err := stateProvider.Get(context.Background(), states.GetRequest{
+		ID: "fake-catalog1",
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, item)
+}
+
+func TestHandleJobEvent(t *testing.T) {
+	ts := InitializeMockSymphonyAPI()
+	queueProvider := &memoryqueue.MemoryQueueProvider{}
+	queueProvider.Init(memoryqueue.MemoryQueueProviderConfig{})
+
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+
+	manager := StagingManager{
+		StateProvider: stateProvider,
+		QueueProvider: queueProvider,
+	}
+	manager.VendorContext = &contexts.VendorContext{
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+			CurrentSite: v1alpha2.SiteConnection{
+				BaseUrl:  ts.URL + "/",
+				Username: "admin",
+				Password: "",
+			},
+		},
+	}
+	err := manager.HandleJobEvent(context.Background(), v1alpha2.Event{
+		Metadata: map[string]string{
+			"site": "fake",
+		},
+		Body: v1alpha2.JobData{
+			Id:     "catalog1",
+			Action: "UPDATE",
+		},
+	})
+	assert.Nil(t, err)
+
+	jobData, err := queueProvider.Dequeue("fake")
+	assert.Nil(t, err)
+	assert.NotNil(t, jobData)
+	assert.Equal(t, "catalog1", jobData.(v1alpha2.JobData).Id)
+	assert.Equal(t, "UPDATE", jobData.(v1alpha2.JobData).Action)
+
+	site, err := queueProvider.Dequeue("site-job-queue")
+	assert.Nil(t, err)
+	assert.NotNil(t, "fake", site.(string))
+}
+func TestGetABatchForSite(t *testing.T) {
+	queueProvider := &memoryqueue.MemoryQueueProvider{}
+	queueProvider.Init(memoryqueue.MemoryQueueProviderConfig{})
+
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+
+	manager := StagingManager{
+		StateProvider: stateProvider,
+		QueueProvider: queueProvider,
+	}
+
+	queueProvider.Enqueue("fake", v1alpha2.JobData{
+		Id:     "catalog1",
+		Action: "UPDATE",
+	})
+	queueProvider.Enqueue("fake", v1alpha2.JobData{
+		Id:     "catalog2",
+		Action: "UPDATE",
+	})
+	jobs, err := manager.GetABatchForSite("fake", 1)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(jobs))
+	assert.Equal(t, "catalog1", jobs[0].Id)
+	assert.Equal(t, "UPDATE", jobs[0].Action)
+
+	jobs, err = manager.GetABatchForSite("fake", 1)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(jobs))
+	assert.Equal(t, "catalog2", jobs[0].Id)
+	assert.Equal(t, "UPDATE", jobs[0].Action)
+}
+
+type AuthResponse struct {
+	AccessToken string   `json:"accessToken"`
+	TokenType   string   `json:"tokenType"`
+	Username    string   `json:"username"`
+	Roles       []string `json:"roles"`
+}
+
+func InitializeMockSymphonyAPI() *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var response interface{}
+		log.Info("Mock Symphony API called", "path", r.URL.Path)
+		switch r.URL.Path {
+		case "/catalogs/registry":
+			response = []model.CatalogState{{
+				Id: "catalog1",
+				Spec: &model.CatalogSpec{
+					Name:       "catalog1",
+					SiteId:     "fake",
+					Generation: "1",
+					ParentName: "fakeparent",
+				},
+				Status: &model.CatalogStatus{
+					Properties: map[string]string{},
+				},
+			}}
+		default:
+			response = AuthResponse{
+				AccessToken: "test-token",
+				TokenType:   "Bearer",
+				Username:    "test-user",
+				Roles:       []string{"role1", "role2"},
+			}
+		}
+
+		json.NewEncoder(w).Encode(response)
+	}))
+	return ts
+}

--- a/api/pkg/apis/v1alpha1/providers/target/mock/mock.go
+++ b/api/pkg/apis/v1alpha1/providers/target/mock/mock.go
@@ -92,8 +92,16 @@ func (m *MockTargetProvider) Get(ctx context.Context, deployment model.Deploymen
 	)
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
-
-	return cache[m.Config.ID], nil
+	ret := make([]model.ComponentSpec, 0)
+	for _, c := range cache[m.Config.ID] {
+		for _, r := range references {
+			if c.Name == r.Component.Name {
+				ret = append(ret, c)
+				break
+			}
+		}
+	}
+	return ret, nil
 }
 func (m *MockTargetProvider) Apply(ctx context.Context, deployment model.DeploymentSpec, step model.DeploymentStep, isDryRun bool) (map[string]model.ComponentResultSpec, error) {
 	_, span := observability.StartSpan(

--- a/api/pkg/apis/v1alpha1/vendors/solution-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/solution-vendor_test.go
@@ -130,6 +130,21 @@ func TestGetInstances(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, summary.SuccessCount)
 	assert.Equal(t, "OK", summary.TargetResults["T1"].Status)
+
+	resp = vendor.onApplyDeployment(v1alpha2.COARequest{
+		Method:  fasthttp.MethodGet,
+		Body:    data,
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	var components []model.ComponentSpec
+	err = json.Unmarshal(resp.Body, &components)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(components))
+	assert.Equal(t, "a", components[0].Name)
+	assert.Equal(t, "mock", components[0].Type)
+	assert.Equal(t, "b", components[1].Name)
+	assert.Equal(t, "mock", components[1].Type)
 }
 func TestApply(t *testing.T) {
 	vendor := createVendor()
@@ -188,6 +203,7 @@ func TestReconcileDocker(t *testing.T) {
 	json.Unmarshal(resp.Body, &summary)
 	assert.False(t, summary.Skipped)
 }
+
 func TestReconcile(t *testing.T) {
 	var summary model.SummarySpec
 	vendor := createVendor()


### PR DESCRIPTION
1. Fix mockTargetProvider where get function doesn't filter component name
2. Add UT for several managers

| manager | previous (%) | now (%) |
-------|---------------------------|-------------------------------------------
|campaign| 51.8 | 75|
| instances | / | 78.1 |
|jobs | / | 73.3|
| solution | 62.5 | 75.7|
|solutions | / | 78.0|
|stage | 43.9 | 69.2|
|staging | / | 60.6|



