### PR TITLE
Deployment as evaluation context value

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/solution/solution-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/solution/solution-manager.go
@@ -191,6 +191,7 @@ func (s *SolutionManager) Reconcile(ctx context.Context, deployment model.Deploy
 	if s.VendorContext != nil && s.VendorContext.EvaluationContext != nil {
 		context := s.VendorContext.EvaluationContext.Clone()
 		context.DeploymentSpec = deployment
+		context.Value = deployment
 		context.Component = ""
 		deployment, err = api_utils.EvaluateDeployment(*context)
 	}


### PR DESCRIPTION
Assign deployment as an evaluation context value, so it is exposed in DSL expressions such as ${{$context('$.Instance.Scope')}}. Currently, the evaluation context value is empty while evaluating Solution's properties.