### PR TITLE
Improve the first experience of maestro CLI

### DIFF
--- a/cli/cmd/p4ectl.go
+++ b/cli/cmd/p4ectl.go
@@ -15,6 +15,7 @@ import (
 
 var (
 	verbose bool
+	debug   bool
 )
 var RootCmd = &cobra.Command{
 	Use:   "maestro",
@@ -41,4 +42,5 @@ func Execute(versiong string) {
 
 func init() {
 	RootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Display verbose tracing info.")
+	RootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Turn off retry for debugging.")
 }

--- a/cli/cmd/samples.go
+++ b/cli/cmd/samples.go
@@ -192,9 +192,11 @@ var RunCmd = &cobra.Command{
 							action.Args[i] = strings.ReplaceAll(action.Args[i], "$(1)", strings.Trim(xArg, `'"`))
 						}
 					}
-					xArg, err = utils.RunCommand("", "", false, action.Command, action.Args...)
+					errOutput := ""
+					xArg, errOutput, err = utils.RunCommandWithRetry("", "", verbose, debug, action.Command, action.Args...)
 					if err != nil {
 						fmt.Printf("\n%s  Failed to execute post deployment script: %s %s\n\n", utils.ColorRed(), err.Error(), utils.ColorReset())
+						fmt.Printf("\n%s  Detailed Messages: %s %s\n\n", utils.ColorRed(), errOutput, utils.ColorReset())
 						return
 					}
 				}

--- a/cli/get_helm.sh
+++ b/cli/get_helm.sh
@@ -1,18 +1,10 @@
 #!/usr/bin/env bash
 
-# Copyright The Helm Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+##
+## Copyright (c) Microsoft Corporation.
+## Licensed under the MIT license.
+## SPDX-License-Identifier: MIT
+##
 
 # The install script is based off of the MIT-licensed script from glide,
 # the package manager for Go: https://github.com/Masterminds/glide.sh/blob/master/get
@@ -68,7 +60,7 @@ runAsRoot() {
 # verifySupported checks that the os/arch combination is supported for
 # binary builds, as well whether or not necessary tools are present.
 verifySupported() {
-  local supported="darwin-amd64\ndarwin-arm64\nlinux-386\nlinux-amd64\nlinux-arm\nlinux-arm64\nlinux-ppc64le\nlinux-s390x\nlinux-riscv64\nwindows-amd64"
+  local supported="darwin-amd64\ndarwin-arm64\nlinux-386\nlinux-amd64\nlinux-arm\nlinux-arm64\nlinux-ppc64le\nlinux-s390x\nwindows-amd64"
   if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
     echo "No prebuilt binary for ${OS}-${ARCH}."
     echo "To build from source, go to https://github.com/helm/helm"
@@ -108,17 +100,11 @@ verifySupported() {
 checkDesiredVersion() {
   if [ "x$DESIRED_VERSION" == "x" ]; then
     # Get tag from release URL
-    local latest_release_url="https://get.helm.sh/helm-latest-version"
-    local latest_release_response=""
+    local latest_release_url="https://github.com/helm/helm/releases"
     if [ "${HAS_CURL}" == "true" ]; then
-      latest_release_response=$( curl -L --silent --show-error --fail "$latest_release_url" 2>&1 || true )
+      TAG=$(curl -Ls $latest_release_url | grep 'href="/helm/helm/releases/tag/v3.[0-9]*.[0-9]*\"' | sed -E 's/.*\/helm\/helm\/releases\/tag\/(v[0-9\.]+)".*/\1/g' | head -1)
     elif [ "${HAS_WGET}" == "true" ]; then
-      latest_release_response=$( wget "$latest_release_url" -q -O - 2>&1 || true )
-    fi
-    TAG=$( echo "$latest_release_response" | grep '^v[0-9]' )
-    if [ "x$TAG" == "x" ]; then
-      printf "Could not retrieve the latest release tag information from %s: %s\n" "${latest_release_url}" "${latest_release_response}"
-      exit 1
+      TAG=$(wget $latest_release_url -O - 2>&1 | grep 'href="/helm/helm/releases/tag/v3.[0-9]*.[0-9]*\"' | sed -E 's/.*\/helm\/helm\/releases\/tag\/(v[0-9\.]+)".*/\1/g' | head -1)
     fi
   else
     TAG=$DESIRED_VERSION
@@ -305,10 +291,6 @@ while [[ $# -gt 0 ]]; do
        shift
        if [[ $# -ne 0 ]]; then
            export DESIRED_VERSION="${1}"
-           if [[ "$1" != "v"* ]]; then
-               echo "Expected version arg ('${DESIRED_VERSION}') to begin with 'v', fixing..."
-               export DESIRED_VERSION="v${1}"
-           fi
        else
            echo -e "Please provide the desired version. e.g. --version v3.0.0 or -v canary"
            exit 0

--- a/cli/get_helm.sh
+++ b/cli/get_helm.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
 
-##
-## Copyright (c) Microsoft Corporation.
-## Licensed under the MIT license.
-## SPDX-License-Identifier: MIT
-##
+# Copyright The Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # The install script is based off of the MIT-licensed script from glide,
 # the package manager for Go: https://github.com/Masterminds/glide.sh/blob/master/get
@@ -60,7 +68,7 @@ runAsRoot() {
 # verifySupported checks that the os/arch combination is supported for
 # binary builds, as well whether or not necessary tools are present.
 verifySupported() {
-  local supported="darwin-amd64\ndarwin-arm64\nlinux-386\nlinux-amd64\nlinux-arm\nlinux-arm64\nlinux-ppc64le\nlinux-s390x\nwindows-amd64"
+  local supported="darwin-amd64\ndarwin-arm64\nlinux-386\nlinux-amd64\nlinux-arm\nlinux-arm64\nlinux-ppc64le\nlinux-s390x\nlinux-riscv64\nwindows-amd64"
   if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
     echo "No prebuilt binary for ${OS}-${ARCH}."
     echo "To build from source, go to https://github.com/helm/helm"
@@ -100,11 +108,17 @@ verifySupported() {
 checkDesiredVersion() {
   if [ "x$DESIRED_VERSION" == "x" ]; then
     # Get tag from release URL
-    local latest_release_url="https://github.com/helm/helm/releases"
+    local latest_release_url="https://get.helm.sh/helm-latest-version"
+    local latest_release_response=""
     if [ "${HAS_CURL}" == "true" ]; then
-      TAG=$(curl -Ls $latest_release_url | grep 'href="/helm/helm/releases/tag/v3.[0-9]*.[0-9]*\"' | sed -E 's/.*\/helm\/helm\/releases\/tag\/(v[0-9\.]+)".*/\1/g' | head -1)
+      latest_release_response=$( curl -L --silent --show-error --fail "$latest_release_url" 2>&1 || true )
     elif [ "${HAS_WGET}" == "true" ]; then
-      TAG=$(wget $latest_release_url -O - 2>&1 | grep 'href="/helm/helm/releases/tag/v3.[0-9]*.[0-9]*\"' | sed -E 's/.*\/helm\/helm\/releases\/tag\/(v[0-9\.]+)".*/\1/g' | head -1)
+      latest_release_response=$( wget "$latest_release_url" -q -O - 2>&1 || true )
+    fi
+    TAG=$( echo "$latest_release_response" | grep '^v[0-9]' )
+    if [ "x$TAG" == "x" ]; then
+      printf "Could not retrieve the latest release tag information from %s: %s\n" "${latest_release_url}" "${latest_release_response}"
+      exit 1
     fi
   else
     TAG=$DESIRED_VERSION
@@ -291,6 +305,10 @@ while [[ $# -gt 0 ]]; do
        shift
        if [[ $# -ne 0 ]]; then
            export DESIRED_VERSION="${1}"
+           if [[ "$1" != "v"* ]]; then
+               echo "Expected version arg ('${DESIRED_VERSION}') to begin with 'v', fixing..."
+               export DESIRED_VERSION="v${1}"
+           fi
        else
            echo -e "Please provide the desired version. e.g. --version v3.0.0 or -v canary"
            exit 0

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -9,6 +9,7 @@ replace github.com/eclipse-symphony/symphony/coa => ../coa
 require github.com/spf13/cobra v1.6.1
 
 require (
+	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/eclipse-symphony/symphony/coa v0.0.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,4 +1,6 @@
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
+github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
+github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cheggaaa/pb v2.0.7+incompatible/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/cheggaaa/pb/v3 v3.0.4/go.mod h1:7rgWxLrAUcFMkvJuv09+DYi7mMUYi8nO9iOWcvGJPfw=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/cli/utils/runcmd.go
+++ b/cli/utils/runcmd.go
@@ -95,9 +95,9 @@ func RunCommandWithRetry(message string, successMessage string, showOutput bool,
 	retryErr := backoff.Retry(func() error {
 		retryCount++
 		if retryCount > 1 {
-			fmt.Printf("\r  %s%s%s ...%s %d %s%s \n", ColorReset(), message, ColorYellow(), "retrying", retryCount, "round", ColorReset())
+			fmt.Printf("\r  %s%s%s ...%s%s \n", ColorReset(), message, ColorYellow(), "trying", ColorReset())
 		}
-		output, errOutput, err = RunCommand(message, successMessage, showOutput, name, args...)
+		output, errOutput, err = runCommandHelper(message, successMessage, showOutput, true, name, args...)
 		return err
 	}, b)
 
@@ -110,7 +110,7 @@ func RunCommandWithRetry(message string, successMessage string, showOutput bool,
 	}
 }
 
-func RunCommand(message string, successMessage string, showOutput bool, name string, args ...string) (string, string, error) {
+func runCommandHelper(message string, successMessage string, showOutput bool, skipFailurePrompt bool, name string, args ...string) (string, string, error) {
 	cmd := exec.Command(name, args...)
 	output := []string{}
 	errOutput := []string{}
@@ -157,7 +157,9 @@ func RunCommand(message string, successMessage string, showOutput bool, name str
 	if exeErr == nil {
 		fmt.Printf("\r  %s%s%s ...%s%s \n", ColorReset(), message, ColorGreen(), successMessage, ColorReset())
 	} else {
-		fmt.Printf("\r  %s%s%s ...%s%s \n", ColorReset(), message, ColorYellow(), "failed", ColorReset())
+		if !skipFailurePrompt {
+			fmt.Printf("\r  %s%s%s ...%s%s \n", ColorReset(), message, ColorYellow(), "failed", ColorReset())
+		}
 	}
 
 	if showOutput {
@@ -170,6 +172,10 @@ func RunCommand(message string, successMessage string, showOutput bool, name str
 	}
 	showCursor()
 	return strings.Join(output, " "), strings.Join(errOutput, "\n"), exeErr
+}
+
+func RunCommand(message string, successMessage string, showOutput bool, name string, args ...string) (string, string, error) {
+	return runCommandHelper(message, successMessage, showOutput, false, name, args...)
 }
 
 func AddtoPath(des string) string {

--- a/cli/utils/runcmd.go
+++ b/cli/utils/runcmd.go
@@ -19,6 +19,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/cenkalti/backoff/v4"
 )
 
 const (
@@ -69,7 +71,46 @@ func RunCommandNoCapture(message string, successMessage string, name string, arg
 	}
 	return "", exeErr
 }
-func RunCommand(message string, successMessage string, showOutput bool, name string, args ...string) (string, error) {
+
+func RunCommandWithRetry(message string, successMessage string, showOutput bool, debug bool, name string, args ...string) (string, string, error) {
+	var output string
+	var errOutput string
+	var err error
+
+	retryCount := 0
+
+	b := backoff.NewExponentialBackOff()
+	if debug {
+		// Customize the backoff parameters.
+		b.InitialInterval = 2 * time.Second    // Initial retry interval.
+		b.MaxInterval = 30 * time.Second       // Maximum retry interval.
+		b.MaxElapsedTime = 1 * time.Nanosecond // Maximum total waiting time. (no retry)
+	} else {
+		// Customize the backoff parameters.
+		b.InitialInterval = 2 * time.Second // Initial retry interval.
+		b.MaxInterval = 30 * time.Second    // Maximum retry interval.
+		b.MaxElapsedTime = 5 * time.Minute  // Maximum total waiting time.
+	}
+
+	retryErr := backoff.Retry(func() error {
+		retryCount++
+		if retryCount > 1 {
+			fmt.Printf("\r  %s%s%s ...%s %d %s%s \n", ColorReset(), message, ColorYellow(), "retrying", retryCount, "round", ColorReset())
+		}
+		output, errOutput, err = RunCommand(message, successMessage, showOutput, name, args...)
+		return err
+	}, b)
+
+	if retryErr == nil {
+		// success
+		return output, "", nil
+	} else {
+		// failure
+		return "", errOutput, fmt.Errorf("failed to run command %s %s", name, strings.Join(args, " "))
+	}
+}
+
+func RunCommand(message string, successMessage string, showOutput bool, name string, args ...string) (string, string, error) {
 	cmd := exec.Command(name, args...)
 	output := []string{}
 	errOutput := []string{}
@@ -128,7 +169,7 @@ func RunCommand(message string, successMessage string, showOutput bool, name str
 		}
 	}
 	showCursor()
-	return strings.Join(output, " "), exeErr
+	return strings.Join(output, " "), strings.Join(errOutput, "\n"), exeErr
 }
 
 func AddtoPath(des string) string {
@@ -143,12 +184,12 @@ func AddtoPath(des string) string {
 }
 
 func CheckDocker(verbose bool) bool {
-	_, err := RunCommand("Checking Docker", "found", verbose, "docker", "info")
+	_, _, err := RunCommand("Checking Docker", "found", verbose, "docker", "info")
 	return err == nil
 }
 
 func CheckKubectl(verbose bool) bool {
-	_, err := RunCommand("Checking kubectl", "found", verbose, "kubectl")
+	_, _, err := RunCommand("Checking kubectl", "found", verbose, "kubectl")
 	return err == nil
 }
 
@@ -162,21 +203,21 @@ func CheckMinikube(verbose bool) bool {
 			fmt.Printf("\n%s  Failed to setting path for minikube.%s\n\n", ColorRed(), ColorReset())
 		}
 	}
-	_, err := RunCommand("Checking minikube", "found", verbose, "minikube", "version")
+	_, _, err := RunCommand("Checking minikube", "found", verbose, "minikube", "version")
 	return err == nil
 }
 
 func CheckK8sConnection(verbose bool) (string, bool) {
-	str, err := RunCommand("Checking kubectl context", "OK", verbose, "kubectl", "config", "current-context")
+	str, _, err := RunCommand("Checking kubectl context", "OK", verbose, "kubectl", "config", "current-context")
 	if err != nil {
 		return str, false
 	}
-	_, err = RunCommand("Checking Kubernetes connection", "OK", verbose, "kubectl", "cluster-info")
+	_, _, err = RunCommand("Checking Kubernetes connection", "OK", verbose, "kubectl", "cluster-info")
 	return str, err == nil
 }
 
 func CheckHelm(verbose bool) bool {
-	info, err := RunCommand("Checking Helm", "found", verbose, "helm", "version")
+	info, _, err := RunCommand("Checking Helm", "found", verbose, "helm", "version")
 	if err != nil {
 		return false
 	}
@@ -213,61 +254,61 @@ func InstallDocker(verbose bool) bool {
 	ios := runtime.GOOS
 	switch ios {
 	case "windows":
-		_, err := RunCommand("Downloading Docker Desktop Engine", "done", verbose, "curl", "-Lo", "docker-msi.exe", "https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe")
+		_, _, err := RunCommand("Downloading Docker Desktop Engine", "done", verbose, "curl", "-Lo", "docker-msi.exe", "https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe")
 		if err != nil {
 			fmt.Printf("\n%s  Failed to download Docker Desktop Engine.%s\n\n", ColorRed(), ColorReset())
 			return false
 		}
-		_, err = RunCommand("Installing Docker Desktop Engine", "done", verbose, "start", "/w", "", "docker-msi.exe", "install", "--quiet", "--accept-license")
+		_, _, err = RunCommand("Installing Docker Desktop Engine", "done", verbose, "start", "/w", "", "docker-msi.exe", "install", "--quiet", "--accept-license")
 		if err != nil {
 			fmt.Printf("\n%s  Failed to install Docker Desktop Engine.%s\n\n", ColorRed(), ColorReset())
 			return false
 		}
 	case "darwin":
 		//TODO: This downloads only for Intel chips
-		_, err := RunCommand("Downloading Docker Desktop Engine", "done", verbose, "curl", "-Lo", "Docker.dmg", "https://desktop.docker.com/mac/main/amd64/Docker.dmg")
+		_, _, err := RunCommand("Downloading Docker Desktop Engine", "done", verbose, "curl", "-Lo", "Docker.dmg", "https://desktop.docker.com/mac/main/amd64/Docker.dmg")
 		if err != nil {
 			fmt.Printf("\n%s  Failed to download Docker Desktop Engine.%s\n\n", ColorRed(), ColorReset())
 			return false
 		}
-		_, err = RunCommand("Attaching Docker Desktop Engine installer", "done", verbose, "sudo", "hdiutil", "attach", "Docker.dmg")
+		_, _, err = RunCommand("Attaching Docker Desktop Engine installer", "done", verbose, "sudo", "hdiutil", "attach", "Docker.dmg")
 		if err != nil {
 			fmt.Printf("\n%s  Failed to attach Docker Desktop Engine installer.%s\n\n", ColorRed(), ColorReset())
 			return false
 		}
-		_, err = RunCommand("Installing Docker Desktop Engine", "done", verbose, "sudo", "/Volumes/Docker/Docker.app/Contents/MacOS/install")
+		_, _, err = RunCommand("Installing Docker Desktop Engine", "done", verbose, "sudo", "/Volumes/Docker/Docker.app/Contents/MacOS/install")
 		if err != nil {
 			fmt.Printf("\n%s  Failed to intall Docker Desktop Engine.%s\n\n", ColorRed(), ColorReset())
 			return false
 		}
-		_, err = RunCommand("Detaching Docker Desktop Engine installer", "done", verbose, "sudo", "hdiutil", "detach", "/Volumes/Docker")
+		_, _, err = RunCommand("Detaching Docker Desktop Engine installer", "done", verbose, "sudo", "hdiutil", "detach", "/Volumes/Docker")
 		if err != nil {
 			fmt.Printf("\n%s  Failed to detach Docker Desktop Engine installer.%s\n\n", ColorRed(), ColorReset())
 			return false
 		}
 	case "linux":
-		_, err := RunCommand("Updating package index", "done", verbose, "sudo", "apt-get", "update")
+		_, _, err := RunCommand("Updating package index", "done", verbose, "sudo", "apt-get", "update")
 		if err != nil {
 			fmt.Printf("\n%s  Failed to update package index.%s\n\n", ColorRed(), ColorReset())
 			return false
 		}
-		_, err = RunCommand("Installing Docker", "done", verbose, "sudo", "apt-get", "install", "-y", "docker.io")
+		_, _, err = RunCommand("Installing Docker", "done", verbose, "sudo", "apt-get", "install", "-y", "docker.io")
 		if err != nil {
 			fmt.Printf("\n%s  Failed to install Docker.%s\n\n", ColorRed(), ColorReset())
 			return false
 		}
-		// err, _ = utils.RunCommand("Adding Docker user group", "done", verbose, "sudo", "groupadd", "docker")
+		// _, _, err = utils.RunCommand("Adding Docker user group", "done", verbose, "sudo", "groupadd", "docker")
 		// if err != nil {
 		// 	fmt.Printf("\n%s  Failed to add Docker user group./%s\n\n", utils.ColorRed(), utils.ColorReset())
 		// 	return false
 		// }
 		user := os.Getenv("USER")
-		_, err = RunCommand("Adding current user to Docker user group", "done", verbose, "sudo", "usermod", "-aG", "docker", user)
+		_, _, err = RunCommand("Adding current user to Docker user group", "done", verbose, "sudo", "usermod", "-aG", "docker", user)
 		if err != nil {
 			fmt.Printf("\n%s  Failed to add current user to Docker user group./%s\n\n", ColorRed(), ColorReset())
 			return false
 		}
-		_, err = RunCommand("Activating group membership", "done", verbose, "newgrp", "docker")
+		_, _, err = RunCommand("Activating group membership", "done", verbose, "newgrp", "docker")
 		if err != nil {
 			fmt.Printf("\n%s  Failed to activate user group.%s\n\n", ColorRed(), ColorReset())
 			return false

--- a/docs/symphony-book/quick_start/quick_start_maestro.md
+++ b/docs/symphony-book/quick_start/quick_start_maestro.md
@@ -50,6 +50,15 @@ maestro up
   maestro samples remove <sample name>
   ```
 
+## Diagnostics
+
+* To get run verbose logs:
+  ```
+  Run maestro command with "--verbose"
+  ```
+
+<!-- Known Issues -->
+
 ## More topics
 
 Now that you have the Symphony API, try out one of the quick start scenarios:


### PR DESCRIPTION
Fix: #71 
Fix: #72 
Fix: #73 

More users start to use maestro CLI and we got some feedback and opened issues #71 #72 #73.
These issues are not always reproduced and most of them can be fixed by retry or users need to get the detailed error information and do some manual mitigation before next retry. But in current maestro CLI, users cannot get the meaningful diagnostic information from output to resolve this issue. And for the transient issues, we don't have any retries. 
So, this PR is trying to,
1. By analyzing existing error patterns, always print the last error in the following error prone paths,
- a. Create minikube cluster
- b. Install cert manager
- c. Deploy symphony by running helm install/upgrade
- d. Run post action step when running samples
3. For path c, d, add retries to overcome the transient issues. Retry timeout is 5 mins. If other paths need retry, we can wrap them with ```RunCommandWithRetry```
4. Also introduce ```--debug``` to skip retry. This is for developers to test and diagnose the first error.
5. Fixed all RunCommand references to respect ```--verbose``` option to print verbose logs.

In the future, 
1. Add auto tests for maestro CLI. 
2. In doc, add known issues or diagnose section to let users know how to debug maestro CLI issue.

Last but not the least,
Found maestro CLI in latest main branch still points to ```oci://ghcr.io/azure/symphony/helm/symphony```, this should be a regression. Fixed the uri in this PR.
