### PR TITLE
Add unit tests for part of vendors

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/targets/targets-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/targets/targets-manager.go
@@ -112,9 +112,15 @@ func (t *TargetsManager) ReportState(ctx context.Context, current model.TargetSt
 		return model.TargetState{}, err
 	}
 
-	dict := target.Body.(map[string]interface{})
+	dict := map[string]interface{}{}
+	if target.Body != nil {
+		dict = target.Body.(map[string]interface{})
+	}
 
-	specCol := dict["spec"].(model.TargetSpec)
+	specCol := model.TargetSpec{}
+	if (dict["spec"] != nil) && (dict["spec"] != "") {
+		specCol = dict["spec"].(model.TargetSpec)
+	}
 
 	delete(dict, "spec")
 	if dict["status"] == nil {

--- a/api/pkg/apis/v1alpha1/managers/targets/targets-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/targets/targets-manager.go
@@ -111,21 +111,16 @@ func (t *TargetsManager) ReportState(ctx context.Context, current model.TargetSt
 		observ_utils.CloseSpanWithError(span, &err)
 		return model.TargetState{}, err
 	}
-	var ok bool
-	dict := map[string]interface{}{}
-	if target.Body != nil {
-		dict, ok = target.Body.(map[string]interface{})
-		if !ok {
-			return model.TargetState{}, fmt.Errorf("unable to cast target body to map[string]interface{}")
-		}
+
+	dict, ok := target.Body.(map[string]interface{})
+	if !ok {
+		return model.TargetState{}, fmt.Errorf("unable to cast target body to map[string]interface{}")
 	}
 
 	specCol := model.TargetSpec{}
-	if (dict["spec"] != nil) && (dict["spec"] != "") {
-		specCol, ok = dict["spec"].(model.TargetSpec)
-		if !ok {
-			return model.TargetState{}, fmt.Errorf("unable to cast target spec to model.TargetSpec")
-		}
+	specCol, ok = dict["spec"].(model.TargetSpec)
+	if !ok {
+		return model.TargetState{}, fmt.Errorf("unable to cast target spec to model.TargetSpec")
 	}
 
 	delete(dict, "spec")

--- a/api/pkg/apis/v1alpha1/managers/targets/targets-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/targets/targets-manager.go
@@ -111,15 +111,21 @@ func (t *TargetsManager) ReportState(ctx context.Context, current model.TargetSt
 		observ_utils.CloseSpanWithError(span, &err)
 		return model.TargetState{}, err
 	}
-
+	var ok bool
 	dict := map[string]interface{}{}
 	if target.Body != nil {
-		dict = target.Body.(map[string]interface{})
+		dict, ok = target.Body.(map[string]interface{})
+		if !ok {
+			return model.TargetState{}, fmt.Errorf("unable to cast target body to map[string]interface{}")
+		}
 	}
 
 	specCol := model.TargetSpec{}
 	if (dict["spec"] != nil) && (dict["spec"] != "") {
-		specCol = dict["spec"].(model.TargetSpec)
+		specCol, ok = dict["spec"].(model.TargetSpec)
+		if !ok {
+			return model.TargetState{}, fmt.Errorf("unable to cast target spec to model.TargetSpec")
+		}
 	}
 
 	delete(dict, "spec")

--- a/api/pkg/apis/v1alpha1/managers/targets/targets-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/targets/targets-manager.go
@@ -117,8 +117,7 @@ func (t *TargetsManager) ReportState(ctx context.Context, current model.TargetSt
 		return model.TargetState{}, fmt.Errorf("unable to cast target body to map[string]interface{}")
 	}
 
-	specCol := model.TargetSpec{}
-	specCol, ok = dict["spec"].(model.TargetSpec)
+	specCol, ok := dict["spec"].(model.TargetSpec)
 	if !ok {
 		return model.TargetState{}, fmt.Errorf("unable to cast target spec to model.TargetSpec")
 	}

--- a/api/pkg/apis/v1alpha1/vendors/activations-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/activations-vendor.go
@@ -83,7 +83,7 @@ func (c *ActivationsVendor) onStatus(request v1alpha2.COARequest) v1alpha2.COARe
 	})
 	defer span.End()
 
-	cLog.Info("V (Activations Vendor): onStatus")
+	vLog.Info("V (Activations Vendor): onStatus")
 	switch request.Method {
 	case fasthttp.MethodPost:
 		ctx, span := observability.StartSpan("onStatus-POST", pCtx, nil)
@@ -121,7 +121,7 @@ func (c *ActivationsVendor) onActivations(request v1alpha2.COARequest) v1alpha2.
 	})
 	defer span.End()
 
-	cLog.Info("V (Activations Vendor): onActivations")
+	vLog.Info("V (Activations Vendor): onActivations")
 
 	switch request.Method {
 	case fasthttp.MethodGet:

--- a/api/pkg/apis/v1alpha1/vendors/activations-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/activations-vendor.go
@@ -83,7 +83,7 @@ func (c *ActivationsVendor) onStatus(request v1alpha2.COARequest) v1alpha2.COARe
 	})
 	defer span.End()
 
-	vLog.Info("V (Activations Vendor): onStatus")
+	vLog.Infof("V (Activations Vendor): onStatus, method: %s, traceId: %s", string(request.Method), span.SpanContext().TraceID().String())
 	switch request.Method {
 	case fasthttp.MethodPost:
 		ctx, span := observability.StartSpan("onStatus-POST", pCtx, nil)
@@ -91,6 +91,7 @@ func (c *ActivationsVendor) onStatus(request v1alpha2.COARequest) v1alpha2.COARe
 		var status model.ActivationStatus
 		err := json.Unmarshal(request.Body, &status)
 		if err != nil {
+			vLog.Infof("V (Activations Vendor): onStatus failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -98,6 +99,7 @@ func (c *ActivationsVendor) onStatus(request v1alpha2.COARequest) v1alpha2.COARe
 		}
 		err = c.ActivationsManager.ReportStatus(ctx, id, status)
 		if err != nil {
+			vLog.Infof("V (Activations Vendor): onStatus failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -107,6 +109,7 @@ func (c *ActivationsVendor) onStatus(request v1alpha2.COARequest) v1alpha2.COARe
 			State: v1alpha2.OK,
 		})
 	}
+	vLog.Infof("V (Activations Vendor): onStatus failed - 405 method not allowed, traceId: %s", span.SpanContext().TraceID().String())
 	resp := v1alpha2.COAResponse{
 		State:       v1alpha2.MethodNotAllowed,
 		Body:        []byte("{\"result\":\"405 - method not allowed\"}"),
@@ -121,7 +124,7 @@ func (c *ActivationsVendor) onActivations(request v1alpha2.COARequest) v1alpha2.
 	})
 	defer span.End()
 
-	vLog.Info("V (Activations Vendor): onActivations")
+	vLog.Infof("V (Activations Vendor): onActivations, method: %s, traceId: %s", string(request.Method), span.SpanContext().TraceID().String())
 
 	switch request.Method {
 	case fasthttp.MethodGet:
@@ -137,6 +140,7 @@ func (c *ActivationsVendor) onActivations(request v1alpha2.COARequest) v1alpha2.
 			state, err = c.ActivationsManager.GetSpec(ctx, id)
 		}
 		if err != nil {
+			vLog.Infof("V (Activations Vendor): onActivations failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -160,6 +164,7 @@ func (c *ActivationsVendor) onActivations(request v1alpha2.COARequest) v1alpha2.
 
 		err := json.Unmarshal(request.Body, &activation)
 		if err != nil {
+			vLog.Infof("V (Activations Vendor): onActivations failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -168,6 +173,7 @@ func (c *ActivationsVendor) onActivations(request v1alpha2.COARequest) v1alpha2.
 
 		err = c.ActivationsManager.UpsertSpec(ctx, id, activation)
 		if err != nil {
+			vLog.Infof("V (Activations Vendor): onActivations failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -175,6 +181,7 @@ func (c *ActivationsVendor) onActivations(request v1alpha2.COARequest) v1alpha2.
 		}
 		entry, err := c.ActivationsManager.GetSpec(ctx, id)
 		if err != nil {
+			vLog.Infof("V (Activations Vendor): onActivations failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -197,6 +204,7 @@ func (c *ActivationsVendor) onActivations(request v1alpha2.COARequest) v1alpha2.
 		id := request.Parameters["__name"]
 		err := c.ActivationsManager.DeleteSpec(ctx, id)
 		if err != nil {
+			vLog.Infof("V (Activations Vendor): onActivations failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -206,6 +214,7 @@ func (c *ActivationsVendor) onActivations(request v1alpha2.COARequest) v1alpha2.
 			State: v1alpha2.OK,
 		})
 	}
+	vLog.Infof("V (Activations Vendor): onActivations failed - 405 method not allowed, traceId: %s", span.SpanContext().TraceID().String())
 	resp := v1alpha2.COAResponse{
 		State:       v1alpha2.MethodNotAllowed,
 		Body:        []byte("{\"result\":\"405 - method not allowed\"}"),

--- a/api/pkg/apis/v1alpha1/vendors/activations-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/activations-vendor_test.go
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package vendors
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/activations"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/pubsub/memory"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+)
+
+func createActivationsVendor() ActivationsVendor {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	manager := activations.ActivationsManager{
+		StateProvider: stateProvider,
+	}
+	vendor := ActivationsVendor{
+		ActivationsManager: &manager,
+	}
+	return vendor
+}
+func TestActivationsEndpoints(t *testing.T) {
+	vendor := createActivationsVendor()
+	vendor.Route = "activations"
+	endpoints := vendor.GetEndpoints()
+	assert.Equal(t, 2, len(endpoints))
+}
+func TestActivationsInfo(t *testing.T) {
+	vendor := createActivationsVendor()
+	vendor.Version = "1.0"
+	info := vendor.GetInfo()
+	assert.NotNil(t, info)
+	assert.Equal(t, "1.0", info.Version)
+}
+func TestActivationsOnStatus(t *testing.T) {
+	vendor := createActivationsVendor()
+	status := model.ActivationStatus{
+		Status: 9996,
+	}
+	data, _ := json.Marshal(status)
+	resp := vendor.onStatus(v1alpha2.COARequest{
+		Method: fasthttp.MethodPost,
+		Body:   data,
+		Parameters: map[string]string{
+			"__name": "activation1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.InternalError, resp.State)
+}
+func TestActivationsOnActivations(t *testing.T) {
+	vendor := createActivationsVendor()
+	vendor.Context = &contexts.VendorContext{}
+	pubSubProvider := memory.InMemoryPubSubProvider{}
+	pubSubProvider.Init(memory.InMemoryPubSubConfig{Name: "test"})
+	vendor.Context.Init(&pubSubProvider)
+	activationName := "activation1"
+	campaignName := "campaign1"
+	succeededCount := 0
+	vendor.Context.Subscribe("activation", func(topic string, event v1alpha2.Event) error {
+		var activation v1alpha2.ActivationData
+		jData, _ := json.Marshal(event.Body)
+		err := json.Unmarshal(jData, &activation)
+		assert.Nil(t, err)
+		assert.Equal(t, campaignName, activation.Campaign)
+		assert.Equal(t, activationName, activation.Activation)
+		succeededCount += 1
+		return nil
+	})
+	activationSpec := model.ActivationSpec{
+		Name:     activationName,
+		Campaign: campaignName,
+	}
+	data, _ := json.Marshal(activationSpec)
+	resp := vendor.onActivations(v1alpha2.COARequest{
+		Method: fasthttp.MethodPost,
+		Body:   data,
+		Parameters: map[string]string{
+			"__name": "activation1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	time.Sleep(time.Second)
+	assert.Equal(t, 1, succeededCount)
+
+	resp = vendor.onActivations(v1alpha2.COARequest{
+		Method: fasthttp.MethodGet,
+		Parameters: map[string]string{
+			"__name": "activation1",
+		},
+		Context: context.Background(),
+	})
+	var activation model.ActivationState
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	err := json.Unmarshal(resp.Body, &activation)
+	assert.Nil(t, err)
+	assert.Equal(t, activationName, activation.Id)
+	assert.Equal(t, campaignName, activation.Spec.Campaign)
+
+	resp = vendor.onActivations(v1alpha2.COARequest{
+		Method:  fasthttp.MethodGet,
+		Context: context.Background(),
+	})
+	var activations []model.ActivationState
+	err = json.Unmarshal(resp.Body, &activations)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(activations))
+	assert.Equal(t, activationName, activations[0].Id)
+	assert.Equal(t, campaignName, activations[0].Spec.Campaign)
+
+	status := model.ActivationStatus{
+		Status: 9996,
+	}
+	data, _ = json.Marshal(status)
+	resp = vendor.onStatus(v1alpha2.COARequest{
+		Method: fasthttp.MethodPost,
+		Body:   data,
+		Parameters: map[string]string{
+			"__name": "activation1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+
+	resp = vendor.onActivations(v1alpha2.COARequest{
+		Method: fasthttp.MethodDelete,
+		Parameters: map[string]string{
+			"__name": "activation1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+}

--- a/api/pkg/apis/v1alpha1/vendors/activations-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/activations-vendor_test.go
@@ -166,3 +166,23 @@ func TestActivationsOnActivations(t *testing.T) {
 	})
 	assert.Equal(t, v1alpha2.OK, resp.State)
 }
+func TestActivationsWrongMethod(t *testing.T) {
+	vendor := createActivationsVendor()
+	resp := vendor.onActivations(v1alpha2.COARequest{
+		Method: fasthttp.MethodPut,
+		Parameters: map[string]string{
+			"__name": "activation1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.MethodNotAllowed, resp.State)
+
+	resp = vendor.onStatus(v1alpha2.COARequest{
+		Method: fasthttp.MethodPut,
+		Parameters: map[string]string{
+			"__name": "activation1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.MethodNotAllowed, resp.State)
+}

--- a/api/pkg/apis/v1alpha1/vendors/activations-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/activations-vendor_test.go
@@ -61,6 +61,18 @@ func TestActivationsOnStatus(t *testing.T) {
 		Context: context.Background(),
 	})
 	assert.Equal(t, v1alpha2.InternalError, resp.State)
+	assert.Equal(t, "entry 'activation1' is not found", string(resp.Body))
+
+	resp = vendor.onStatus(v1alpha2.COARequest{
+		Method: fasthttp.MethodPost,
+		Body:   []byte{},
+		Parameters: map[string]string{
+			"__name": "activation1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.InternalError, resp.State)
+	assert.Equal(t, "unexpected end of JSON input", string(resp.Body))
 }
 func TestActivationsOnActivations(t *testing.T) {
 	vendor := createActivationsVendor()
@@ -81,12 +93,20 @@ func TestActivationsOnActivations(t *testing.T) {
 		succeededCount += 1
 		return nil
 	})
+	resp := vendor.onActivations(v1alpha2.COARequest{
+		Method: fasthttp.MethodGet,
+		Parameters: map[string]string{
+			"__name": "activation1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.InternalError, resp.State)
 	activationSpec := model.ActivationSpec{
 		Name:     activationName,
 		Campaign: campaignName,
 	}
 	data, _ := json.Marshal(activationSpec)
-	resp := vendor.onActivations(v1alpha2.COARequest{
+	resp = vendor.onActivations(v1alpha2.COARequest{
 		Method: fasthttp.MethodPost,
 		Body:   data,
 		Parameters: map[string]string{

--- a/api/pkg/apis/v1alpha1/vendors/campaigns-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/campaigns-vendor.go
@@ -75,7 +75,7 @@ func (c *CampaignsVendor) onCampaigns(request v1alpha2.COARequest) v1alpha2.COAR
 		"method": "onCampaigns",
 	})
 	defer span.End()
-	cLog.Info("V (Campaigns): onCampaigns")
+	cLog.Infof("V (Campaigns): onCampaigns, method: %s, traceId: %s", string(request.Method), span.SpanContext().TraceID().String())
 
 	switch request.Method {
 	case fasthttp.MethodGet:
@@ -91,6 +91,7 @@ func (c *CampaignsVendor) onCampaigns(request v1alpha2.COARequest) v1alpha2.COAR
 			state, err = c.CampaignsManager.GetSpec(ctx, id)
 		}
 		if err != nil {
+			cLog.Infof("V (Campaigns): onCampaigns failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -114,6 +115,7 @@ func (c *CampaignsVendor) onCampaigns(request v1alpha2.COARequest) v1alpha2.COAR
 
 		err := json.Unmarshal(request.Body, &campaign)
 		if err != nil {
+			cLog.Infof("V (Campaigns): onCampaigns failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -122,6 +124,7 @@ func (c *CampaignsVendor) onCampaigns(request v1alpha2.COARequest) v1alpha2.COAR
 
 		err = c.CampaignsManager.UpsertSpec(ctx, id, campaign)
 		if err != nil {
+			cLog.Infof("V (Campaigns): onCampaigns failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -135,6 +138,7 @@ func (c *CampaignsVendor) onCampaigns(request v1alpha2.COARequest) v1alpha2.COAR
 		id := request.Parameters["__name"]
 		err := c.CampaignsManager.DeleteSpec(ctx, id)
 		if err != nil {
+			cLog.Infof("V (Campaigns): onCampaigns failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -144,6 +148,7 @@ func (c *CampaignsVendor) onCampaigns(request v1alpha2.COARequest) v1alpha2.COAR
 			State: v1alpha2.OK,
 		})
 	}
+	cLog.Infof("V (Campaigns): onCampaigns failed - 405 method not allowed, traceId: %s", span.SpanContext().TraceID().String())
 	resp := v1alpha2.COAResponse{
 		State:       v1alpha2.MethodNotAllowed,
 		Body:        []byte("{\"result\":\"405 - method not allowed\"}"),

--- a/api/pkg/apis/v1alpha1/vendors/campaigns-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/campaigns-vendor_test.go
@@ -154,5 +154,21 @@ func TestCampaignsOnCampaignsFailure(t *testing.T) {
 	})
 	assert.Equal(t, v1alpha2.InternalError, resp.State)
 	assert.Equal(t, "entry 'campaign1' is not found", string(resp.Body))
+}
 
+func TestCampaignsWrongMethod(t *testing.T) {
+	vendor := createCampaignsVendor()
+	campaignSpec := model.CampaignSpec{
+		Name: "campaign1",
+	}
+	data, _ := json.Marshal(campaignSpec)
+	resp := vendor.onCampaigns(v1alpha2.COARequest{
+		Method: fasthttp.MethodPut,
+		Body:   data,
+		Parameters: map[string]string{
+			"__name": "campaign1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.MethodNotAllowed, resp.State)
 }

--- a/api/pkg/apis/v1alpha1/vendors/campaigns-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/campaigns-vendor_test.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package vendors
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	sym_mgr "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/vendors"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+)
+
+func createCampaignsVendor() CampaignsVendor {
+	stateProvider := memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	vendor := CampaignsVendor{}
+	vendor.Init(vendors.VendorConfig{
+		Properties: map[string]string{
+			"test": "true",
+		},
+		Managers: []managers.ManagerConfig{
+			{
+				Name: "campaigns-manager",
+				Type: "managers.symphony.campaigns",
+				Properties: map[string]string{
+					"providers.state": "mem-state",
+				},
+				Providers: map[string]managers.ProviderConfig{
+					"mem-state": {
+						Type:   "providers.state.memory",
+						Config: memorystate.MemoryStateProviderConfig{},
+					},
+				},
+			},
+		},
+	}, []managers.IManagerFactroy{
+		&sym_mgr.SymphonyManagerFactory{},
+	}, map[string]map[string]providers.IProvider{
+		"campaigns-manager": {
+			"mem-state": &stateProvider,
+		},
+	}, nil)
+	return vendor
+}
+func TestCampaignsEndpoints(t *testing.T) {
+	vendor := createCampaignsVendor()
+	vendor.Route = "campaigns"
+	endpoints := vendor.GetEndpoints()
+	assert.Equal(t, 1, len(endpoints))
+}
+func TestCampaignsInfo(t *testing.T) {
+	vendor := createCampaignsVendor()
+	vendor.Version = "1.0"
+	info := vendor.GetInfo()
+	assert.NotNil(t, info)
+	assert.Equal(t, "1.0", info.Version)
+}
+func TestCampaignsOnCampaigns(t *testing.T) {
+	vendor := createCampaignsVendor()
+	campaignSpec := model.CampaignSpec{
+		Name: "campaign1",
+	}
+	data, _ := json.Marshal(campaignSpec)
+	resp := vendor.onCampaigns(v1alpha2.COARequest{
+		Method: fasthttp.MethodPost,
+		Body:   data,
+		Parameters: map[string]string{
+			"__name": "campaign1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+
+	resp = vendor.onCampaigns(v1alpha2.COARequest{
+		Method: fasthttp.MethodGet,
+		Parameters: map[string]string{
+			"__name": "campaign1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	var campaign model.CampaignState
+	err := json.Unmarshal(resp.Body, &campaign)
+	assert.Nil(t, err)
+	assert.Equal(t, "campaign1", campaign.Id)
+
+	resp = vendor.onCampaigns(v1alpha2.COARequest{
+		Method:  fasthttp.MethodGet,
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	var campaigns []model.CampaignState
+	err = json.Unmarshal(resp.Body, &campaigns)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(campaigns))
+	assert.Equal(t, "campaign1", campaigns[0].Id)
+
+	resp = vendor.onCampaigns(v1alpha2.COARequest{
+		Method: fasthttp.MethodDelete,
+		Parameters: map[string]string{
+			"__name": "campaign1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+}

--- a/api/pkg/apis/v1alpha1/vendors/campaigns-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/campaigns-vendor_test.go
@@ -116,3 +116,43 @@ func TestCampaignsOnCampaigns(t *testing.T) {
 	})
 	assert.Equal(t, v1alpha2.OK, resp.State)
 }
+func TestCampaignsOnCampaignsFailure(t *testing.T) {
+	vendor := createCampaignsVendor()
+	campaignSpec := model.CampaignSpec{
+		Name: "campaign1",
+	}
+	data, _ := json.Marshal(campaignSpec)
+	resp := vendor.onCampaigns(v1alpha2.COARequest{
+		Method: fasthttp.MethodGet,
+		Body:   data,
+		Parameters: map[string]string{
+			"__name": "campaign1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.InternalError, resp.State)
+	assert.Equal(t, "entry 'campaign1' is not found", string(resp.Body))
+
+	resp = vendor.onCampaigns(v1alpha2.COARequest{
+		Method: fasthttp.MethodPost,
+		Body:   []byte("bad data"),
+		Parameters: map[string]string{
+			"__name": "campaign1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.InternalError, resp.State)
+	assert.Equal(t, "invalid character 'b' looking for beginning of value", string(resp.Body))
+
+	resp = vendor.onCampaigns(v1alpha2.COARequest{
+		Method: fasthttp.MethodDelete,
+		Body:   data,
+		Parameters: map[string]string{
+			"__name": "campaign1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.InternalError, resp.State)
+	assert.Equal(t, "entry 'campaign1' is not found", string(resp.Body))
+
+}

--- a/api/pkg/apis/v1alpha1/vendors/instances-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/instances-vendor.go
@@ -77,7 +77,7 @@ func (c *InstancesVendor) onInstances(request v1alpha2.COARequest) v1alpha2.COAR
 	})
 	defer span.End()
 
-	iLog.Info("~ Instances Manager ~ : onInstances")
+	iLog.Infof("V (Instances): onInstances, method: %s, traceId: %s", string(request.Method), span.SpanContext().TraceID().String())
 
 	switch request.Method {
 	case fasthttp.MethodGet:
@@ -101,6 +101,7 @@ func (c *InstancesVendor) onInstances(request v1alpha2.COARequest) v1alpha2.COAR
 			state, err = c.InstancesManager.GetSpec(ctx, id, scope)
 		}
 		if err != nil {
+			iLog.Infof("V (Instances): onInstances failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -142,6 +143,7 @@ func (c *InstancesVendor) onInstances(request v1alpha2.COARequest) v1alpha2.COAR
 			} else {
 				parts := strings.Split(target_selector, "=")
 				if len(parts) != 2 {
+					iLog.Infof("V (Instances): onInstances failed - invalid target selector format, traceId: %s", span.SpanContext().TraceID().String())
 					return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 						State: v1alpha2.InternalError,
 						Body:  []byte("invalid target selector format. Expected: <property>=<value>"),
@@ -156,6 +158,7 @@ func (c *InstancesVendor) onInstances(request v1alpha2.COARequest) v1alpha2.COAR
 		} else {
 			err := json.Unmarshal(request.Body, &instance)
 			if err != nil {
+				iLog.Infof("V (Instances): onInstances failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 				return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 					State: v1alpha2.InternalError,
 					Body:  []byte(err.Error()),
@@ -164,6 +167,7 @@ func (c *InstancesVendor) onInstances(request v1alpha2.COARequest) v1alpha2.COAR
 		}
 		err := c.InstancesManager.UpsertSpec(ctx, id, instance, scope)
 		if err != nil {
+			iLog.Infof("V (Instances): onInstances failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -209,6 +213,7 @@ func (c *InstancesVendor) onInstances(request v1alpha2.COARequest) v1alpha2.COAR
 		} else {
 			err := c.InstancesManager.DeleteSpec(ctx, id, scope)
 			if err != nil {
+				iLog.Infof("V (Instances): onInstances failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 				return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 					State: v1alpha2.InternalError,
 					Body:  []byte(err.Error()),
@@ -219,6 +224,7 @@ func (c *InstancesVendor) onInstances(request v1alpha2.COARequest) v1alpha2.COAR
 			State: v1alpha2.OK,
 		})
 	}
+	iLog.Infof("V (Instances): onInstances failed - 405 method not allowed, traceId: %s", span.SpanContext().TraceID().String())
 	resp := v1alpha2.COAResponse{
 		State:       v1alpha2.MethodNotAllowed,
 		Body:        []byte("{\"result\":\"405 - method not allowed\"}"),

--- a/api/pkg/apis/v1alpha1/vendors/instances-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/instances-vendor.go
@@ -77,7 +77,7 @@ func (c *InstancesVendor) onInstances(request v1alpha2.COARequest) v1alpha2.COAR
 	})
 	defer span.End()
 
-	tLog.Info("~ Instances Manager ~ : onInstances")
+	iLog.Info("~ Instances Manager ~ : onInstances")
 
 	switch request.Method {
 	case fasthttp.MethodGet:

--- a/api/pkg/apis/v1alpha1/vendors/instances-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/instances-vendor_test.go
@@ -199,3 +199,12 @@ func TestInstancesTargetSelector(t *testing.T) {
 	assert.Equal(t, "instance1", instance.Id)
 	assert.Equal(t, "value1", instance.Spec.Target.Selector["property1"])
 }
+
+func TestInstancesWrongMethod(t *testing.T) {
+	vendor := createInstancesVendor()
+	resp := vendor.onInstances(v1alpha2.COARequest{
+		Method:  fasthttp.MethodPut,
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.MethodNotAllowed, resp.State)
+}

--- a/api/pkg/apis/v1alpha1/vendors/instances-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/instances-vendor_test.go
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package vendors
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	sym_mgr "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/pubsub/memory"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/vendors"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+)
+
+func createInstancesVendor() InstancesVendor {
+	stateProvider := memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	vendor := InstancesVendor{}
+	vendor.Init(vendors.VendorConfig{
+		Properties: map[string]string{
+			"test": "true",
+		},
+		Managers: []managers.ManagerConfig{
+			{
+				Name: "instances-manager",
+				Type: "managers.symphony.instances",
+				Properties: map[string]string{
+					"providers.state": "mem-state",
+				},
+				Providers: map[string]managers.ProviderConfig{
+					"mem-state": {
+						Type:   "providers.state.memory",
+						Config: memorystate.MemoryStateProviderConfig{},
+					},
+				},
+			},
+		},
+	}, []managers.IManagerFactroy{
+		&sym_mgr.SymphonyManagerFactory{},
+	}, map[string]map[string]providers.IProvider{
+		"instances-manager": {
+			"mem-state": &stateProvider,
+		},
+	}, nil)
+	return vendor
+}
+func TestInstancesEndpoints(t *testing.T) {
+	vendor := createInstancesVendor()
+	vendor.Route = "instances"
+	endpoints := vendor.GetEndpoints()
+	assert.Equal(t, 1, len(endpoints))
+}
+func TestInstancesInfo(t *testing.T) {
+	vendor := createInstancesVendor()
+	vendor.Version = "1.0"
+	info := vendor.GetInfo()
+	assert.NotNil(t, info)
+	assert.Equal(t, "1.0", info.Version)
+}
+func TestInstancesOnInstances(t *testing.T) {
+	vendor := createInstancesVendor()
+	vendor.Context = &contexts.VendorContext{}
+	pubSubProvider := memory.InMemoryPubSubProvider{}
+	pubSubProvider.Init(memory.InMemoryPubSubConfig{Name: "test"})
+	vendor.Context.Init(&pubSubProvider)
+	vendor.Config.Properties = map[string]string{
+		"useJobManager": "true",
+	}
+	succeededCount := 0
+	vendor.Context.Subscribe("job", func(topic string, event v1alpha2.Event) error {
+		var job v1alpha2.JobData
+		jData, _ := json.Marshal(event.Body)
+		err := json.Unmarshal(jData, &job)
+		assert.Nil(t, err)
+		assert.Equal(t, "instance", event.Metadata["objectType"])
+		assert.Equal(t, "instance1", job.Id)
+		assert.Equal(t, true, job.Action == "UPDATE" || job.Action == "DELETE")
+		succeededCount += 1
+		return nil
+	})
+	instanceSpec := model.InstanceSpec{}
+	data, _ := json.Marshal(instanceSpec)
+	resp := vendor.onInstances(v1alpha2.COARequest{
+		Method: fasthttp.MethodPost,
+		Body:   data,
+		Parameters: map[string]string{
+			"__name":   "instance1",
+			"target":   "target1",
+			"solution": "solution1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+
+	resp = vendor.onInstances(v1alpha2.COARequest{
+		Method: fasthttp.MethodGet,
+		Parameters: map[string]string{
+			"__name": "instance1",
+		},
+		Context: context.Background(),
+	})
+	var instance model.InstanceState
+	err := json.Unmarshal(resp.Body, &instance)
+	assert.Nil(t, err)
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	assert.Equal(t, "instance1", instance.Id)
+	assert.Equal(t, "target1", instance.Spec.Target.Name)
+
+	resp = vendor.onInstances(v1alpha2.COARequest{
+		Method:  fasthttp.MethodGet,
+		Context: context.Background(),
+	})
+	var instances []model.InstanceState
+	err = json.Unmarshal(resp.Body, &instances)
+	assert.Nil(t, err)
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	assert.Equal(t, 1, len(instances))
+	assert.Equal(t, "instance1", instances[0].Id)
+	assert.Equal(t, "target1", instances[0].Spec.Target.Name)
+
+	resp = vendor.onInstances(v1alpha2.COARequest{
+		Method: fasthttp.MethodDelete,
+		Parameters: map[string]string{
+			"__name": "instance1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	time.Sleep(time.Second)
+	assert.Equal(t, 2, succeededCount)
+
+	vendor.Config.Properties = map[string]string{
+		"useJobManager": "false",
+	}
+	resp = vendor.onInstances(v1alpha2.COARequest{
+		Method: fasthttp.MethodDelete,
+		Parameters: map[string]string{
+			"__name": "instance1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+
+	resp = vendor.onInstances(v1alpha2.COARequest{
+		Method:  fasthttp.MethodGet,
+		Context: context.Background(),
+	})
+	err = json.Unmarshal(resp.Body, &instances)
+	assert.Nil(t, err)
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	assert.Equal(t, 0, len(instances))
+}
+
+func TestInstancesTargetSelector(t *testing.T) {
+	vendor := createInstancesVendor()
+	vendor.Context = &contexts.VendorContext{}
+	pubSubProvider := memory.InMemoryPubSubProvider{}
+	pubSubProvider.Init(memory.InMemoryPubSubConfig{Name: "test"})
+	vendor.Context.Init(&pubSubProvider)
+
+	instanceSpec := model.InstanceSpec{}
+	data, _ := json.Marshal(instanceSpec)
+	resp := vendor.onInstances(v1alpha2.COARequest{
+		Method: fasthttp.MethodPost,
+		Body:   data,
+		Parameters: map[string]string{
+			"__name":          "instance1",
+			"target-selector": "property1=value1",
+			"solution":        "solution1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+
+	resp = vendor.onInstances(v1alpha2.COARequest{
+		Method: fasthttp.MethodGet,
+		Parameters: map[string]string{
+			"__name": "instance1",
+		},
+		Context: context.Background(),
+	})
+	var instance model.InstanceState
+	err := json.Unmarshal(resp.Body, &instance)
+	assert.Nil(t, err)
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	assert.Equal(t, "instance1", instance.Id)
+	assert.Equal(t, "value1", instance.Spec.Target.Selector["property1"])
+}

--- a/api/pkg/apis/v1alpha1/vendors/job-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/job-vendor.go
@@ -102,11 +102,13 @@ func (c *JobVendor) onHello(request v1alpha2.COARequest) v1alpha2.COAResponse {
 	})
 	defer span.End()
 
+	jLog.Infof("V (Job): onHello, method: %s, traceId: %s", string(request.Method), span.SpanContext().TraceID().String())
 	switch request.Method {
 	case fasthttp.MethodPost:
 		var activationData v1alpha2.ActivationData
 		err := json.Unmarshal(request.Body, &activationData)
 		if err != nil {
+			jLog.Errorf("V (Job): onHello failed - %s, traceId: %s", span.SpanContext().TraceID().String(), err.Error())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State:       v1alpha2.BadRequest,
 				Body:        []byte("{\"result\":\"400 - bad request\"}"),
@@ -120,6 +122,7 @@ func (c *JobVendor) onHello(request v1alpha2.COARequest) v1alpha2.COAResponse {
 			State: v1alpha2.OK,
 		})
 	}
+	jLog.Errorf("V (Job): onHello failed - 405 method not allowed, traceId: %s", span.SpanContext().TraceID().String())
 	resp := v1alpha2.COAResponse{
 		State:       v1alpha2.MethodNotAllowed,
 		Body:        []byte("{\"result\":\"405 - method not allowed\"}"),

--- a/api/pkg/apis/v1alpha1/vendors/job-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/job-vendor_test.go
@@ -112,3 +112,11 @@ func TestJobsonHello(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	assert.Equal(t, 1, succeededCount)
 }
+func TestJobWrongMethod(t *testing.T) {
+	vendor := createJobVendor()
+	resp := vendor.onHello(v1alpha2.COARequest{
+		Method:  fasthttp.MethodGet,
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.MethodNotAllowed, resp.State)
+}

--- a/api/pkg/apis/v1alpha1/vendors/job-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/job-vendor_test.go
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package vendors
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	sym_mgr "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/jobs"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/pubsub/memory"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/vendors"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+)
+
+func createJobVendor() JobVendor {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	manager := jobs.JobsManager{
+		StateProvider: stateProvider,
+	}
+	vendor := JobVendor{
+		JobsManager: &manager,
+	}
+	return vendor
+}
+func TestJobsEndpoints(t *testing.T) {
+	vendor := createJobVendor()
+	vendor.Route = "instances"
+	endpoints := vendor.GetEndpoints()
+	assert.Equal(t, 1, len(endpoints))
+}
+func TestJobsInfo(t *testing.T) {
+	vendor := createJobVendor()
+	vendor.Version = "1.0"
+	info := vendor.GetInfo()
+	assert.NotNil(t, info)
+	assert.Equal(t, "1.0", info.Version)
+}
+func TestJobsInit(t *testing.T) {
+	stateProvider := memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	vendor := JobVendor{}
+	err := vendor.Init(vendors.VendorConfig{
+		Properties: map[string]string{
+			"test": "true",
+		},
+		Managers: []managers.ManagerConfig{
+			{
+				Name: "jobs-manager",
+				Type: "managers.symphony.jobs",
+				Properties: map[string]string{
+					"providers.state": "mem-state",
+				},
+				Providers: map[string]managers.ProviderConfig{
+					"mem-state": {
+						Type:   "providers.state.memory",
+						Config: memorystate.MemoryStateProviderConfig{},
+					},
+				},
+			},
+		},
+	}, []managers.IManagerFactroy{
+		&sym_mgr.SymphonyManagerFactory{},
+	}, map[string]map[string]providers.IProvider{
+		"jobs-manager": {
+			"mem-state": &stateProvider,
+		},
+	}, nil)
+	assert.Nil(t, err)
+}
+func TestJobsonHello(t *testing.T) {
+	vendor := createJobVendor()
+	vendor.Context = &contexts.VendorContext{}
+	pubSubProvider := memory.InMemoryPubSubProvider{}
+	pubSubProvider.Init(memory.InMemoryPubSubConfig{Name: "test"})
+	vendor.Context.Init(&pubSubProvider)
+	succeededCount := 0
+	vendor.Context.Subscribe("activation", func(topic string, event v1alpha2.Event) error {
+		var activation v1alpha2.ActivationData
+		jData, _ := json.Marshal(event.Body)
+		err := json.Unmarshal(jData, &activation)
+		assert.Nil(t, err)
+		assert.Equal(t, "activation1", activation.Activation)
+		assert.Equal(t, "campaign1", activation.Campaign)
+		succeededCount += 1
+		return nil
+	})
+	activation := v1alpha2.ActivationData{
+		Activation: "activation1",
+		Campaign:   "campaign1",
+	}
+	data, _ := json.Marshal(activation)
+	resp := vendor.onHello(v1alpha2.COARequest{
+		Method:  fasthttp.MethodPost,
+		Body:    data,
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	time.Sleep(1 * time.Second)
+	assert.Equal(t, 1, succeededCount)
+}

--- a/api/pkg/apis/v1alpha1/vendors/solution-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/solution-vendor.go
@@ -84,7 +84,7 @@ func (c *SolutionVendor) onQueue(request v1alpha2.COARequest) v1alpha2.COARespon
 	})
 	defer span.End()
 
-	log.Info("V (Solution): onQueue")
+	sLog.Infof("V (Solution): onQueue, method: %s, traceId: %s", request.Method, span.SpanContext().TraceID().String())
 
 	scope, exist := request.Parameters["scope"]
 	if !exist {
@@ -97,6 +97,7 @@ func (c *SolutionVendor) onQueue(request v1alpha2.COARequest) v1alpha2.COARespon
 		instance := request.Parameters["instance"]
 
 		if instance == "" {
+			sLog.Infof("V (Solution): onQueue failed - 400 instance parameter is not found, traceId: %s", span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State:       v1alpha2.BadRequest,
 				Body:        []byte("{\"result\":\"400 - instance parameter is not found\"}"),
@@ -106,6 +107,7 @@ func (c *SolutionVendor) onQueue(request v1alpha2.COARequest) v1alpha2.COARespon
 		summary, err := c.SolutionManager.GetSummary(ctx, instance, scope)
 		data, _ := json.Marshal(summary)
 		if err != nil {
+			sLog.Infof("V (Solution): onQueue failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 			if v1alpha2.IsNotFound(err) {
 				return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 					State: v1alpha2.NotFound,
@@ -130,6 +132,7 @@ func (c *SolutionVendor) onQueue(request v1alpha2.COARequest) v1alpha2.COARespon
 		delete := request.Parameters["delete"]
 		target := request.Parameters["target"]
 		if instance == "" {
+			sLog.Infof("V (Solution): onQueue failed - 400 instance parameter is not found, traceId: %s", span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State:       v1alpha2.BadRequest,
 				Body:        []byte("{\"result\":\"400 - instance parameter is not found\"}"),
@@ -160,6 +163,7 @@ func (c *SolutionVendor) onQueue(request v1alpha2.COARequest) v1alpha2.COARespon
 			ContentType: "application/json",
 		})
 	}
+	sLog.Infof("V (Solution): onQueue failed - 405 method not allowed, traceId: %s", span.SpanContext().TraceID().String())
 	return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 		State:       v1alpha2.MethodNotAllowed,
 		Body:        []byte("{\"result\":\"405 - method not allowed\"}"),
@@ -172,7 +176,7 @@ func (c *SolutionVendor) onReconcile(request v1alpha2.COARequest) v1alpha2.COARe
 	})
 	defer span.End()
 
-	log.Info("V (Solution): onReconcile")
+	sLog.Infof("V (Solution): onReconcile, method: %s, traceId: %s", request.Method, span.SpanContext().TraceID().String())
 	scope, exist := request.Parameters["scope"]
 	if !exist {
 		scope = "default"
@@ -184,6 +188,7 @@ func (c *SolutionVendor) onReconcile(request v1alpha2.COARequest) v1alpha2.COARe
 		var deployment model.DeploymentSpec
 		err := json.Unmarshal(request.Body, &deployment)
 		if err != nil {
+			sLog.Infof("V (Solution): onReconcile failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -193,6 +198,7 @@ func (c *SolutionVendor) onReconcile(request v1alpha2.COARequest) v1alpha2.COARe
 		summary, err := c.SolutionManager.Reconcile(ctx, deployment, delete == "true", scope)
 		data, _ := json.Marshal(summary)
 		if err != nil {
+			sLog.Infof("V (Solution): onReconcile failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  data,
@@ -204,6 +210,7 @@ func (c *SolutionVendor) onReconcile(request v1alpha2.COARequest) v1alpha2.COARe
 			ContentType: "application/json",
 		})
 	}
+	sLog.Infof("V (Solution): onReconcile failed - 405 method not allowed, traceId: %s", span.SpanContext().TraceID().String())
 	return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 		State:       v1alpha2.MethodNotAllowed,
 		Body:        []byte("{\"result\":\"405 - method not allowed\"}"),
@@ -217,7 +224,7 @@ func (c *SolutionVendor) onApplyDeployment(request v1alpha2.COARequest) v1alpha2
 	})
 	defer span.End()
 
-	log.Infof("V (Solution): received request %s", request.Method)
+	sLog.Infof("V (Solution): onApplyDeployment %s, traceId: %s", request.Method, span.SpanContext().TraceID().String())
 	scope, exist := request.Parameters["scope"]
 	if !exist {
 		scope = "default"
@@ -229,6 +236,7 @@ func (c *SolutionVendor) onApplyDeployment(request v1alpha2.COARequest) v1alpha2
 		deployment := new(model.DeploymentSpec)
 		err := json.Unmarshal(request.Body, &deployment)
 		if err != nil {
+			sLog.Infof("V (Solution): onApplyDeployment failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 			return v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -242,6 +250,7 @@ func (c *SolutionVendor) onApplyDeployment(request v1alpha2.COARequest) v1alpha2
 		deployment := new(model.DeploymentSpec)
 		err := json.Unmarshal(request.Body, &deployment)
 		if err != nil {
+			sLog.Infof("V (Solution): onApplyDeployment failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 			return v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -263,7 +272,7 @@ func (c *SolutionVendor) onApplyDeployment(request v1alpha2.COARequest) v1alpha2
 		response := c.doRemove(ctx, deployment, scope)
 		return observ_utils.CloseSpanWithCOAResponse(span, response)
 	}
-
+	sLog.Infof("V (Solution): onApplyDeployment failed - 405 method not allowed, traceId: %s", span.SpanContext().TraceID().String())
 	resp := v1alpha2.COAResponse{
 		State:       v1alpha2.MethodNotAllowed,
 		Body:        []byte("{\"result\":\"405 - method not allowed\"}"),
@@ -278,8 +287,11 @@ func (c *SolutionVendor) doGet(ctx context.Context, deployment model.DeploymentS
 		"method": "doGet",
 	})
 	defer span.End()
+	sLog.Infof("V (Solution): doGet, traceId: %s", span.SpanContext().TraceID().String())
+
 	_, components, err := c.SolutionManager.Get(ctx, deployment)
 	if err != nil {
+		sLog.Infof("V (Solution): doGet failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 		response := v1alpha2.COAResponse{
 			State: v1alpha2.InternalError,
 			Body:  []byte(err.Error()),
@@ -301,9 +313,11 @@ func (c *SolutionVendor) doDeploy(ctx context.Context, deployment model.Deployme
 		"method": "doDeploy",
 	})
 	defer span.End()
+	sLog.Infof("V (Solution): doDeploy, traceId: %s", span.SpanContext().TraceID().String())
 	summary, err := c.SolutionManager.Reconcile(ctx, deployment, false, scope)
 	data, _ := json.Marshal(summary)
 	if err != nil {
+		sLog.Infof("V (Solution): doDeploy failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 		response := v1alpha2.COAResponse{
 			State: v1alpha2.InternalError,
 			Body:  data,
@@ -325,9 +339,11 @@ func (c *SolutionVendor) doRemove(ctx context.Context, deployment model.Deployme
 	})
 	defer span.End()
 
+	sLog.Infof("V (Solution): doRemove, traceId: %s", span.SpanContext().TraceID().String())
 	summary, err := c.SolutionManager.Reconcile(ctx, deployment, true, scope)
 	data, _ := json.Marshal(summary)
 	if err != nil {
+		sLog.Infof("V (Solution): doRemove failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 		response := v1alpha2.COAResponse{
 			State: v1alpha2.InternalError,
 			Body:  data,

--- a/api/pkg/apis/v1alpha1/vendors/solutions-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/solutions-vendor.go
@@ -75,7 +75,7 @@ func (c *SolutionsVendor) onSolutions(request v1alpha2.COARequest) v1alpha2.COAR
 		"method": "onSolutions",
 	})
 	defer span.End()
-	tLog.Info("V (Solutions): onSolutions")
+	uLog.Infof("V (Solutions): onSolutions, method: %s, traceId: %s", request.Method, span.SpanContext().TraceID().String())
 	scope, exist := request.Parameters["scope"]
 	if !exist {
 		scope = "default"
@@ -98,6 +98,7 @@ func (c *SolutionsVendor) onSolutions(request v1alpha2.COARequest) v1alpha2.COAR
 			state, err = c.SolutionsManager.GetSpec(ctx, id, scope)
 		}
 		if err != nil {
+			uLog.Infof("V (Solutions): onSolutions failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -139,6 +140,7 @@ func (c *SolutionsVendor) onSolutions(request v1alpha2.COARequest) v1alpha2.COAR
 		} else {
 			err := json.Unmarshal(request.Body, &solution)
 			if err != nil {
+				uLog.Infof("V (Solutions): onSolutions failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 				return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 					State: v1alpha2.InternalError,
 					Body:  []byte(err.Error()),
@@ -147,6 +149,7 @@ func (c *SolutionsVendor) onSolutions(request v1alpha2.COARequest) v1alpha2.COAR
 		}
 		err := c.SolutionsManager.UpsertSpec(ctx, id, solution, scope)
 		if err != nil {
+			uLog.Infof("V (Solutions): onSolutions failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -176,6 +179,7 @@ func (c *SolutionsVendor) onSolutions(request v1alpha2.COARequest) v1alpha2.COAR
 		id := request.Parameters["__name"]
 		err := c.SolutionsManager.DeleteSpec(ctx, id, scope)
 		if err != nil {
+			uLog.Infof("V (Solutions): onSolutions failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -185,6 +189,7 @@ func (c *SolutionsVendor) onSolutions(request v1alpha2.COARequest) v1alpha2.COAR
 			State: v1alpha2.OK,
 		})
 	}
+	uLog.Infof("V (Solutions): onSolutions failed - 405 method not allowed, traceId: %s", span.SpanContext().TraceID().String())
 	resp := v1alpha2.COAResponse{
 		State:       v1alpha2.MethodNotAllowed,
 		Body:        []byte("{\"result\":\"405 - method not allowed\"}"),

--- a/api/pkg/apis/v1alpha1/vendors/solutions-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/solutions-vendor_test.go
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package vendors
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	sym_mgr "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/pubsub/memory"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/vendors"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+)
+
+func TestSolutionsEndpoints(t *testing.T) {
+	vendor := createSolutionsVendor()
+	vendor.Route = "solutions"
+	endpoints := vendor.GetEndpoints()
+	assert.Equal(t, 1, len(endpoints))
+}
+
+func TestSolutionsInfo(t *testing.T) {
+	vendor := createSolutionsVendor()
+	vendor.Version = "1.0"
+	info := vendor.GetInfo()
+	assert.NotNil(t, info)
+	assert.Equal(t, "1.0", info.Version)
+}
+func createSolutionsVendor() SolutionsVendor {
+	stateProvider := memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	vendor := SolutionsVendor{}
+	vendor.Init(vendors.VendorConfig{
+		Properties: map[string]string{
+			"test": "true",
+		},
+		Managers: []managers.ManagerConfig{
+			{
+				Name: "solutions-manager",
+				Type: "managers.symphony.solutions",
+				Properties: map[string]string{
+					"providers.state": "mem-state",
+				},
+				Providers: map[string]managers.ProviderConfig{
+					"mem-state": {
+						Type:   "providers.state.memory",
+						Config: memorystate.MemoryStateProviderConfig{},
+					},
+				},
+			},
+		},
+	}, []managers.IManagerFactroy{
+		&sym_mgr.SymphonyManagerFactory{},
+	}, map[string]map[string]providers.IProvider{
+		"solutions-manager": {
+			"mem-state": &stateProvider,
+		},
+	}, nil)
+	return vendor
+}
+func TestSolutionsOnSolutions(t *testing.T) {
+	vendor := createSolutionsVendor()
+	vendor.Context = &contexts.VendorContext{}
+	vendor.Context.SiteInfo = v1alpha2.SiteInfo{
+		SiteId: "fake",
+	}
+	pubSubProvider := memory.InMemoryPubSubProvider{}
+	pubSubProvider.Init(memory.InMemoryPubSubConfig{Name: "test"})
+	vendor.Context.Init(&pubSubProvider)
+	solution := model.SolutionSpec{
+		DisplayName: "solution1",
+	}
+	data, _ := json.Marshal(solution)
+	resp := vendor.onSolutions(v1alpha2.COARequest{
+		Method: fasthttp.MethodPost,
+		Body:   data,
+		Parameters: map[string]string{
+			"__name": "solutions1",
+			"scope":  "scope1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+
+	resp = vendor.onSolutions(v1alpha2.COARequest{
+		Method: fasthttp.MethodGet,
+		Parameters: map[string]string{
+			"__name": "solutions1",
+			"scope":  "scope1",
+		},
+		Context: context.Background(),
+	})
+	var solutions model.SolutionState
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	err := json.Unmarshal(resp.Body, &solutions)
+	assert.Nil(t, err)
+	assert.Equal(t, "solutions1", solutions.Id)
+	assert.Equal(t, "default", solutions.Scope)
+
+	resp = vendor.onSolutions(v1alpha2.COARequest{
+		Method: fasthttp.MethodGet,
+		Parameters: map[string]string{
+			"scope": "scope1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	var solutionsList []model.SolutionState
+	err = json.Unmarshal(resp.Body, &solutionsList)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(solutionsList))
+	assert.Equal(t, "solutions1", solutionsList[0].Id)
+	assert.Equal(t, "default", solutionsList[0].Scope)
+
+	resp = vendor.onSolutions(v1alpha2.COARequest{
+		Method: fasthttp.MethodDelete,
+		Parameters: map[string]string{
+			"__name": "solutions1",
+			"scope":  "scope1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+}

--- a/api/pkg/apis/v1alpha1/vendors/stage-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/stage-vendor_test.go
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package vendors
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sym_mgr "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/pubsub/memory"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/utils"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/vendors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStageEndpoints(t *testing.T) {
+	vendor := createStageVendor()
+	vendor.Route = "stage"
+	endpoints := vendor.GetEndpoints()
+	assert.Equal(t, 0, len(endpoints))
+}
+
+func TestStageInfo(t *testing.T) {
+	vendor := createStageVendor()
+	vendor.Version = "1.0"
+	info := vendor.GetInfo()
+	assert.NotNil(t, info)
+	assert.Equal(t, "1.0", info.Version)
+}
+func createStageVendor() StageVendor {
+	stateProvider := memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	pubSubProvider := memory.InMemoryPubSubProvider{}
+	pubSubProvider.Init(memory.InMemoryPubSubConfig{Name: "test"})
+	vendor := StageVendor{}
+	vendor.Init(vendors.VendorConfig{
+		Properties: map[string]string{
+			"test": "true",
+		},
+		Managers: []managers.ManagerConfig{
+			{
+				Name: "stage-manager",
+				Type: "managers.symphony.stage",
+				Properties: map[string]string{
+					"providers.state": "mem-state",
+				},
+				Providers: map[string]managers.ProviderConfig{
+					"mem-state": {
+						Type:   "providers.state.memory",
+						Config: memorystate.MemoryStateProviderConfig{},
+					},
+				},
+			},
+			{
+				Name: "campaigns-manager",
+				Type: "managers.symphony.campaigns",
+				Properties: map[string]string{
+					"providers.state": "mem-state",
+				},
+				Providers: map[string]managers.ProviderConfig{
+					"mem-state": {
+						Type:   "providers.state.memory",
+						Config: memorystate.MemoryStateProviderConfig{},
+					},
+				},
+			},
+			{
+				Name: "activations-manager",
+				Type: "managers.symphony.activations",
+				Properties: map[string]string{
+					"providers.state": "mem-state",
+				},
+				Providers: map[string]managers.ProviderConfig{
+					"mem-state": {
+						Type:   "providers.state.memory",
+						Config: memorystate.MemoryStateProviderConfig{},
+					},
+				},
+			},
+		},
+	}, []managers.IManagerFactroy{
+		&sym_mgr.SymphonyManagerFactory{},
+	}, map[string]map[string]providers.IProvider{
+		"stage-manager": {
+			"mem-state": &stateProvider,
+		},
+		"campaigns-manager": {
+			"mem-state": &stateProvider,
+		},
+		"activations-manager": {
+			"mem-state": &stateProvider,
+		},
+	}, &pubSubProvider)
+	return vendor
+}
+
+func TestStageActivateCampaign(t *testing.T) {
+	vendor := createStageVendor()
+	vendor.Context.EvaluationContext = &utils.EvaluationContext{}
+	err := vendor.CampaignsManager.UpsertSpec(context.Background(), "test-campaign", model.CampaignSpec{
+		Name:        "test-campaign",
+		SelfDriving: true,
+		FirstStage:  "test",
+		Stages: map[string]model.StageSpec{
+			"test": {
+				Provider: "providers.stage.mock",
+				Inputs: map[string]interface{}{
+					"foo": "${{$output(test,foo)}}",
+				},
+				StageSelector: "${{$if($lt($output(test,foo), 5), test, '')}}",
+			},
+		},
+	})
+	assert.Nil(t, err)
+	err = vendor.ActivationsManager.UpsertSpec(context.Background(), "test-activation", model.ActivationSpec{
+		Campaign: "test-campaign",
+		Name:     "test-activation",
+		Stage:    "test",
+		Inputs: map[string]interface{}{
+			"foo": 0,
+		},
+		Generation: "1",
+	})
+	assert.Nil(t, err)
+	vendor.Context.Publish("activation", v1alpha2.Event{
+		Body: v1alpha2.ActivationData{
+			Campaign:   "test-campaign",
+			Activation: "test-activation",
+			Stage:      "test",
+			Inputs: map[string]interface{}{
+				"foo": 0,
+			},
+		},
+	})
+	vendor.Context.Publish("job-report", v1alpha2.Event{
+		Body: model.ActivationStatus{
+			Status: v1alpha2.Done,
+			Outputs: map[string]interface{}{
+				"__campaign":             "test-campaign",
+				"__activation":           "test-activation",
+				"__stage":                "test",
+				"__activationGeneration": "1",
+				"__site":                 "fake",
+			},
+		},
+	})
+	vendor.Context.Publish("remote-job", v1alpha2.Event{
+		Body: v1alpha2.JobData{
+			Body: v1alpha2.InputOutputData{
+				Inputs: map[string]interface{}{
+					"__activation":           "test-activation",
+					"__activationGeneration": "1",
+					"__campaign":             "test-campaign",
+					"__stage":                "test",
+					"operation":              "wait",
+				},
+			},
+		},
+	})
+	vendor.Context.Publish("remote-job", v1alpha2.Event{
+		Body: v1alpha2.JobData{
+			Body: v1alpha2.InputOutputData{
+				Inputs: map[string]interface{}{
+					"__activation":           "test-activation",
+					"__activationGeneration": "1",
+					"__campaign":             "test-campaign",
+					"__stage":                "test",
+					"operation":              "materialize",
+				},
+			},
+		},
+	})
+	vendor.Context.Publish("remote-job", v1alpha2.Event{
+		Body: v1alpha2.JobData{
+			Body: v1alpha2.InputOutputData{
+				Inputs: map[string]interface{}{
+					"__activation":           "test-activation",
+					"__activationGeneration": "1",
+					"__campaign":             "test-campaign",
+					"__stage":                "test",
+					"operation":              "mock",
+				},
+			},
+		},
+	})
+	time.Sleep(2 * time.Second)
+
+	activation, err := vendor.ActivationsManager.GetSpec(context.Background(), "test-activation")
+	assert.Nil(t, err)
+	assert.NotNil(t, activation)
+	assert.Equal(t, "test-activation", activation.Id)
+	assert.NotNil(t, activation.Status.UpdateTime)
+	assert.Equal(t, v1alpha2.Done, activation.Status.Status)
+}

--- a/api/pkg/apis/v1alpha1/vendors/staging-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/staging-vendor_test.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package vendors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func createStagingVendor() StagingVendor {
+	vendor := StagingVendor{}
+	return vendor
+}
+func TestStagingEndpoints(t *testing.T) {
+	vendor := createStagingVendor()
+	vendor.Route = "staging"
+	endpoints := vendor.GetEndpoints()
+	assert.Equal(t, 1, len(endpoints))
+}
+func TestStagingInfo(t *testing.T) {
+	vendor := createStagingVendor()
+	vendor.Version = "1.0"
+	info := vendor.GetInfo()
+	assert.NotNil(t, info)
+	assert.Equal(t, "1.0", info.Version)
+}

--- a/api/pkg/apis/v1alpha1/vendors/targets-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/targets-vendor_test.go
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package vendors
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	sym_mgr "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/pubsub/memory"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/vendors"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+)
+
+func TestTargetsEndpoints(t *testing.T) {
+	vendor := createTargetsVendor()
+	vendor.Route = "targets"
+	endpoints := vendor.GetEndpoints()
+	assert.Equal(t, 5, len(endpoints))
+}
+
+func TestTargetsInfo(t *testing.T) {
+	vendor := createTargetsVendor()
+	vendor.Version = "1.0"
+	info := vendor.GetInfo()
+	assert.NotNil(t, info)
+	assert.Equal(t, "1.0", info.Version)
+}
+func createTargetsVendor() TargetsVendor {
+	stateProvider := memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	pubSubProvider := memory.InMemoryPubSubProvider{}
+	pubSubProvider.Init(memory.InMemoryPubSubConfig{Name: "test"})
+	vendor := TargetsVendor{}
+	vendor.Init(vendors.VendorConfig{
+		Properties: map[string]string{
+			"test": "true",
+		},
+		Managers: []managers.ManagerConfig{
+			{
+				Name: "targets-manager",
+				Type: "managers.symphony.targets",
+				Properties: map[string]string{
+					"providers.state": "mem-state",
+				},
+				Providers: map[string]managers.ProviderConfig{
+					"mem-state": {
+						Type:   "providers.state.memory",
+						Config: memorystate.MemoryStateProviderConfig{},
+					},
+				},
+			},
+		},
+	}, []managers.IManagerFactroy{
+		&sym_mgr.SymphonyManagerFactory{},
+	}, map[string]map[string]providers.IProvider{
+		"targets-manager": {
+			"mem-state": &stateProvider,
+		},
+	}, &pubSubProvider)
+	vendor.Config.Properties["useJobManager"] = "true"
+	return vendor
+}
+func TestTargetsOnRegistry(t *testing.T) {
+	vendor := createTargetsVendor()
+	target := model.TargetSpec{
+		DisplayName: "target1",
+		Topologies: []model.TopologySpec{
+			{
+				Bindings: []model.BindingSpec{
+					{
+						Role:     "mock",
+						Provider: "providers.target.mock",
+						Config: map[string]string{
+							"id": uuid.New().String(),
+						},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.Marshal(target)
+	resp := vendor.onRegistry(v1alpha2.COARequest{
+		Method: fasthttp.MethodPost,
+		Body:   data,
+		Parameters: map[string]string{
+			"__name":       "target1",
+			"with-binding": "staging",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+
+	resp = vendor.onRegistry(v1alpha2.COARequest{
+		Method: fasthttp.MethodGet,
+		Parameters: map[string]string{
+			"__name": "target1",
+		},
+		Context: context.Background(),
+	})
+	var targets model.TargetState
+	json.Unmarshal(resp.Body, &targets)
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	assert.Equal(t, "target1", targets.Id)
+	assert.Equal(t, 1, len(targets.Spec.Topologies))
+
+	resp = vendor.onRegistry(v1alpha2.COARequest{
+		Method:  fasthttp.MethodGet,
+		Context: context.Background(),
+	})
+	var targetsList []model.TargetState
+	json.Unmarshal(resp.Body, &targetsList)
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	assert.Equal(t, 1, len(targetsList))
+
+	resp = vendor.onRegistry(v1alpha2.COARequest{
+		Method: fasthttp.MethodDelete,
+		Parameters: map[string]string{
+			"__name": "target1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+}
+
+type AuthResponse struct {
+	AccessToken string   `json:"accessToken"`
+	TokenType   string   `json:"tokenType"`
+	Username    string   `json:"username"`
+	Roles       []string `json:"roles"`
+}
+
+func TestTargetsOnBootstrap(t *testing.T) {
+	vendor := createTargetsVendor()
+	authRequest := AuthRequest{
+		UserName: "symphony-test",
+		Password: "",
+	}
+	data, _ := json.Marshal(authRequest)
+	resp := vendor.onBootstrap(v1alpha2.COARequest{
+		Method:  fasthttp.MethodPost,
+		Body:    data,
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	var authResponse AuthResponse
+	json.Unmarshal(resp.Body, &authResponse)
+	assert.NotNil(t, authResponse.AccessToken)
+	assert.Equal(t, "Bearer", authResponse.TokenType)
+}
+
+func TestTargetsOnStatus(t *testing.T) {
+	vendor := createTargetsVendor()
+
+	target := model.TargetSpec{
+		DisplayName: "target1",
+		Topologies: []model.TopologySpec{
+			{
+				Bindings: []model.BindingSpec{
+					{
+						Role:     "mock",
+						Provider: "providers.target.mock",
+						Config: map[string]string{
+							"id": uuid.New().String(),
+						},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.Marshal(target)
+	resp := vendor.onRegistry(v1alpha2.COARequest{
+		Method: fasthttp.MethodPost,
+		Body:   data,
+		Parameters: map[string]string{
+			"__name":       "target1",
+			"with-binding": "staging",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+
+	dict := map[string]interface{}{
+		"status": map[string]interface{}{
+			"properties": map[string]string{
+				"testkey": "testvalue",
+			},
+		},
+	}
+	data, _ = json.Marshal(dict)
+	resp = vendor.onStatus(v1alpha2.COARequest{
+		Method: fasthttp.MethodPost,
+		Body:   data,
+		Parameters: map[string]string{
+			"__name": "target1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+
+	resp = vendor.onStatus(v1alpha2.COARequest{
+		Method: fasthttp.MethodGet,
+		Parameters: map[string]string{
+			"__name": "target1",
+		},
+		Context: context.Background(),
+	})
+	var targetState model.TargetState
+	json.Unmarshal(resp.Body, &targetState)
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	assert.Equal(t, "testvalue", targetState.Status["testkey"])
+}
+func TestTargetsOnHeartbeats(t *testing.T) {
+	vendor := createTargetsVendor()
+
+	target := model.TargetSpec{
+		DisplayName: "target1",
+		Topologies: []model.TopologySpec{
+			{
+				Bindings: []model.BindingSpec{
+					{
+						Role:     "mock",
+						Provider: "providers.target.mock",
+						Config: map[string]string{
+							"id": uuid.New().String(),
+						},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.Marshal(target)
+	resp := vendor.onRegistry(v1alpha2.COARequest{
+		Method: fasthttp.MethodPost,
+		Body:   data,
+		Parameters: map[string]string{
+			"__name":       "target1",
+			"with-binding": "staging",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+
+	resp = vendor.onHeartBeat(v1alpha2.COARequest{
+		Method: fasthttp.MethodPost,
+		Parameters: map[string]string{
+			"__name": "target1",
+		},
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.OK, resp.State)
+
+	resp = vendor.onRegistry(v1alpha2.COARequest{
+		Method: fasthttp.MethodGet,
+		Parameters: map[string]string{
+			"__name": "target1",
+		},
+		Context: context.Background(),
+	})
+	var targetState model.TargetState
+	json.Unmarshal(resp.Body, &targetState)
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	assert.NotNil(t, targetState.Status["ping"])
+}

--- a/api/pkg/apis/v1alpha1/vendors/targets-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/targets-vendor_test.go
@@ -200,18 +200,10 @@ func TestTargetsOnStatus(t *testing.T) {
 		},
 	}
 	data, _ = json.Marshal(dict)
-	resp = vendor.onStatus(v1alpha2.COARequest{
-		Method: fasthttp.MethodPost,
-		Body:   data,
-		Parameters: map[string]string{
-			"__name": "target1",
-		},
-		Context: context.Background(),
-	})
-	assert.Equal(t, v1alpha2.OK, resp.State)
 
 	resp = vendor.onStatus(v1alpha2.COARequest{
 		Method: fasthttp.MethodPost,
+		Body:   data,
 		Parameters: map[string]string{
 			"__name": "target1",
 		},

--- a/api/pkg/apis/v1alpha1/vendors/targets-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/targets-vendor_test.go
@@ -211,7 +211,7 @@ func TestTargetsOnStatus(t *testing.T) {
 	assert.Equal(t, v1alpha2.OK, resp.State)
 
 	resp = vendor.onStatus(v1alpha2.COARequest{
-		Method: fasthttp.MethodGet,
+		Method: fasthttp.MethodPost,
 		Parameters: map[string]string{
 			"__name": "target1",
 		},
@@ -273,4 +273,30 @@ func TestTargetsOnHeartbeats(t *testing.T) {
 	json.Unmarshal(resp.Body, &targetState)
 	assert.Equal(t, v1alpha2.OK, resp.State)
 	assert.NotNil(t, targetState.Status["ping"])
+}
+func TestTargetWrongMethod(t *testing.T) {
+	vendor := createTargetsVendor()
+	resp := vendor.onRegistry(v1alpha2.COARequest{
+		Method:  fasthttp.MethodPut,
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.MethodNotAllowed, resp.State)
+
+	resp = vendor.onBootstrap(v1alpha2.COARequest{
+		Method:  fasthttp.MethodPut,
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.MethodNotAllowed, resp.State)
+
+	resp = vendor.onStatus(v1alpha2.COARequest{
+		Method:  fasthttp.MethodPut,
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.MethodNotAllowed, resp.State)
+
+	resp = vendor.onHeartBeat(v1alpha2.COARequest{
+		Method:  fasthttp.MethodPut,
+		Context: context.Background(),
+	})
+	assert.Equal(t, v1alpha2.MethodNotAllowed, resp.State)
 }

--- a/api/pkg/apis/v1alpha1/vendors/vendorfactory_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/vendorfactory_test.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package vendors
+
+import (
+	"testing"
+
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/vendors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateVendor(t *testing.T) {
+	factory := SymphonyVendorFactory{}
+	config := vendors.VendorConfig{}
+	config.Type = "vendors.echo"
+	vendor, err := factory.CreateVendor(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, vendor.(*EchoVendor))
+
+	config.Type = "vendors.solution"
+	vendor, err = factory.CreateVendor(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, vendor.(*SolutionVendor))
+
+	config.Type = "vendors.agent"
+	vendor, err = factory.CreateVendor(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, vendor.(*AgentVendor))
+
+	config.Type = "vendors.targets"
+	vendor, err = factory.CreateVendor(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, vendor.(*TargetsVendor))
+
+	config.Type = "vendors.instances"
+	vendor, err = factory.CreateVendor(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, vendor.(*InstancesVendor))
+
+	config.Type = "vendors.devices"
+	vendor, err = factory.CreateVendor(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, vendor.(*DevicesVendor))
+
+	config.Type = "vendors.solutions"
+	vendor, err = factory.CreateVendor(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, vendor.(*SolutionsVendor))
+
+	config.Type = "vendors.campaigns"
+	vendor, err = factory.CreateVendor(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, vendor.(*CampaignsVendor))
+
+	config.Type = "vendors.catalogs"
+	vendor, err = factory.CreateVendor(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, vendor.(*CatalogsVendor))
+
+	config.Type = "vendors.activations"
+	vendor, err = factory.CreateVendor(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, vendor.(*ActivationsVendor))
+
+	config.Type = "vendors.users"
+	vendor, err = factory.CreateVendor(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, vendor.(*UsersVendor))
+
+	config.Type = "vendors.jobs"
+	vendor, err = factory.CreateVendor(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, vendor.(*JobVendor))
+
+	config.Type = "vendors.stage"
+	vendor, err = factory.CreateVendor(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, vendor.(*StageVendor))
+
+	config.Type = "vendors.federation"
+	vendor, err = factory.CreateVendor(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, vendor.(*FederationVendor))
+
+	config.Type = "vendors.staging"
+	vendor, err = factory.CreateVendor(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, vendor.(*StagingVendor))
+
+	config.Type = "vendors.models"
+	vendor, err = factory.CreateVendor(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, vendor.(*ModelsVendor))
+
+	config.Type = "vendors.skills"
+	vendor, err = factory.CreateVendor(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, vendor.(*SkillsVendor))
+
+	config.Type = "vendors.settings"
+	vendor, err = factory.CreateVendor(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, vendor.(*SettingsVendor))
+
+	config.Type = "vendors.trails"
+	vendor, err = factory.CreateVendor(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, vendor.(*TrailsVendor))
+
+	config.Type = "vendors.backgroundjob"
+	vendor, err = factory.CreateVendor(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, vendor.(*BackgroundJobVendor))
+}


### PR DESCRIPTION
1. Improve vendor logging.
2. Test coverage improvements:

| components | previous(%) | now (%)|
|---------------|------------|-------|
| activations-vendor| / | 70.3|
|instances-vendor|/ | 84.0|
|job-vendor| /|59.1|
|staging-vendor| /|38.5|
|vendorfactory| /|95.5|
|solution-vendor| 50.7|82.4|
|stage-vendor| /| 68.9|
|solutions-vendor|0 | 79.7|
|targets-vendor|/|74.0|
|campaigns-vendor|0 | 81.1|
