### PR TITLE
Enable local MQTT test and log improvement

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,6 +16,7 @@ jobs:
     env:
       TEST_KUBECTL: yes
       TEST_MINIKUBE_ENABLED: yes
+      TEST_MQTT_LOCAL_ENABLED: yes
     steps:
     - uses: actions/checkout@v3
 
@@ -49,6 +50,13 @@ jobs:
         sudo mv minikube /usr/local/bin/
         minikube start
         kubectl config view
+    
+    - name: Install Mqtt
+      run: | 
+        sudo apt-get update
+        sudo apt-get install mosquitto mosquitto-clients
+        sudo service mosquitto start
+        sudo service mosquitto status
 
     - name: COA Test
       run: cd coa && go test -v ./... -run '^[^C]*$|^[^c][^o]*$|^[^c][^o]*o[^n][^f][^o][^r][^m][^a][^n][^c][^e][^C]*$'

--- a/api/pkg/apis/v1alpha1/managers/target/target-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/target/target-manager.go
@@ -51,11 +51,11 @@ type DeviceSpec struct {
 }
 
 func (s *TargetManager) Init(context *contexts.VendorContext, config managers.ManagerConfig, providers map[string]providers.IProvider) error {
-
 	probeProvider, err := managers.GetProbeProvider(config, providers)
 	if err == nil {
 		s.ProbeProvider = probeProvider
 	} else {
+		log.Errorf("M (Target): failed to get probe provider %+v", err)
 		return err
 	}
 
@@ -63,6 +63,7 @@ func (s *TargetManager) Init(context *contexts.VendorContext, config managers.Ma
 	if err == nil {
 		s.ReferenceProvider = referenceProvider
 	} else {
+		log.Errorf("M (Target): failed to get reference provider %+v", err)
 		return err
 	}
 
@@ -70,6 +71,7 @@ func (s *TargetManager) Init(context *contexts.VendorContext, config managers.Ma
 	if err == nil {
 		s.UploaderProvider = uploaderProvider
 	} else {
+		log.Errorf("M (Target): failed to get upload provider %+v", err)
 		return err
 	}
 
@@ -77,6 +79,7 @@ func (s *TargetManager) Init(context *contexts.VendorContext, config managers.Ma
 	if err == nil {
 		s.Reporter = reporterProvider
 	} else {
+		log.Errorf("M (Target): failed to get reporter %+v", err)
 		return err
 	}
 
@@ -97,6 +100,7 @@ func (s *TargetManager) Enabled() bool {
 }
 func (s *TargetManager) Poll() []error {
 	target := s.ReferenceProvider.TargetID()
+	log.Infof("M (Target): Poll target- %s", target)
 
 	ret, err := s.ReferenceProvider.List(target+"=true", "", "default", model.FabricGroup, "devices", "v1", "v1alpha2.ReferenceK8sCRD")
 	if err != nil {
@@ -170,6 +174,8 @@ func (s *TargetManager) Poll() []error {
 	return errors
 }
 func (s *TargetManager) reportStatus(deviceName string, targetName string, snapshot string, targetStatus string, deviceStatus string, overwrite bool, errStr string) []error {
+	log.Infof("M (Target): reportStatus deviceName- %s, targetName - %s, snapshot -%s targetStatus -%s, deviceStatus -%s, overwrite -%s", deviceName, targetName, snapshot, targetStatus, deviceStatus, overwrite)
+
 	ret := make([]error, 0)
 	report := make(map[string]string)
 	report[targetName+".status"] = targetStatus
@@ -194,6 +200,7 @@ func (s *TargetManager) reportStatus(deviceName string, targetName string, snaps
 		log.Debugf("failed to report target status: %s", err.Error())
 		ret = append(ret, err)
 	}
+
 	return ret
 }
 func (s *TargetManager) Reconcil() []error {

--- a/api/pkg/apis/v1alpha1/providers/states/k8s/k8s_test.go
+++ b/api/pkg/apis/v1alpha1/providers/states/k8s/k8s_test.go
@@ -72,7 +72,7 @@ func TestInitWithBadData(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestUpSert(t *testing.T) {
+func TestUpsert(t *testing.T) {
 	testK8s := os.Getenv("TEST_K8S_STATE")
 	if testK8s == "" {
 		t.Skip("Skipping because TEST_K8S_STATE enviornment variable is not set")

--- a/api/pkg/apis/v1alpha1/providers/target/adb/adb.go
+++ b/api/pkg/apis/v1alpha1/providers/target/adb/adb.go
@@ -65,6 +65,7 @@ func (i *AdbProvider) Init(config providers.IProviderConfig) error {
 
 	updateConfig, err := toAdbProviderConfig(config)
 	if err != nil {
+		aLog.Errorf("  P (Android ADB): expected AdbProviderConfig: %+v", err)
 		return errors.New("expected AdbProviderConfig")
 	}
 	i.Config = updateConfig
@@ -88,7 +89,7 @@ func (i *AdbProvider) Get(ctx context.Context, deployment model.DeploymentSpec, 
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 
-	aLog.Infof("  P (Android ADB): getting artifacts: %s - %s", deployment.Instance.Scope, deployment.Instance.Name)
+	aLog.Infof("  P (Android ADB): getting artifacts: %s - %s, traceId: %s", deployment.Instance.Scope, deployment.Instance.Name, span.SpanContext().TraceID().String())
 
 	ret := make([]model.ComponentSpec, 0)
 
@@ -106,6 +107,7 @@ func (i *AdbProvider) Get(ctx context.Context, deployment model.DeploymentSpec, 
 			out, err = exec.Command("adb", params...).Output()
 
 			if err != nil {
+				aLog.Errorf("  P (Android ADB): failed to get application %+v, error: %+v, traceId: %s", p, err, span.SpanContext().TraceID().String())
 				return nil, err
 			}
 			str := string(out)
@@ -130,12 +132,13 @@ func (i *AdbProvider) Apply(ctx context.Context, deployment model.DeploymentSpec
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 
-	aLog.Infof("  P (Android ADB Provider): applying artifacts: %s - %s", deployment.Instance.Scope, deployment.Instance.Name)
+	aLog.Infof("  P (Android ADB Provider): applying artifacts: %s - %s, traceId: %s", deployment.Instance.Scope, deployment.Instance.Name, span.SpanContext().TraceID().String())
 
 	components := step.GetComponents()
 
 	err = i.GetValidationRule(ctx).Validate(components)
 	if err != nil {
+		aLog.Errorf(" P (Android ADB Provider): failed to validate components, error: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 		return nil, err
 	}
 	if isDryRun {
@@ -155,6 +158,7 @@ func (i *AdbProvider) Apply(ctx context.Context, deployment model.DeploymentSpec
 						cmd := exec.Command("adb", params...)
 						err = cmd.Run()
 						if err != nil {
+							aLog.Errorf("  P (Android ADB): failed to install application %+v, error: %+v, traceId: %s", p, err, span.SpanContext().TraceID().String())
 							ret[component.Name] = model.ComponentResultSpec{
 								Status:  v1alpha2.UpdateFailed,
 								Message: err.Error(),
@@ -178,6 +182,7 @@ func (i *AdbProvider) Apply(ctx context.Context, deployment model.DeploymentSpec
 					cmd := exec.Command("adb", params...)
 					err = cmd.Run()
 					if err != nil {
+						aLog.Errorf("  P (Android ADB): failed to uninstall application %+v, error: %+v, traceId: %s", p, err, span.SpanContext().TraceID().String())
 						ret[component.Name] = model.ComponentResultSpec{
 							Status:  v1alpha2.DeleteFailed,
 							Message: err.Error(),

--- a/api/pkg/apis/v1alpha1/providers/target/azure/adu/adu.go
+++ b/api/pkg/apis/v1alpha1/providers/target/azure/adu/adu.go
@@ -81,6 +81,7 @@ func ADUTargetProviderConfigFromMap(properties map[string]string) (ADUTargetProv
 func (i *ADUTargetProvider) InitWithMap(properties map[string]string) error {
 	config, err := ADUTargetProviderConfigFromMap(properties)
 	if err != nil {
+		sLog.Errorf("  P (ADU Target Provider): expected ADUTargetProviderConfig %+v", err)
 		return err
 	}
 	return i.Init(config)
@@ -97,11 +98,11 @@ func (i *ADUTargetProvider) Init(config providers.IProviderConfig) error {
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 
-	sLog.Info("~~~ ADU Target Provider ~~~ : Init()")
+	sLog.Info("  P (ADU Target Provider): Init()")
 
 	updateConfig, err := toADUTargetProviderConfig(config)
 	if err != nil {
-		sLog.Errorf("~~~ ADU Target Provider ~~~ : expected ADUTargetProviderConfig: %+v", err)
+		sLog.Errorf("  P (ADU Target Provider): expected ADUTargetProviderConfig: %+v", err)
 		return err
 	}
 	i.Config = updateConfig
@@ -131,10 +132,10 @@ func (i *ADUTargetProvider) Get(ctx context.Context, dep model.DeploymentSpec, r
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 
-	sLog.Info("~~~ ADU Update Provider ~~~ : getting components")
+	sLog.Info("P (ADU Target Provider): getting components: %s - %s, traceId: %s", dep.Instance.Scope, dep.Instance.Name, span.SpanContext().TraceID().String())
 	deployment, err := i.getDeployment()
 	if err != nil {
-		sLog.Errorf("~~~ ADU Target Provider ~~~ : %+v", err)
+		sLog.Errorf("P (ADU Target Provider): %+v, traceId: %s", err, span.SpanContext().TraceID().String())
 		return nil, err
 	}
 
@@ -186,11 +187,12 @@ func (i *ADUTargetProvider) Apply(ctx context.Context, deployment model.Deployme
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 
-	sLog.Info("  P (ADU Update): applying components")
+	sLog.Info("  P (ADU Update): applying components: %s - %s, traceId: %s", deployment.Instance.Scope, deployment.Instance.Name, span.SpanContext().TraceID().String())
 
 	components := step.GetComponents()
 	err = i.GetValidationRule(ctx).Validate(components)
 	if err != nil {
+		sLog.Errorf(" P (ADU Update): failed to validate components, error: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 		return nil, err
 	}
 	if isDryRun {
@@ -204,6 +206,7 @@ func (i *ADUTargetProvider) Apply(ctx context.Context, deployment model.Deployme
 		var deployment azureutils.ADUDeployment
 		deployment, err = getDeploymentFromComponent(c.Component)
 		if err != nil {
+			sLog.Errorf(" P (ADU Update): failed to get deployment from component: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 			ret[c.Component.Name] = model.ComponentResultSpec{
 				Status:  v1alpha2.ValidateFailed,
 				Message: err.Error(),
@@ -218,12 +221,13 @@ func (i *ADUTargetProvider) Apply(ctx context.Context, deployment model.Deployme
 					Status:  v1alpha2.UpdateFailed,
 					Message: err.Error(),
 				}
-				sLog.Errorf("  P (ADU Update): %+v", err)
+				sLog.Errorf("  P (ADU Update):  failed to apply deployment: %+v, traceId: %s", err, span.SpanContext().TraceID().String())
 				return ret, err
 			}
 		} else {
 			err = i.deleteDeploymeent(deployment)
 			if err != nil {
+				sLog.Debugf("  P (ADU Update):  failed to delete deployment: %+v, traceId: %s", err, span.SpanContext().TraceID().String())
 				ret[c.Component.Name] = model.ComponentResultSpec{
 					Status:  v1alpha2.DeleteFailed,
 					Message: err.Error(),

--- a/api/pkg/apis/v1alpha1/providers/target/azure/iotedge/iotedge.go
+++ b/api/pkg/apis/v1alpha1/providers/target/azure/iotedge/iotedge.go
@@ -185,17 +185,17 @@ func (i *IoTEdgeTargetProvider) Get(ctx context.Context, deployment model.Deploy
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 
-	sLog.Info("  P(IoT Edge Target): getting components")
+	sLog.Info("  P(IoT Edge Target): getting components: %s - %s, traceId: %s", deployment.Instance.Scope, deployment.Instance.Name, span.SpanContext().TraceID().String())
 
 	hubTwin, err := i.getIoTEdgeModuleTwin(ctx, "$edgeHub")
 	if err != nil {
-		sLog.Error("  P(IoT Edge Target): +%v", err)
+		sLog.Error("  P(IoT Edge Target): failed to get edgeHub module twin: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 		return nil, err
 	}
 
 	modules, err := i.getIoTEdgeModules(ctx)
 	if err != nil {
-		sLog.Error("  P(IoT Edge Target): +%v", err)
+		sLog.Error("  P(IoT Edge Target): failed to get modules: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 		return nil, err
 	}
 	components := make([]model.ComponentSpec, 0)
@@ -204,13 +204,13 @@ func (i *IoTEdgeTargetProvider) Get(ctx context.Context, deployment model.Deploy
 			var twin ModuleTwin
 			twin, err = i.getIoTEdgeModuleTwin(ctx, k)
 			if err != nil {
-				sLog.Error("  P(IoT Edge Target): +%v", err)
+				sLog.Error("  P(IoT Edge Target): failed to get %s module: +%v, traceId: %s", k, err, span.SpanContext().TraceID().String())
 				return nil, err
 			}
 			var component model.ComponentSpec
 			component, err = toComponent(hubTwin, twin, deployment.Instance.Name, m)
 			if err != nil {
-				sLog.Error("  P(IoT Edge Target): +%v", err)
+				sLog.Error("  P(IoT Edge Target):failed to parse %s twin to component +%v, traceId: %s", k, err, span.SpanContext().TraceID().String())
 				return nil, err
 			}
 			components = append(components, component)
@@ -227,7 +227,7 @@ func (i *IoTEdgeTargetProvider) Apply(ctx context.Context, deployment model.Depl
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 
-	sLog.Info("  P(IoT Edge Target): applying components")
+	sLog.Infof("  P(IoT Edge Target): applying components, traceId: %s", span.SpanContext().TraceID().String())
 
 	components := step.GetComponents()
 	err = i.GetValidationRule(ctx).Validate(components)
@@ -243,13 +243,13 @@ func (i *IoTEdgeTargetProvider) Apply(ctx context.Context, deployment model.Depl
 
 	edgeAgent, err := i.getIoTEdgeModuleTwin(ctx, "$edgeAgent")
 	if err != nil {
-		sLog.Errorf("  P(IoT Edge Target): +%v", err)
+		sLog.Errorf("  P(IoT Edge Target): failed to get edgeAgent moduel twin: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 		return ret, err
 	}
 
 	edgeHub, err := i.getIoTEdgeModuleTwin(ctx, "$edgeHub")
 	if err != nil {
-		sLog.Errorf("  P(IoT Edge Target): +%v", err)
+		sLog.Errorf("  P(IoT Edge Target): failed to get edgeHub module twin: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 		return ret, err
 	}
 
@@ -263,7 +263,7 @@ func (i *IoTEdgeTargetProvider) Apply(ctx context.Context, deployment model.Depl
 				Message: e.Error(),
 			}
 			err = e
-			sLog.Errorf("  P(IoT Edge Target): +%v", err)
+			sLog.Errorf("  P(IoT Edge Target): failed to parse %s component to module: +%v, traceId: %s", a.Name, err, span.SpanContext().TraceID().String())
 			return ret, err
 		}
 		modules[a.Name] = module
@@ -271,7 +271,7 @@ func (i *IoTEdgeTargetProvider) Apply(ctx context.Context, deployment model.Depl
 	if len(modules) > 0 {
 		err = i.deployToIoTEdge(ctx, deployment.Instance.Name, deployment.Instance.Metadata, modules, edgeAgent, edgeHub)
 		if err != nil {
-			sLog.Errorf("  P(IoT Edge Target): +%v", err)
+			sLog.Errorf("  P(IoT Edge Target): failed to deploy to IoT edge: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 			return ret, err
 		}
 	}
@@ -285,6 +285,7 @@ func (i *IoTEdgeTargetProvider) Apply(ctx context.Context, deployment model.Depl
 				Status:  v1alpha2.DeleteFailed,
 				Message: e.Error(),
 			}
+			sLog.Errorf("  P(IoT Edge Target): failed to parse %s component to module: +%v, traceId: %s", a.Name, err, span.SpanContext().TraceID().String())
 			return ret, err
 		}
 		modules[a.Name] = module
@@ -292,6 +293,7 @@ func (i *IoTEdgeTargetProvider) Apply(ctx context.Context, deployment model.Depl
 	if len(modules) > 0 {
 		err = i.remvoefromIoTEdge(ctx, deployment.Instance.Name, deployment.Instance.Metadata, modules, edgeAgent, edgeHub)
 		if err != nil {
+			sLog.Errorf("  P(IoT Edge Target): failed to remove from IoT edge: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 			return ret, err
 		}
 	}

--- a/api/pkg/apis/v1alpha1/providers/target/http/http.go
+++ b/api/pkg/apis/v1alpha1/providers/target/http/http.go
@@ -88,7 +88,7 @@ func (i *HttpTargetProvider) Get(ctx context.Context, deployment model.Deploymen
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 
-	sLog.Infof("  P(HTTP Target): getting artifacts: %s - %s", deployment.Instance.Scope, deployment.Instance.Name)
+	sLog.Infof("  P(HTTP Target): getting artifacts: %s - %s, traceId: %s", deployment.Instance.Scope, deployment.Instance.Name, span.SpanContext().TraceID().String())
 
 	// This provider doesn't remember what it does, so it always return nil when asked
 	return nil, nil
@@ -101,7 +101,7 @@ func (i *HttpTargetProvider) Apply(ctx context.Context, deployment model.Deploym
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 
-	sLog.Infof("  P(HTTP Target): applying artifacts: %s - %s", deployment.Instance.Scope, deployment.Instance.Name)
+	sLog.Infof("  P(HTTP Target): applying artifacts: %s - %s, traceId: %s", deployment.Instance.Scope, deployment.Instance.Name, span.SpanContext().TraceID().String())
 
 	injections := &model.ValueInjections{
 		InstanceId: deployment.Instance.Name,
@@ -112,6 +112,7 @@ func (i *HttpTargetProvider) Apply(ctx context.Context, deployment model.Deploym
 	components := step.GetComponents()
 	err = i.GetValidationRule(ctx).Validate(components)
 	if err != nil {
+		sLog.Errorf("  P (HTTP Target): failed to validate components: %+v, traceId: %s", err, span.SpanContext().TraceID().String())
 		return nil, err
 	}
 	if isDryRun {
@@ -132,7 +133,7 @@ func (i *HttpTargetProvider) Apply(ctx context.Context, deployment model.Deploym
 					Status:  v1alpha2.UpdateFailed,
 					Message: err.Error(),
 				}
-				sLog.Errorf("  P(HTTP Target): %v", err)
+				sLog.Errorf("  P(HTTP Target): %v, traceId: %s", err, span.SpanContext().TraceID().String())
 				return ret, err
 			}
 			if method == "" {
@@ -146,7 +147,7 @@ func (i *HttpTargetProvider) Apply(ctx context.Context, deployment model.Deploym
 					Status:  v1alpha2.UpdateFailed,
 					Message: err.Error(),
 				}
-				sLog.Errorf("  P(HTTP Target): %v", err)
+				sLog.Errorf("  P(HTTP Target): %v, traceId: %s", err, span.SpanContext().TraceID().String())
 				return ret, err
 			}
 			request.Header.Set("Content-Type", "application/json; charset=UTF-8")
@@ -159,7 +160,7 @@ func (i *HttpTargetProvider) Apply(ctx context.Context, deployment model.Deploym
 					Status:  v1alpha2.UpdateFailed,
 					Message: err.Error(),
 				}
-				sLog.Errorf("  P(HTTP Target): %v", err)
+				sLog.Errorf("  P(HTTP Target): %v, traceId: %s", err, span.SpanContext().TraceID().String())
 				return ret, err
 			}
 			if resp.StatusCode != http.StatusOK {
@@ -175,7 +176,7 @@ func (i *HttpTargetProvider) Apply(ctx context.Context, deployment model.Deploym
 					Message: message,
 				}
 				err = errors.New("HTTP request didn't respond 200 OK")
-				sLog.Errorf("  P(HTTP Target): %v", err)
+				sLog.Errorf("  P(HTTP Target): %v, traceId: %s", err, span.SpanContext().TraceID().String())
 				return ret, err
 			}
 		}

--- a/api/pkg/apis/v1alpha1/providers/target/ingress/ingress.go
+++ b/api/pkg/apis/v1alpha1/providers/target/ingress/ingress.go
@@ -108,7 +108,7 @@ func (i *IngressTargetProvider) InitWithMap(properties map[string]string) error 
 // Init initializes the ingress target provider
 func (i *IngressTargetProvider) Init(config providers.IProviderConfig) error {
 	_, span := observability.StartSpan(
-		"ConfigMap Target Provider",
+		"Ingress Target Provider",
 		context.TODO(),
 		&map[string]string{
 			"method": "Init",
@@ -116,11 +116,11 @@ func (i *IngressTargetProvider) Init(config providers.IProviderConfig) error {
 	)
 	var err error
 	defer utils.CloseSpanWithError(span, &err)
-	sLog.Info("  P (ConfigMap Target): Init()")
+	sLog.Info("  P (Ingress Target): Init()")
 
 	updateConfig, err := toIngressTargetProviderConfig(config)
 	if err != nil {
-		sLog.Errorf("  P (ConfigMap Target): expected IngressTargetProviderConfig - %+v", err)
+		sLog.Errorf("  P (Ingress Target): expected IngressTargetProviderConfig - %+v", err)
 		return err
 	}
 
@@ -160,25 +160,25 @@ func (i *IngressTargetProvider) Init(config providers.IProviderConfig) error {
 		}
 	}
 	if err != nil {
-		sLog.Errorf("  P (Ingress Target): %+v", err)
+		sLog.Errorf("  P (Ingress Target): failed to get the cluster config: %+v", err)
 		return err
 	}
 
 	i.Client, err = kubernetes.NewForConfig(kConfig)
 	if err != nil {
-		sLog.Errorf("  P (Ingress Target): %+v", err)
+		sLog.Errorf("  P (Ingress Target): failed to create a new clientset: %+v", err)
 		return err
 	}
 
 	i.DynamicClient, err = dynamic.NewForConfig(kConfig)
 	if err != nil {
-		sLog.Errorf("  P (Ingress Target): %+v", err)
+		sLog.Errorf("  P (Ingress Target): failed to create a dynamic client: %+v", err)
 		return err
 	}
 
 	i.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(kConfig)
 	if err != nil {
-		sLog.Errorf("  P (Ingress Target): %+v", err)
+		sLog.Errorf("  P (Ingress Target): failed to create a discovery client: %+v", err)
 		return err
 	}
 
@@ -209,7 +209,7 @@ func (i *IngressTargetProvider) Get(ctx context.Context, deployment model.Deploy
 	)
 	var err error
 	defer utils.CloseSpanWithError(span, &err)
-	sLog.Infof("  P (Ingress Target): getting artifacts: %s - %s", deployment.Instance.Scope, deployment.Instance.Name)
+	sLog.Infof("  P (Ingress Target): getting artifacts: %s - %s, traceId: %s", deployment.Instance.Scope, deployment.Instance.Name, span.SpanContext().TraceID().String())
 
 	ret := make([]model.ComponentSpec, 0)
 	for _, component := range references {
@@ -217,10 +217,10 @@ func (i *IngressTargetProvider) Get(ctx context.Context, deployment model.Deploy
 		obj, err = i.Client.NetworkingV1().Ingresses(deployment.Instance.Scope).Get(ctx, component.Component.Name, metav1.GetOptions{})
 		if err != nil {
 			if kerrors.IsNotFound(err) {
-				sLog.Infof("  P (Ingress Target): resource not found: %s", err)
+				sLog.Infof("  P (Ingress Target): resource not found: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 				continue
 			}
-			sLog.Error("  P (Ingress Target): failed to read object: +%v", err)
+			sLog.Error("  P (Ingress Target): failed to read object: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 			return nil, err
 		}
 		component.Component.Properties = make(map[string]interface{})
@@ -243,7 +243,7 @@ func (i *IngressTargetProvider) Apply(ctx context.Context, deployment model.Depl
 	)
 	var err error
 	defer utils.CloseSpanWithError(span, &err)
-	sLog.Infof("  P (Ingress Target):  applying artifacts: %s - %s", deployment.Instance.Scope, deployment.Instance.Name)
+	sLog.Infof("  P (Ingress Target):  applying artifacts: %s - %s, traceId: %s", deployment.Instance.Scope, deployment.Instance.Name, span.SpanContext().TraceID().String())
 
 	components := step.GetComponents()
 	err = i.GetValidationRule(ctx).Validate(components)
@@ -273,7 +273,7 @@ func (i *IngressTargetProvider) Apply(ctx context.Context, deployment model.Depl
 					var rules []networkingv1.IngressRule
 					err = json.Unmarshal(jData, &rules)
 					if err != nil {
-						sLog.Error("  P (Ingress Target): failed to unmarshal ingress: +%v", err)
+						sLog.Error("  P (Ingress Target): failed to unmarshal ingress: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 						return ret, err
 					}
 					newIngress.Spec.Rules = rules
@@ -284,7 +284,7 @@ func (i *IngressTargetProvider) Apply(ctx context.Context, deployment model.Depl
 					if ok {
 						newIngress.Spec.IngressClassName = &s
 					} else {
-						sLog.Error("  P (Ingress Target): failed to convert ingress class name: +%v", v)
+						sLog.Error("  P (Ingress Target): failed to convert ingress class name: +%v, traceId: %s", v, span.SpanContext().TraceID().String())
 						return ret, err
 					}
 				}
@@ -301,7 +301,7 @@ func (i *IngressTargetProvider) Apply(ctx context.Context, deployment model.Depl
 				i.ensureNamespace(ctx, deployment.Instance.Scope)
 				err = i.applyIngress(ctx, newIngress, deployment.Instance.Scope)
 				if err != nil {
-					sLog.Error("  P (Ingress Target): failed to apply ingress: +%v", err)
+					sLog.Error("  P (Ingress Target): failed to apply ingress: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 					return ret, err
 				}
 			}
@@ -313,7 +313,7 @@ func (i *IngressTargetProvider) Apply(ctx context.Context, deployment model.Depl
 			if component.Type == "ingress" {
 				err = i.deleteIngress(ctx, component.Name, deployment.Instance.Scope)
 				if err != nil {
-					sLog.Error("  P (Ingress Target): failed to delete ingress: +%v", err)
+					sLog.Error("  P (Ingress Target): failed to delete ingress: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 					return ret, err
 				}
 			}
@@ -325,7 +325,7 @@ func (i *IngressTargetProvider) Apply(ctx context.Context, deployment model.Depl
 // ensureNamespace ensures that the namespace exists
 func (k *IngressTargetProvider) ensureNamespace(ctx context.Context, namespace string) error {
 	_, span := observability.StartSpan(
-		"ConfigMap Target Provider",
+		"Ingress Target Provider",
 		ctx,
 		&map[string]string{
 			"method": "ensureNamespace",
@@ -333,6 +333,7 @@ func (k *IngressTargetProvider) ensureNamespace(ctx context.Context, namespace s
 	)
 	var err error
 	defer utils.CloseSpanWithError(span, &err)
+	sLog.Infof("  P (Ingress Target): ensureNamespace %s, traceId: %s", namespace, span.SpanContext().TraceID().String())
 
 	_, err = k.Client.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 	if err == nil {
@@ -346,12 +347,11 @@ func (k *IngressTargetProvider) ensureNamespace(ctx context.Context, namespace s
 			},
 		}, metav1.CreateOptions{})
 		if err != nil {
-			sLog.Error("  P (ConfigMap Target): failed to create namespace: +%v", err)
+			sLog.Error("  P (Ingress Target): failed to create namespace: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 			return err
 		}
-
 	} else {
-		sLog.Error("  P (ConfigMap Target): failed to get namespace: +%v", err)
+		sLog.Error("  P (Ingress Target): failed to get namespace: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 		return err
 	}
 
@@ -381,10 +381,21 @@ func (*IngressTargetProvider) GetValidationRule(ctx context.Context) model.Valid
 
 // deleteConfigMap deletes a configmap
 func (i *IngressTargetProvider) deleteIngress(ctx context.Context, name string, scope string) error {
-	err := i.Client.NetworkingV1().Ingresses(scope).Delete(ctx, name, metav1.DeleteOptions{})
+	_, span := observability.StartSpan(
+		"Ingress Target Provider",
+		ctx,
+		&map[string]string{
+			"method": "deleteIngress",
+		},
+	)
+	var err error
+	defer utils.CloseSpanWithError(span, &err)
+	sLog.Infof("  P (Ingress Target): deleteIngress name %s, scope %s, traceId: %s", name, scope, span.SpanContext().TraceID().String())
+
+	err = i.Client.NetworkingV1().Ingresses(scope).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
 		if !kerrors.IsNotFound(err) {
-			sLog.Error("  P (Ingress Target): failed to delete ingress: +%v", err)
+			sLog.Error("  P (Ingress Target): failed to delete ingress: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 			return err
 		}
 	}
@@ -393,18 +404,29 @@ func (i *IngressTargetProvider) deleteIngress(ctx context.Context, name string, 
 
 // applyCustomResource applies a custom resource from a byte array
 func (i *IngressTargetProvider) applyIngress(ctx context.Context, ingress *networkingv1.Ingress, scope string) error {
+	_, span := observability.StartSpan(
+		"Ingress Target Provider",
+		ctx,
+		&map[string]string{
+			"method": "applyIngress",
+		},
+	)
+	var err error
+	defer utils.CloseSpanWithError(span, &err)
+	sLog.Infof("  P (Ingress Target): applyIngress scope %s, name %s, traceId: %s", scope, ingress.Name, span.SpanContext().TraceID().String())
+
 	existingIngress, err := i.Client.NetworkingV1().Ingresses(scope).Get(ctx, ingress.Name, metav1.GetOptions{})
 	if err != nil {
 		if kerrors.IsNotFound(err) {
-			sLog.Infof("  P (Ingress Target): resource not found: %s", err)
+			sLog.Infof("  P (Ingress Target): resource not found: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 			_, err = i.Client.NetworkingV1().Ingresses(scope).Create(ctx, ingress, metav1.CreateOptions{})
 			if err != nil {
-				sLog.Error("  P (Ingress Target): failed to create ingress: +%v", err)
+				sLog.Error("  P (Ingress Target): failed to create ingress: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 				return err
 			}
 			return nil
 		}
-		sLog.Error("  P (Ingress Target): failed to read object: +%v", err)
+		sLog.Error("  P (Ingress Target): failed to read object: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 		return err
 	}
 
@@ -414,7 +436,7 @@ func (i *IngressTargetProvider) applyIngress(ctx context.Context, ingress *netwo
 	}
 	_, err = i.Client.NetworkingV1().Ingresses(scope).Update(ctx, existingIngress, metav1.UpdateOptions{})
 	if err != nil {
-		sLog.Error("  P (Ingress Target): failed to update ingress: +%v", err)
+		sLog.Error("  P (Ingress Target): failed to update ingress: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 		return err
 	}
 	return nil

--- a/api/pkg/apis/v1alpha1/providers/target/kubectl/kubectl.go
+++ b/api/pkg/apis/v1alpha1/providers/target/kubectl/kubectl.go
@@ -125,7 +125,7 @@ func (i *KubectlTargetProvider) Init(config providers.IProviderConfig) error {
 
 	updateConfig, err := toKubectlTargetProviderConfig(config)
 	if err != nil {
-		sLog.Errorf("  P (Kubectl Target): expected KubectlTargetProviderConfig - %+v", err)
+		sLog.Errorf("  P (Kubectl Target): expected KubectlTargetProviderConfig - %+v")
 		return err
 	}
 
@@ -150,7 +150,7 @@ func (i *KubectlTargetProvider) Init(config providers.IProviderConfig) error {
 			if i.Config.ConfigData != "" {
 				kConfig, err = clientcmd.RESTConfigFromKubeConfig([]byte(i.Config.ConfigData))
 				if err != nil {
-					sLog.Errorf("  P (Kubectl Target):  %+v", err)
+					sLog.Errorf("  P (Kubectl Target): failed to get RESTconfg: %+v", err)
 					return err
 				}
 			} else {
@@ -165,25 +165,25 @@ func (i *KubectlTargetProvider) Init(config providers.IProviderConfig) error {
 		}
 	}
 	if err != nil {
-		sLog.Errorf("  P (Kubectl Target): %+v", err)
+		sLog.Errorf("  P (Kubectl Target): failed to get the cluster config: %+v", err)
 		return err
 	}
 
 	i.Client, err = kubernetes.NewForConfig(kConfig)
 	if err != nil {
-		sLog.Errorf("  P (Kubectl Target): %+v", err)
+		sLog.Errorf("  P (Kubectl Target): failed to create a new clientset: %+v", err)
 		return err
 	}
 
 	i.DynamicClient, err = dynamic.NewForConfig(kConfig)
 	if err != nil {
-		sLog.Errorf("  P (Kubectl Target): %+v", err)
+		sLog.Errorf("  P (Kubectl Target): failed to create a dynamic client: %+v", err)
 		return err
 	}
 
 	i.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(kConfig)
 	if err != nil {
-		sLog.Errorf("  P (Kubectl Target): %+v", err)
+		sLog.Errorf("  P (Kubectl Target): failed to create a discovery client: %+v", err)
 		return err
 	}
 
@@ -214,7 +214,7 @@ func (i *KubectlTargetProvider) Get(ctx context.Context, deployment model.Deploy
 	)
 	var err error
 	defer utils.CloseSpanWithError(span, &err)
-	sLog.Infof("  P (Kubectl Target): getting artifacts: %s - %s", deployment.Instance.Scope, deployment.Instance.Name)
+	sLog.Infof("  P (Kubectl Target): getting artifacts: %s - %s, traceId: %s", deployment.Instance.Scope, deployment.Instance.Name, span.SpanContext().TraceID().String())
 
 	ret := make([]model.ComponentSpec, 0)
 	for _, component := range references {
@@ -226,17 +226,17 @@ func (i *KubectlTargetProvider) Get(ctx context.Context, deployment model.Deploy
 				case dataBytes, ok := <-chanMes:
 					if !ok {
 						err = errors.New("failed to receive from data channel")
-						sLog.Error("  P (Kubectl Target): +%v", err)
+						sLog.Error("  P (Kubectl Target): +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 						return nil, err
 					}
 
 					_, err = i.getCustomResource(ctx, dataBytes, deployment.Instance.Scope)
 					if err != nil {
 						if kerrors.IsNotFound(err) {
-							sLog.Infof("  P (Kubectl Target): resource not found: %s", err)
+							sLog.Infof("  P (Kubectl Target): resource not found: %s, traceId: %s", err, span.SpanContext().TraceID().String())
 							continue
 						}
-						sLog.Error("  P (Kubectl Target): failed to read object: +%v", err)
+						sLog.Error("  P (Kubectl Target): failed to read object: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 						return nil, err
 					}
 
@@ -246,14 +246,14 @@ func (i *KubectlTargetProvider) Get(ctx context.Context, deployment model.Deploy
 				case err, ok := <-chanErr:
 					if !ok {
 						err = errors.New("failed to receive from error channel")
-						sLog.Error("  P (Kubectl Target): +%v", err)
+						sLog.Error("  P (Kubectl Target): +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 						return nil, err
 					}
 
 					if err == io.EOF {
 						stop = true
 					} else {
-						sLog.Error("  P (Kubectl Target): failed to apply Yaml: +%v", err)
+						sLog.Error("  P (Kubectl Target): failed to apply Yaml: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 						return nil, err
 					}
 				}
@@ -262,17 +262,17 @@ func (i *KubectlTargetProvider) Get(ctx context.Context, deployment model.Deploy
 			var dataBytes []byte
 			dataBytes, err = json.Marshal(component.Component.Properties["resource"])
 			if err != nil {
-				sLog.Error("  P (Kubectl Target): failed to get deployment bytes from component: +%v", err)
+				sLog.Errorf("  P (Kubectl Target): failed to get deployment bytes from component: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 				return nil, err
 			}
 
 			_, err = i.getCustomResource(ctx, dataBytes, deployment.Instance.Scope)
 			if err != nil {
 				if kerrors.IsNotFound(err) {
-					sLog.Infof("  P (Kubectl Target): resource not found: %s", err)
+					sLog.Infof("  P (Kubectl Target): resource not found: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 					continue
 				}
-				sLog.Error("  P (Kubectl Target): failed to read object: +%v", err)
+				sLog.Errorf("  P (Kubectl Target): failed to read object: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 				return nil, err
 			}
 
@@ -280,7 +280,7 @@ func (i *KubectlTargetProvider) Get(ctx context.Context, deployment model.Deploy
 
 		} else {
 			err = errors.New("component doesn't have yaml or resource property")
-			sLog.Error("  P (Kubectl Target): component doesn't have yaml or resource property")
+			sLog.Errorf("  P (Kubectl Target): component doesn't have yaml or resource property, traceId: %s", span.SpanContext().TraceID().String())
 			return nil, err
 		}
 	}
@@ -299,11 +299,12 @@ func (i *KubectlTargetProvider) Apply(ctx context.Context, deployment model.Depl
 	)
 	var err error
 	defer utils.CloseSpanWithError(span, &err)
-	sLog.Infof("  P (Kubectl Target):  applying artifacts: %s - %s", deployment.Instance.Scope, deployment.Instance.Name)
+	sLog.Infof("  P (Kubectl Target):  applying artifacts: %s - %s, traceId: %s", deployment.Instance.Scope, deployment.Instance.Name, span.SpanContext().TraceID().String())
 
 	components := step.GetComponents()
 	err = i.GetValidationRule(ctx).Validate(components)
 	if err != nil {
+		sLog.Errorf(" P (Kubectl Target): failed to validate components, error: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 		return nil, err
 	}
 	if isDryRun {
@@ -323,28 +324,28 @@ func (i *KubectlTargetProvider) Apply(ctx context.Context, deployment model.Depl
 						case dataBytes, ok := <-chanMes:
 							if !ok {
 								err = errors.New("failed to receive from data channel")
-								sLog.Error("  P (Kubectl Target):  +%v", err)
+								sLog.Error("  P (Kubectl Target):  +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 								return ret, err
 							}
 
 							i.ensureNamespace(ctx, deployment.Instance.Scope)
 							err = i.applyCustomResource(ctx, dataBytes, deployment.Instance.Scope)
 							if err != nil {
-								sLog.Error("  P (Kubectl Target):  failed to apply Yaml: +%v", err)
+								sLog.Error("  P (Kubectl Target):  failed to apply Yaml: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 								return ret, err
 							}
 
 						case err, ok := <-chanErr:
 							if !ok {
 								err = errors.New("failed to receive from error channel")
-								sLog.Error("  P (Kubectl Target):  +%v", err)
+								sLog.Error("  P (Kubectl Target):  +%v, traceId: %s, traceId: %s", err, span.SpanContext().TraceID().String())
 								return ret, err
 							}
 
 							if err == io.EOF {
 								stop = true
 							} else {
-								sLog.Error("  P (Kubectl Target):  failed to apply Yaml: +%v", err)
+								sLog.Error("  P (Kubectl Target):  failed to apply Yaml: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 								return ret, err
 							}
 						}
@@ -353,20 +354,20 @@ func (i *KubectlTargetProvider) Apply(ctx context.Context, deployment model.Depl
 					var dataBytes []byte
 					dataBytes, err = json.Marshal(component.Properties["resource"])
 					if err != nil {
-						sLog.Error("  P (Kubectl Target): failed to convert resource data to bytes: +%v", err)
+						sLog.Error("  P (Kubectl Target): failed to convert resource data to bytes: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 						return ret, err
 					}
 
 					i.ensureNamespace(ctx, deployment.Instance.Scope)
 					err = i.applyCustomResource(ctx, dataBytes, deployment.Instance.Scope)
 					if err != nil {
-						sLog.Error("  P (Kubectl Target):  failed to apply custom resource: +%v", err)
+						sLog.Error("  P (Kubectl Target):  failed to apply custom resource: +%v, traceId: %s", err, err, span.SpanContext().TraceID().String())
 						return ret, err
 					}
 
 				} else {
 					err = errors.New("component doesn't have yaml property or resource property")
-					sLog.Error("  P (Kubectl Target):  component doesn't have yaml property or resource property")
+					sLog.Errorf("  P (Kubectl Target):  component doesn't have yaml property or resource property, traceId: %s", err, span.SpanContext().TraceID().String())
 					return ret, err
 				}
 			}
@@ -384,27 +385,27 @@ func (i *KubectlTargetProvider) Apply(ctx context.Context, deployment model.Depl
 						case dataBytes, ok := <-chanMes:
 							if !ok {
 								err = errors.New("failed to receive from data channel")
-								sLog.Error("  P (Kubectl Target):  +%v", err)
+								sLog.Errorf("  P (Kubectl Target):  +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 								return ret, err
 							}
 
 							err = i.deleteCustomResource(ctx, dataBytes, deployment.Instance.Scope)
 							if err != nil {
-								sLog.Error("  P (Kubectl Target): failed to read object: +%v", err)
+								sLog.Errorf("  P (Kubectl Target): failed to read object: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 								return ret, err
 							}
 
 						case err, ok := <-chanErr:
 							if !ok {
 								err = errors.New("failed to receive from error channel")
-								sLog.Error("  P (Kubectl Target): +%v", err)
+								sLog.Errorf("  P (Kubectl Target): +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 								return ret, err
 							}
 
 							if err == io.EOF {
 								stop = true
 							} else {
-								sLog.Error("  P (Kubectl Target): failed to remove resource: +%v", err)
+								sLog.Errorf("  P (Kubectl Target): failed to remove resource: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 								return ret, err
 							}
 						}
@@ -413,19 +414,19 @@ func (i *KubectlTargetProvider) Apply(ctx context.Context, deployment model.Depl
 					var dataBytes []byte
 					dataBytes, err = json.Marshal(component.Properties["resource"])
 					if err != nil {
-						sLog.Error("  P (Kubectl Target): failed to convert resource data to bytes: +%v", err)
+						sLog.Errorf("  P (Kubectl Target): failed to convert resource data to bytes: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 						return ret, err
 					}
 
 					err = i.deleteCustomResource(ctx, dataBytes, deployment.Instance.Scope)
 					if err != nil {
-						sLog.Error("  P (Kubectl Target): failed to delete custom resource: +%v", err)
+						sLog.Errorf("  P (Kubectl Target): failed to delete custom resource: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 						return ret, err
 					}
 
 				} else {
 					err = errors.New("component doesn't have yaml property or resource property")
-					sLog.Error("  P (Kubectl Target): component doesn't have yaml property or resource property")
+					sLog.Errorf("  P (Kubectl Target): component doesn't have yaml property or resource property, traceId: %s", span.SpanContext().TraceID().String())
 					return ret, err
 				}
 			}
@@ -445,6 +446,7 @@ func (k *KubectlTargetProvider) ensureNamespace(ctx context.Context, namespace s
 	)
 	var err error
 	defer utils.CloseSpanWithError(span, &err)
+	sLog.Infof("  P (Kubectl Target): ensureNamespace %s, traceId: %s", namespace, span.SpanContext().TraceID().String())
 
 	_, err = k.Client.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 	if err == nil {
@@ -458,12 +460,12 @@ func (k *KubectlTargetProvider) ensureNamespace(ctx context.Context, namespace s
 			},
 		}, metav1.CreateOptions{})
 		if err != nil {
-			sLog.Error("~~~ Kubectl Target Provider ~~~ : failed to create namespace: +%v", err)
+			sLog.Errorf("  P (Kubectl Target): failed to create namespace: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 			return err
 		}
 
 	} else {
-		sLog.Error("~~~ Kubectl Target Provider ~~~ : failed to get namespace: +%v", err)
+		sLog.Errorf("  P (Kubectl Target): failed to get namespace: +%v, traceId: %s", err, span.SpanContext().TraceID().String())
 		return err
 	}
 

--- a/api/pkg/apis/v1alpha1/providers/target/mqtt/mqtt_test.go
+++ b/api/pkg/apis/v1alpha1/providers/target/mqtt/mqtt_test.go
@@ -21,13 +21,13 @@ import (
 )
 
 func TestDoubleIni(t *testing.T) {
-	testMQTT := os.Getenv("TEST_MQTT")
+	testMQTT := os.Getenv("TEST_MQTT_LOCAL_ENABLED")
 	if testMQTT == "" {
 		t.Skip("Skipping because TES_MQTT enviornment variable is not set")
 	}
 	config := MQTTTargetProviderConfig{
 		Name:          "me",
-		BrokerAddress: "tcp://20.118.146.198:1883",
+		BrokerAddress: "tcp://127.0.0.1:1883",
 		ClientID:      "coa-test2",
 		RequestTopic:  "coa-request",
 		ResponseTopic: "coa-response",
@@ -40,13 +40,13 @@ func TestDoubleIni(t *testing.T) {
 }
 
 func TestInitWithMap(t *testing.T) {
-	testMQTT := os.Getenv("TEST_MQTT")
+	testMQTT := os.Getenv("TEST_MQTT_LOCAL_ENABLED")
 	if testMQTT == "" {
 		t.Skip("Skipping because TES_MQTT enviornment variable is not set")
 	}
 	configMap := map[string]string{
 		"name":          "me",
-		"brokerAddress": "tcp://20.118.146.198:1883",
+		"brokerAddress": "tcp://127.0.0.1:1883",
 		"clientID":      "coa-test2",
 		"requestTopic":  "coa-request",
 		"responseTopic": "coa-response",
@@ -57,7 +57,7 @@ func TestInitWithMap(t *testing.T) {
 }
 
 func TestInitWithMapInvalidConfig(t *testing.T) {
-	testMQTT := os.Getenv("TEST_MQTT")
+	testMQTT := os.Getenv("TEST_MQTT_LOCAL_ENABLED")
 	if testMQTT == "" {
 		t.Skip("Skipping because TES_MQTT enviornment variable is not set")
 	}
@@ -70,14 +70,14 @@ func TestInitWithMapInvalidConfig(t *testing.T) {
 
 	configMap = map[string]string{
 		"name":          "me",
-		"brokerAddress": "tcp://20.118.146.198:1883",
+		"brokerAddress": "tcp://127.0.0.1:1883",
 	}
 	err = provider.InitWithMap(configMap)
 	assert.NotNil(t, err)
 
 	configMap = map[string]string{
 		"name":          "me",
-		"brokerAddress": "tcp://20.118.146.198:1883",
+		"brokerAddress": "tcp://127.0.0.1:1883",
 		"clientID":      "coa-test2",
 	}
 	err = provider.InitWithMap(configMap)
@@ -85,7 +85,7 @@ func TestInitWithMapInvalidConfig(t *testing.T) {
 
 	configMap = map[string]string{
 		"name":          "me",
-		"brokerAddress": "tcp://20.118.146.198:1883",
+		"brokerAddress": "tcp://127.0.0.1:1883",
 		"clientID":      "coa-test2",
 		"requestTopic":  "coa-request",
 	}
@@ -94,7 +94,7 @@ func TestInitWithMapInvalidConfig(t *testing.T) {
 
 	configMap = map[string]string{
 		"name":           "me",
-		"brokerAddress":  "tcp://20.118.146.198:1883",
+		"brokerAddress":  "tcp://127.0.0.1:1883",
 		"clientID":       "coa-test2",
 		"requestTopic":   "coa-request",
 		"responseTopic":  "coa-response",
@@ -105,7 +105,7 @@ func TestInitWithMapInvalidConfig(t *testing.T) {
 
 	configMap = map[string]string{
 		"name":             "me",
-		"brokerAddress":    "tcp://20.118.146.198:1883",
+		"brokerAddress":    "tcp://127.0.0.1:1883",
 		"clientID":         "coa-test2",
 		"requestTopic":     "coa-request",
 		"responseTopic":    "coa-response",
@@ -117,7 +117,7 @@ func TestInitWithMapInvalidConfig(t *testing.T) {
 
 	configMap = map[string]string{
 		"name":               "me",
-		"brokerAddress":      "tcp://20.118.146.198:1883",
+		"brokerAddress":      "tcp://127.0.0.1:1883",
 		"clientID":           "coa-test2",
 		"requestTopic":       "coa-request",
 		"responseTopic":      "coa-response",
@@ -129,7 +129,7 @@ func TestInitWithMapInvalidConfig(t *testing.T) {
 
 	configMap = map[string]string{
 		"name":               "me",
-		"brokerAddress":      "tcp://20.118.146.198:1883",
+		"brokerAddress":      "tcp://127.0.0.1:1883",
 		"clientID":           "coa-test2",
 		"requestTopic":       "coa-request",
 		"responseTopic":      "coa-response",
@@ -148,7 +148,7 @@ func TestGet(t *testing.T) {
 	}
 	config := MQTTTargetProviderConfig{
 		Name:          "me",
-		BrokerAddress: "tcp://20.118.146.198:1883",
+		BrokerAddress: "tcp://127.0.0.1:1883",
 		ClientID:      "coa-test2",
 		RequestTopic:  "coa-request",
 		ResponseTopic: "coa-response",
@@ -240,7 +240,7 @@ func TestApply(t *testing.T) {
 	}
 	config := MQTTTargetProviderConfig{
 		Name:          "me",
-		BrokerAddress: "tcp://20.118.146.198:1883",
+		BrokerAddress: "tcp://127.0.0.1:1883",
 		ClientID:      "coa-test2",
 		RequestTopic:  "coa-request",
 		ResponseTopic: "coa-response",
@@ -467,10 +467,67 @@ func TestGetApply(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestLocalApplyGet(t *testing.T) {
+	testMQTT := os.Getenv("TEST_MQTT_LOCAL_ENABLED")
+	if testMQTT == "" {
+		t.Skip("Skipping because TES_MQTT enviornment variable is not set")
+	}
+	config := MQTTTargetProviderConfig{
+		Name:           "me",
+		BrokerAddress:  "tcp://127.0.0.1:1883",
+		ClientID:       "coa-test2",
+		RequestTopic:   "coa-request",
+		ResponseTopic:  "coa-response",
+		TimeoutSeconds: 8,
+	}
+	provider := MQTTTargetProvider{}
+	err := provider.Init(config)
+	assert.Nil(t, err)
+
+	opts := gmqtt.NewClientOptions().AddBroker(config.BrokerAddress).SetClientID("test-sender")
+	opts.SetKeepAlive(2 * time.Second)
+	opts.SetPingTimeout(1 * time.Second)
+
+	c := gmqtt.NewClient(opts)
+	if token := c.Connect(); token.Wait() && token.Error() != nil {
+		panic(token.Error())
+	}
+	if token := c.Subscribe(config.RequestTopic, 0, func(client gmqtt.Client, msg gmqtt.Message) {
+		var response v1alpha2.COAResponse
+		response.State = v1alpha2.OK
+		response.Metadata = make(map[string]string)
+		var request v1alpha2.COARequest
+		json.Unmarshal(msg.Payload(), &request)
+		if request.Method == "GET" {
+			response.Metadata["call-context"] = "TargetProvider-Get"
+			ret := make([]model.ComponentSpec, 0)
+			data, _ := json.Marshal(ret)
+			response.State = v1alpha2.OK
+			response.Body = data
+		} else {
+			response.Metadata["call-context"] = "TargetProvider-Apply"
+			response.State = v1alpha2.OK
+		}
+		data, _ := json.Marshal(response)
+		token := c.Publish(config.ResponseTopic, 0, false, data)
+		token.Wait()
+	}); token.Wait() && token.Error() != nil {
+		if token.Error().Error() != "subscription exists" {
+			panic(token.Error())
+		}
+	}
+
+	_, err = provider.Apply(context.Background(), model.DeploymentSpec{}, model.DeploymentStep{}, false)
+	assert.Nil(t, err)
+	arr, err := provider.Get(context.Background(), model.DeploymentSpec{}, nil)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(arr))
+}
+
 func TestInitFailed(t *testing.T) {
 	config := MQTTTargetProviderConfig{
 		Name:          "me",
-		BrokerAddress: "tcp://127.0.0.1:1883",
+		BrokerAddress: "tcp://8.8.8.8:1883",
 		ClientID:      "coa-test2",
 		RequestTopic:  "coa-request",
 		ResponseTopic: "coa-response",

--- a/api/pkg/apis/v1alpha1/providers/target/staging/staging.go
+++ b/api/pkg/apis/v1alpha1/providers/target/staging/staging.go
@@ -86,7 +86,7 @@ func (i *StagingTargetProvider) Get(ctx context.Context, deployment model.Deploy
 	ctx, span := observability.StartSpan("Staging Target Provider", ctx, &map[string]string{
 		"method": "Get",
 	})
-	sLog.Infof("  P (Staging Target): getting artifacts: %s - %s", deployment.Instance.Scope, deployment.Instance.Name)
+	sLog.Infof("  P (Staging Target): getting artifacts: %s - %s, traceId: %s", deployment.Instance.Scope, deployment.Instance.Name, span.SpanContext().TraceID().String())
 
 	var err error
 	defer observ_utils.CloseSpanWithError(span, &err)
@@ -104,10 +104,10 @@ func (i *StagingTargetProvider) Get(ctx context.Context, deployment model.Deploy
 
 	if err != nil {
 		if v1alpha2.IsNotFound(err) {
-			sLog.Infof("  P (Staging Target): no staged artifact found")
+			sLog.Infof("  P (Staging Target): no staged artifact found, traceId: %s")
 			return nil, nil
 		}
-		sLog.Errorf("  P (Staging Target): failed to get staged artifact: %v", err)
+		sLog.Errorf("  P (Staging Target): failed to get staged artifact: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 		return nil, err
 	}
 
@@ -116,7 +116,7 @@ func (i *StagingTargetProvider) Get(ctx context.Context, deployment model.Deploy
 		jData, _ := json.Marshal(spec)
 		err = json.Unmarshal(jData, &components)
 		if err != nil {
-			sLog.Errorf("  P (Staging Target): failed to get staged artifact: %v", err)
+			sLog.Errorf("  P (Staging Target): failed to get staged artifact: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 			return nil, err
 		}
 		ret := make([]model.ComponentSpec, len(references))
@@ -131,21 +131,21 @@ func (i *StagingTargetProvider) Get(ctx context.Context, deployment model.Deploy
 		return ret, nil
 	}
 	err = v1alpha2.NewCOAError(nil, "staged artifact is not found as a 'spec' property", v1alpha2.NotFound)
-	sLog.Errorf("  P (Staging Target): failed to get staged artifact: %v", err)
+	sLog.Errorf("  P (Staging Target): failed to get staged artifact: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 	return nil, err
 }
 func (i *StagingTargetProvider) Apply(ctx context.Context, deployment model.DeploymentSpec, step model.DeploymentStep, isDryRun bool) (map[string]model.ComponentResultSpec, error) {
 	ctx, span := observability.StartSpan("Staging Target Provider", ctx, &map[string]string{
 		"method": "Apply",
 	})
-	sLog.Infof("  P (Staging Target): applying artifacts: %s - %s", deployment.Instance.Scope, deployment.Instance.Name)
+	sLog.Infof("  P (Staging Target): applying artifacts: %s - %s, traceId: %s", deployment.Instance.Scope, deployment.Instance.Name, span.SpanContext().TraceID().String())
 
 	var err error
 	defer observ_utils.CloseSpanWithError(span, &err)
 
 	err = i.GetValidationRule(ctx).Validate([]model.ComponentSpec{}) //this provider doesn't handle any components	TODO: is this right?
 	if err != nil {
-		sLog.Errorf("  P (Staging Target): failed to validate components: %v", err)
+		sLog.Errorf("  P (Staging Target): failed to validate components: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 		return nil, err
 	}
 	if isDryRun {
@@ -168,7 +168,7 @@ func (i *StagingTargetProvider) Apply(ctx context.Context, deployment model.Depl
 		i.Context.SiteInfo.CurrentSite.Username,
 		i.Context.SiteInfo.CurrentSite.Password)
 	if err != nil && !v1alpha2.IsNotFound(err) {
-		sLog.Errorf("  P (Staging Target): failed to get staged artifact: %v", err)
+		sLog.Errorf("  P (Staging Target): failed to get staged artifact: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 		return ret, err
 	}
 
@@ -189,7 +189,7 @@ func (i *StagingTargetProvider) Apply(ctx context.Context, deployment model.Depl
 		jData, _ := json.Marshal(v)
 		err = json.Unmarshal(jData, &existing)
 		if err != nil {
-			sLog.Errorf("  P (Staging Target): failed to get staged artifact: %v", err)
+			sLog.Errorf("  P (Staging Target): failed to unmarshall catalog components: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 			return ret, err
 		}
 	}
@@ -220,7 +220,7 @@ func (i *StagingTargetProvider) Apply(ctx context.Context, deployment model.Depl
 		jData, _ := json.Marshal(v)
 		err = json.Unmarshal(jData, &deleted)
 		if err != nil {
-			sLog.Errorf("  P (Staging Target): failed to get staged artifact: %v", err)
+			sLog.Errorf("  P (Staging Target): failed to get staged artifact: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 			return ret, err
 		}
 	}
@@ -256,7 +256,7 @@ func (i *StagingTargetProvider) Apply(ctx context.Context, deployment model.Depl
 		i.Context.SiteInfo.CurrentSite.Username,
 		i.Context.SiteInfo.CurrentSite.Password, jData)
 	if err != nil {
-		sLog.Errorf("  P (Staging Target): failed to upsert staged artifact: %v", err)
+		sLog.Errorf("  P (Staging Target): failed to upsert staged artifact: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 	}
 	return ret, err
 }

--- a/api/pkg/apis/v1alpha1/vendors/agent-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/agent-vendor.go
@@ -81,7 +81,7 @@ func (c *AgentVendor) onConfig(request v1alpha2.COARequest) v1alpha2.COAResponse
 	})
 	defer span.End()
 
-	log.Infof("V (Agent): onConfig %s", request.Method)
+	log.Infof("V (Agent): onConfig %s, traceId: %s", request.Method, span.SpanContext().TraceID().String())
 
 	switch request.Method {
 	case fasthttp.MethodPost:
@@ -104,7 +104,7 @@ func (c *AgentVendor) onReference(request v1alpha2.COARequest) v1alpha2.COARespo
 	})
 	defer span.End()
 
-	log.Infof("V (Agent): onReference %s", request.Method)
+	log.Infof("V (Agent): onReference %s, traceId: %s", request.Method, span.SpanContext().TraceID().String())
 
 	switch request.Method {
 	case fasthttp.MethodGet:
@@ -117,6 +117,7 @@ func (c *AgentVendor) onReference(request v1alpha2.COARequest) v1alpha2.COARespo
 		return observ_utils.CloseSpanWithCOAResponse(span, response)
 	}
 
+	log.Infof("V (Agent): onReference returns MethodNotAllowed, traceId: %s", span.SpanContext().TraceID().String())
 	resp := v1alpha2.COAResponse{
 		State:       v1alpha2.MethodNotAllowed,
 		Body:        []byte("{\"result\":\"405 - method not allowed\"}"),
@@ -127,6 +128,12 @@ func (c *AgentVendor) onReference(request v1alpha2.COARequest) v1alpha2.COARespo
 }
 
 func (c *AgentVendor) doGet(ctx context.Context, parameters map[string]string) v1alpha2.COAResponse {
+	_, span := observability.StartSpan("Agent Vendor", ctx, &map[string]string{
+		"method": "doGet",
+	})
+	defer span.End()
+	log.Infof("V (Agent): doGet with parameters %v, traceId: %s", parameters, span.SpanContext().TraceID().String())
+
 	var scope = "default"
 	var kind = ""
 	var ref = ""
@@ -194,11 +201,14 @@ func (c *AgentVendor) doGet(ctx context.Context, parameters map[string]string) v
 		data, err = c.ReferenceManager.Get(ref, id, scope, group, kind, version, labelSelector, fieldSelector)
 	}
 	if err != nil {
+		log.Errorf("V (Agent): failed to get references, traceId: %s", span.SpanContext().TraceID().String())
 		return v1alpha2.COAResponse{
 			State: v1alpha2.InternalError,
 			Body:  []byte(err.Error()),
 		}
 	}
+
+	log.Info("V (Agent): get references successfully")
 	return v1alpha2.COAResponse{
 		State:       v1alpha2.OK,
 		Body:        data,
@@ -207,6 +217,13 @@ func (c *AgentVendor) doGet(ctx context.Context, parameters map[string]string) v
 }
 
 func (c *AgentVendor) doApplyConfig(ctx context.Context, parameters map[string]string, data []byte) v1alpha2.COAResponse {
+	_, span := observability.StartSpan("Agent Vendor", ctx, &map[string]string{
+		"method": "doApplyConfig",
+	})
+	defer span.End()
+
+	log.Infof("V (Agent): doApplyConfig with parameters %v, traceId: %s", parameters, span.SpanContext().TraceID().String())
+
 	var config managers.ProviderConfig
 	err := json.Unmarshal(data, &config)
 	if err != nil {
@@ -229,6 +246,8 @@ func (c *AgentVendor) doApplyConfig(ctx context.Context, parameters map[string]s
 			}
 		}
 	}
+
+	log.Info("V (Agent): apply configs successfully")
 	return v1alpha2.COAResponse{
 		State:       v1alpha2.OK,
 		Body:        []byte("{}"),
@@ -237,6 +256,13 @@ func (c *AgentVendor) doApplyConfig(ctx context.Context, parameters map[string]s
 }
 
 func (c *AgentVendor) doPost(ctx context.Context, parameters map[string]string, data []byte) v1alpha2.COAResponse {
+	_, span := observability.StartSpan("Agent Vendor", ctx, &map[string]string{
+		"method": "doPost",
+	})
+	defer span.End()
+
+	log.Infof("V (Agent): doPost with parameters %v, traceId: %s", parameters, span.SpanContext().TraceID().String())
+
 	var scope = "default"
 	var kind = ""
 	var group = ""
@@ -264,6 +290,7 @@ func (c *AgentVendor) doPost(ctx context.Context, parameters map[string]string, 
 	properties := make(map[string]string)
 	err := json.Unmarshal(data, &properties)
 	if err != nil {
+		log.Errorf("V (Agent): failed to unmarshall data, traceId: %s", span.SpanContext().TraceID().String())
 		return v1alpha2.COAResponse{
 			State: v1alpha2.InternalError,
 			Body:  []byte(err.Error()),
@@ -271,11 +298,14 @@ func (c *AgentVendor) doPost(ctx context.Context, parameters map[string]string, 
 	}
 	err = c.ReferenceManager.Report(id, scope, group, kind, version, properties, overwrite)
 	if err != nil {
+		log.Errorf("V (Agent): failed to report status, traceId: %s", span.SpanContext().TraceID().String())
 		return v1alpha2.COAResponse{
 			State: v1alpha2.InternalError,
 			Body:  []byte(err.Error()),
 		}
 	}
+
+	log.Info("V (Agent): report status successfully")
 	return v1alpha2.COAResponse{
 		State:       v1alpha2.OK,
 		Body:        data,

--- a/api/pkg/apis/v1alpha1/vendors/devices-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/devices-vendor.go
@@ -75,8 +75,7 @@ func (c *DevicesVendor) onDevices(request v1alpha2.COARequest) v1alpha2.COARespo
 		"method": "onDevices",
 	})
 	defer span.End()
-
-	tLog.Info("~ Devices Manager ~ : onDevices")
+	tLog.Infof("V (Devices): onDevices %s, traceId: %s", request.Method, span.SpanContext().TraceID().String())
 
 	switch request.Method {
 	case fasthttp.MethodGet:
@@ -92,6 +91,7 @@ func (c *DevicesVendor) onDevices(request v1alpha2.COARequest) v1alpha2.COARespo
 			state, err = c.DevicesManager.GetSpec(ctx, id)
 		}
 		if err != nil {
+			log.Errorf("V (Devices): failed to get device spec, error %v, traceId: %s", err, span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -115,6 +115,7 @@ func (c *DevicesVendor) onDevices(request v1alpha2.COARequest) v1alpha2.COARespo
 
 		err := json.Unmarshal(request.Body, &device)
 		if err != nil {
+			log.Errorf("V (Devices): failed to unmarshall request body, error %v, traceId: %s", err, span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -123,6 +124,7 @@ func (c *DevicesVendor) onDevices(request v1alpha2.COARequest) v1alpha2.COARespo
 
 		err = c.DevicesManager.UpsertSpec(ctx, id, device)
 		if err != nil {
+			log.Errorf("V (Devices): failed to upsert device spec, error %v, traceId: %s", err, span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -136,6 +138,7 @@ func (c *DevicesVendor) onDevices(request v1alpha2.COARequest) v1alpha2.COARespo
 		id := request.Parameters["__name"]
 		err := c.DevicesManager.DeleteSpec(ctx, id)
 		if err != nil {
+			log.Errorf("V (Devices): failed to delete device spec, error %v, traceId: %s", err, span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -145,6 +148,8 @@ func (c *DevicesVendor) onDevices(request v1alpha2.COARequest) v1alpha2.COARespo
 			State: v1alpha2.OK,
 		})
 	}
+
+	log.Infof("V (Devices): onDevices returns MethodNotAllowed, traceId: %s", span.SpanContext().TraceID().String())
 	resp := v1alpha2.COAResponse{
 		State:       v1alpha2.MethodNotAllowed,
 		Body:        []byte("{\"result\":\"405 - method not allowed\"}"),

--- a/api/pkg/apis/v1alpha1/vendors/settings-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/settings-vendor.go
@@ -78,7 +78,8 @@ func (c *SettingsVendor) onConfig(request v1alpha2.COARequest) v1alpha2.COARespo
 		"method": "onConfig",
 	})
 	defer span.End()
-	csLog.Info("V (Settings): onConfig")
+	csLog.Infof("V (Settings): onConfig %s, traceId: %s", request.Method, span.SpanContext().TraceID().String())
+
 	switch request.Method {
 	case fasthttp.MethodGet:
 		id := request.Parameters["__name"]
@@ -91,6 +92,7 @@ func (c *SettingsVendor) onConfig(request v1alpha2.COARequest) v1alpha2.COARespo
 		if field != "" {
 			val, err := c.EvaluationContext.ConfigProvider.Get(id, field, parts, nil)
 			if err != nil {
+				log.Errorf("V (Settings): onConfig failed to get config %s, error: %v traceId: %s", id, err, span.SpanContext().TraceID().String())
 				return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 					State: v1alpha2.InternalError,
 					Body:  []byte(err.Error()),
@@ -105,6 +107,7 @@ func (c *SettingsVendor) onConfig(request v1alpha2.COARequest) v1alpha2.COARespo
 		} else {
 			val, err := c.EvaluationContext.ConfigProvider.GetObject(id, parts, nil)
 			if err != nil {
+				log.Errorf("V (Settings): onConfig failed to get object %s, error: %v traceId: %s", id, err, span.SpanContext().TraceID().String())
 				return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 					State: v1alpha2.InternalError,
 					Body:  []byte(err.Error()),
@@ -118,6 +121,8 @@ func (c *SettingsVendor) onConfig(request v1alpha2.COARequest) v1alpha2.COARespo
 			})
 		}
 	}
+
+	log.Infof("V (Settings): onConfig returned MethodNotAllowed, traceId: %s", span.SpanContext().TraceID().String())
 	resp := v1alpha2.COAResponse{
 		State:       v1alpha2.MethodNotAllowed,
 		Body:        []byte("{\"result\":\"405 - method not allowed\"}"),

--- a/api/pkg/apis/v1alpha1/vendors/users-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/users-vendor.go
@@ -84,11 +84,12 @@ func (c *UsersVendor) onAuth(request v1alpha2.COARequest) v1alpha2.COAResponse {
 		"method": "onAuth",
 	})
 	defer span.End()
-	log.Debug("V (Users): authenticate user")
+	log.Infof("V (Users): authenticate user %s, traceId: %s", request.Method, span.SpanContext().TraceID().String())
 
 	var authRequest AuthRequest
 	err := json.Unmarshal(request.Body, &authRequest)
 	if err != nil {
+		log.Errorf("V (Targets): onAuth failed to unmarshall request body, error: %v traceId: %s", err, span.SpanContext().TraceID().String())
 		return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 			State: v1alpha2.Unauthorized,
 			Body:  []byte(err.Error()),
@@ -120,6 +121,7 @@ func (c *UsersVendor) onAuth(request v1alpha2.COARequest) v1alpha2.COAResponse {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	ss, _ := token.SignedString(mySigningKey)
 
+	log.Infof("V (Targets): onAuth succeeded, traceId: %s", span.SpanContext().TraceID().String())
 	rolesJSON, _ := json.Marshal(roles)
 	resp := v1alpha2.COAResponse{
 		State:       v1alpha2.OK,

--- a/coa/pkg/apis/v1alpha2/bindings/mqtt/mqtt_test.go
+++ b/coa/pkg/apis/v1alpha2/bindings/mqtt/mqtt_test.go
@@ -18,13 +18,13 @@ import (
 )
 
 func TestMQTTEcho(t *testing.T) {
-	testMQTT := os.Getenv("TEST_MQTT")
+	testMQTT := os.Getenv("TEST_MQTT_LOCAL_ENABLED")
 	if testMQTT == "" {
 		t.Skip("Skipping because TES_MQTT enviornment variable is not set")
 	}
 	sig := make(chan int)
 	config := MQTTBindingConfig{
-		BrokerAddress: "tcp://20.118.146.198:1883",
+		BrokerAddress: "tcp://127.0.0.1:1883",
 		ClientID:      "coa-test2",
 		RequestTopic:  "coa-request",
 		ResponseTopic: "coa-response",

--- a/coa/pkg/apis/v1alpha2/providers/certs/autogen/autogen.go
+++ b/coa/pkg/apis/v1alpha2/providers/certs/autogen/autogen.go
@@ -12,8 +12,11 @@ import (
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/logger"
 	fasthttp "github.com/valyala/fasthttp"
 )
+
+var log = logger.NewLogger("coa.runtime")
 
 type AutoGenCertProviderConfig struct {
 	Name string `json:"name"`
@@ -31,6 +34,7 @@ func (s *AutoGenCertProvider) SetContext(ctx contexts.ManagerContext) {
 func (w *AutoGenCertProvider) Init(config providers.IProviderConfig) error {
 	certConfig, err := toAutoGenCertProviderConfig(config)
 	if err != nil {
+		log.Errorf("  P (Autogen): failed to parse provider config %+v", err)
 		return v1alpha2.NewCOAError(nil, "provided config is not a valid cert generation provider config", v1alpha2.InvalidArgument)
 	}
 	w.Config = certConfig

--- a/coa/pkg/apis/v1alpha2/providers/certs/localfile/localfile.go
+++ b/coa/pkg/apis/v1alpha2/providers/certs/localfile/localfile.go
@@ -14,7 +14,10 @@ import (
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/logger"
 )
+
+var log = logger.NewLogger("coa.runtime")
 
 type LocalCertFileProviderConfig struct {
 	Name     string `json:"name"`
@@ -34,6 +37,7 @@ func (s *LocalCertFileProvider) SetContext(ctx contexts.ManagerContext) {
 func (w *LocalCertFileProvider) Init(config providers.IProviderConfig) error {
 	certConfig, err := toLocalCertFileProviderConfig(config)
 	if err != nil {
+		log.Errorf("  P (Localfile): expect LocalCertFileProviderConfig %+v", err)
 		return v1alpha2.NewCOAError(nil, "provided config is not a valid local cert file provider config", v1alpha2.InvalidArgument)
 	}
 	w.Config = certConfig
@@ -44,6 +48,7 @@ func toLocalCertFileProviderConfig(config providers.IProviderConfig) (LocalCertF
 	ret := LocalCertFileProviderConfig{}
 	data, err := json.Marshal(config)
 	if err != nil {
+		log.Errorf("  P (Localfile): failed to marshall config %+v", err)
 		return ret, err
 	}
 	err = json.Unmarshal(data, &ret)
@@ -53,18 +58,22 @@ func toLocalCertFileProviderConfig(config providers.IProviderConfig) (LocalCertF
 func (w *LocalCertFileProvider) GetCert(host string) ([]byte, []byte, error) {
 	certFile, err := os.Open(w.Config.CertFile)
 	if err != nil {
+		log.Errorf("  P (Localfile): failed to open certificate file %+v", err)
 		return nil, nil, v1alpha2.NewCOAError(err, "failed to read certificate file", v1alpha2.InternalError)
 	}
 	certData, err := ioutil.ReadAll(certFile)
 	if err != nil {
+		log.Errorf("  P (Localfile): failed to read certificate file %+v", err)
 		return nil, nil, v1alpha2.NewCOAError(err, "failed to read certificate file", v1alpha2.InternalError)
 	}
 	keyFile, err := os.Open(w.Config.KeyFile)
 	if err != nil {
+		log.Errorf("  P (Localfile): failed to open key file %+v", err)
 		return nil, nil, v1alpha2.NewCOAError(err, "failed to read key file", v1alpha2.InternalError)
 	}
 	keyData, err := ioutil.ReadAll(keyFile)
 	if err != nil {
+		log.Errorf("  P (Localfile): failed to read key file %+v", err)
 		return nil, nil, v1alpha2.NewCOAError(err, "failed to read key file", v1alpha2.InternalError)
 	}
 	return certData, keyData, nil

--- a/coa/pkg/apis/v1alpha2/providers/pubsub/memory/memory.go
+++ b/coa/pkg/apis/v1alpha2/providers/pubsub/memory/memory.go
@@ -12,7 +12,10 @@ import (
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	contexts "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	providers "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/logger"
 )
+
+var log = logger.NewLogger("coa.runtime")
 
 type InMemoryPubSubProvider struct {
 	Config      InMemoryPubSubConfig               `json:"config"`
@@ -43,6 +46,7 @@ func (s *InMemoryPubSubProvider) SetContext(ctx *contexts.ManagerContext) {
 func (i *InMemoryPubSubProvider) InitWithMap(properties map[string]string) error {
 	config, err := InMemoryPubSubConfigFromMap(properties)
 	if err != nil {
+		log.Errorf("  P (Memory PubSub): failed to parse provider config from map %+v", err)
 		return err
 	}
 	return i.Init(config)
@@ -51,6 +55,7 @@ func (i *InMemoryPubSubProvider) InitWithMap(properties map[string]string) error
 func (i *InMemoryPubSubProvider) Init(config providers.IProviderConfig) error {
 	vConfig, err := toInMemoryPubSubConfig(config)
 	if err != nil {
+		log.Errorf("  P (Memory PubSub): failed to parse provider config %+v", err)
 		return v1alpha2.NewCOAError(nil, "provided config is not a valid in-memory pub-sub provider config", v1alpha2.BadConfig)
 	}
 	i.Config = vConfig

--- a/coa/pkg/apis/v1alpha2/providers/pubsub/redis/redis.go
+++ b/coa/pkg/apis/v1alpha2/providers/pubsub/redis/redis.go
@@ -152,6 +152,7 @@ func (i *RedisPubSubProvider) InitWithMap(properties map[string]string) error {
 func (i *RedisPubSubProvider) Init(config providers.IProviderConfig) error {
 	vConfig, err := toRedisPubSubProviderConfig(config)
 	if err != nil {
+		mLog.Debugf("  P (Redis PubSub): failed to parse provider config %+v", err)
 		return v1alpha2.NewCOAError(nil, "provided config is not a valid redis pub-sub provider config", v1alpha2.BadConfig)
 	}
 	i.Config = vConfig
@@ -174,6 +175,7 @@ func (i *RedisPubSubProvider) Init(config providers.IProviderConfig) error {
 	}
 	client := redis.NewClient(options)
 	if _, err := client.Ping().Result(); err != nil {
+		mLog.Debugf("  P (Redis PubSub): failed to connect to redis %+v", err)
 		return v1alpha2.NewCOAError(err, fmt.Sprintf("redis stream: error connecting to redis at %s", i.Config.Host), v1alpha2.InternalError)
 	}
 	i.Client = client

--- a/coa/pkg/apis/v1alpha2/providers/states/httpstate/httpstate.go
+++ b/coa/pkg/apis/v1alpha2/providers/states/httpstate/httpstate.go
@@ -19,10 +19,15 @@ import (
 
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	contexts "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/observability"
+	observ_utils "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/observability/utils"
 	providers "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
 	states "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/utils"
+	"github.com/eclipse-symphony/symphony/coa/pkg/logger"
 )
+
+var sLog = logger.NewLogger("coa.runtime")
 
 type HttpStateProviderConfig struct {
 	Name              string `json:"name"`
@@ -102,6 +107,7 @@ func (s *HttpStateProvider) SetContext(ctx *contexts.ManagerContext) {
 func (i *HttpStateProvider) InitWithMap(properties map[string]string) error {
 	config, err := HttpStateProviderConfigFromMap(properties)
 	if err != nil {
+		sLog.Errorf("  P (Http State): failed to parse provider config from map %+v", err)
 		return err
 	}
 	return i.Init(config)
@@ -111,24 +117,37 @@ func (s *HttpStateProvider) Init(config providers.IProviderConfig) error {
 	// parameter checks
 	stateConfig, err := toHttpStateProviderConfig(config)
 	if err != nil {
+		sLog.Errorf("  P (Http State): failed to parse provider config %+v", err)
 		return errors.New("expected HttpStateProviderConfig")
 	}
 	s.Config = stateConfig
 	if s.Config.Url == "" {
-		return v1alpha2.NewCOAError(nil, "Http sate provider url is not set", v1alpha2.BadConfig)
+		return v1alpha2.NewCOAError(nil, "Http state provider url is not set", v1alpha2.BadConfig)
 	}
 	s.Data = make(map[string]interface{}, 0)
 	return nil
 }
 
 func (s *HttpStateProvider) Upsert(ctx context.Context, entry states.UpsertRequest) (string, error) {
+	_, span := observability.StartSpan("Http State Provider", ctx, &map[string]string{
+		"method": "Upsert",
+	})
+	var err error = nil
+	defer observ_utils.CloseSpanWithError(span, &err)
+	sLog.Infof("  P (Http State): upsert states %s, traceId: %s", entry.Value.ID, span.SpanContext().TraceID().String())
+
 	client := &http.Client{}
 	rUrl := s.Config.Url
-	var err error
+	if entry.Value.ID == "" {
+		err = v1alpha2.NewCOAError(nil, "found invalid entry ID", v1alpha2.InternalError)
+		sLog.Errorf("  P (Http State): upsert failed %+v, traceId: %s", err, span.SpanContext().TraceID().String())
+		return "", err
+	}
 	if s.Config.PostNameInPath {
 		rUrl, err = url.JoinPath(s.Config.Url, entry.Value.ID)
 	}
 	if err != nil {
+		sLog.Errorf("  P (Http State): failed to form %s request path: %+v, traceId: %s", entry.Value.ID, err, span.SpanContext().TraceID().String())
 		return "", err
 	}
 	obj := entry.Value.Body
@@ -144,64 +163,100 @@ func (s *HttpStateProvider) Upsert(ctx context.Context, entry states.UpsertReque
 	jData, _ := json.Marshal(obj)
 	req, err := http.NewRequest("POST", rUrl, bytes.NewBuffer(jData))
 	if err != nil {
+		sLog.Errorf("  P (Http State): failed to create a Post request: %+v, traceId: %s", entry.Value.ID, err, span.SpanContext().TraceID().String())
 		return "", err
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		sLog.Errorf("  P (Http State): failed to get response from upserting %s: %+v, traceId: %s", entry.Value.ID, err, span.SpanContext().TraceID().String())
 		return "", err
 	}
 	if resp.StatusCode >= 300 {
+		sLog.Errorf("  P (Http State): failed to get correct state code: %+v, status code %d, traceId: %s", entry.Value.ID, resp.StatusCode, err, span.SpanContext().TraceID().String())
 		return "", fmt.Errorf("failed to invoke HTTP state store: [%d]", resp.StatusCode)
 	}
 	return entry.Value.ID, nil
 }
 
 func (s *HttpStateProvider) List(ctx context.Context, request states.ListRequest) ([]states.StateEntry, string, error) {
-	return nil, "", v1alpha2.NewCOAError(nil, "Http sate store list is not implemented", v1alpha2.NotImplemented)
+	return nil, "", v1alpha2.NewCOAError(nil, "Http state store list is not implemented", v1alpha2.NotImplemented)
 }
 
 func (s *HttpStateProvider) Delete(ctx context.Context, request states.DeleteRequest) error {
+	_, span := observability.StartSpan("Http State Provider", ctx, &map[string]string{
+		"method": "Delete",
+	})
+	var err error = nil
+	defer observ_utils.CloseSpanWithError(span, &err)
+	sLog.Infof("  P (Http State): list states, traceId: %s", span.SpanContext().TraceID().String())
+
 	client := &http.Client{}
+	if request.ID == "" {
+		err := v1alpha2.NewCOAError(nil, "found invalid request ID", v1alpha2.InternalError)
+		sLog.Errorf("  P (Http State): failed to list states: %+v, traceId: %s", err, span.SpanContext().TraceID().String())
+		return err
+	}
 	rUrl, err := url.JoinPath(s.Config.Url, request.ID)
 	if err != nil {
+		sLog.Errorf("  P (Http State): failed to form %s request path: %+v, traceId: %s", request.ID, err, span.SpanContext().TraceID().String())
 		return err
 	}
 	req, err := http.NewRequest("DELETE", rUrl, nil)
 	if err != nil {
+		sLog.Errorf("  P (Http State): failed to create a Delete request: %+v, traceId: %s", request.ID, err, span.SpanContext().TraceID().String())
 		return err
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		sLog.Errorf("  P (Http State): failed to get response from upserting %s: %+v, traceId: %s", request.ID, err, span.SpanContext().TraceID().String())
 		return err
 	}
 	if resp.StatusCode >= 300 {
+		sLog.Errorf("  P (Http State): failed to get correct state code: %+v, status code %d, traceId: %s", request.ID, resp.StatusCode, err, span.SpanContext().TraceID().String())
 		return v1alpha2.NewCOAError(nil, fmt.Sprintf("failed to delete from HTTP state store: [%d]", resp.StatusCode), v1alpha2.InternalError)
-
 	}
 	return nil
 }
 
 func (s *HttpStateProvider) Get(ctx context.Context, request states.GetRequest) (states.StateEntry, error) {
+	_, span := observability.StartSpan("Http State Provider", ctx, &map[string]string{
+		"method": "Delete",
+	})
+	var err error = nil
+	defer observ_utils.CloseSpanWithError(span, &err)
+	sLog.Infof("  P (Http State): get states %s, traceId: %s", request.ID, span.SpanContext().TraceID().String())
+
 	client := &http.Client{}
+	if request.ID == "" {
+		err := v1alpha2.NewCOAError(nil, "found invalid request ID", v1alpha2.InternalError)
+		sLog.Errorf("  P (Http State): failed to get states: %+v, traceId: %s", err, span.SpanContext().TraceID().String())
+		return states.StateEntry{}, err
+	}
 	rUrl, err := url.JoinPath(s.Config.Url, request.ID)
 	if err != nil {
+		sLog.Errorf("  P (Http State): failed to create a Get request: %+v, traceId: %s", request.ID, err, span.SpanContext().TraceID().String())
 		return states.StateEntry{}, err
 	}
 	req, err := http.NewRequest("GET", rUrl, nil)
 	if err != nil {
+		sLog.Errorf("  P (Http State): request creation failed: %+v, traceId: %s", request.ID, err, span.SpanContext().TraceID().String())
 		return states.StateEntry{}, err
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		sLog.Errorf("  P (Http State): failed to get response from getting %s: %+v, traceId: %s", request.ID, err, span.SpanContext().TraceID().String())
 		return states.StateEntry{}, err
 	}
 	if resp.StatusCode == 204 && s.Config.NotFoundAs204 {
+		sLog.Infof("  P (Http State): cannot find %s state: %+v, traceId: %s", request.ID, err, span.SpanContext().TraceID().String())
 		return states.StateEntry{}, v1alpha2.NewCOAError(nil, "not found", v1alpha2.NotFound)
 	}
 	if resp.StatusCode >= 300 {
 		if resp.StatusCode == 404 {
+			sLog.Infof("  P (Http State): received 404 status code: %+v, traceId: %s", err, span.SpanContext().TraceID().String())
 			return states.StateEntry{}, v1alpha2.NewCOAError(nil, "not found", v1alpha2.NotFound)
 		} else {
+			sLog.Errorf("  P (Http State): failed to get correct state code: %+v, status code %d, traceId: %s", request.ID, resp.StatusCode, err, span.SpanContext().TraceID().String())
 			return states.StateEntry{}, v1alpha2.NewCOAError(nil, fmt.Sprintf("failed to invoke HTTP state store: [%d]", resp.StatusCode), v1alpha2.InternalError)
 		}
 
@@ -209,11 +264,13 @@ func (s *HttpStateProvider) Get(ctx context.Context, request states.GetRequest) 
 	defer resp.Body.Close()
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
+		sLog.Errorf("  P (Http State): failed to read request body: %+v, traceId: %s", resp.StatusCode, err, span.SpanContext().TraceID().String())
 		return states.StateEntry{}, err
 	}
 	var obj interface{}
 	err = json.Unmarshal(bodyBytes, &obj)
 	if err != nil {
+		sLog.Errorf("  P (Http State): failed to unmarshall response body: %+v, traceId: %s", resp.StatusCode, err, span.SpanContext().TraceID().String())
 		return states.StateEntry{}, err
 	}
 	return states.StateEntry{

--- a/coa/pkg/apis/v1alpha2/providers/states/httpstate/httpstate_test.go
+++ b/coa/pkg/apis/v1alpha2/providers/states/httpstate/httpstate_test.go
@@ -9,6 +9,7 @@ package httpstate
 import (
 	"context"
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -237,12 +238,48 @@ func TestGet(t *testing.T) {
 func TestUpsertGetDelete(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "GET" {
+			relativePath := r.URL.Path
+			if relativePath == "" || relativePath == "/" {
+				http.Error(w, "invalid path", http.StatusBadRequest)
+				return
+			}
 			response := map[string]interface{}{
 				"key": "abc",
 			}
 			jsonResponse, _ := json.Marshal(response)
 			w.Header().Set("Content-Type", "application/json")
 			w.Write(jsonResponse)
+		} else if r.Method == "POST" {
+			var data []map[string]interface{}
+			body, _ := ioutil.ReadAll(r.Body)
+			err := json.Unmarshal([]byte(body), &data)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if len(data) == 0 {
+				http.Error(w, "invalid request body", http.StatusBadRequest)
+				return
+			}
+			firstItemKey := data[0]["key"].(string)
+			if firstItemKey == "" {
+				http.Error(w, "invalid request body", http.StatusBadRequest)
+				return
+			}
+			response := map[string]interface{}{
+				"key":   data[0]["key"],
+				"value": data[0]["value"],
+			}
+			jsonResponse, _ := json.Marshal(response)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(jsonResponse)
+		} else if r.Method == "DELETE" {
+			relativePath := r.URL.Path
+			if relativePath == "" || relativePath == "/" {
+				http.Error(w, "invalid path", http.StatusBadRequest)
+				return
+			}
+			w.Write([]byte("OK"))
 		} else {
 			w.Write([]byte("OK"))
 		}
@@ -258,6 +295,7 @@ func TestUpsertGetDelete(t *testing.T) {
 		PostAsArray:       true,
 		NotFoundAs204:     true,
 	})
+	assert.Nil(t, err)
 
 	_, err = provider.Upsert(context.Background(), states.UpsertRequest{
 		Value: states.StateEntry{
@@ -277,6 +315,24 @@ func TestUpsertGetDelete(t *testing.T) {
 		ID: "123",
 	})
 	assert.Nil(t, err)
+
+	_, err = provider.Upsert(context.Background(), states.UpsertRequest{
+		Value: states.StateEntry{
+			ID:   "",
+			Body: TestPayload{},
+		},
+	})
+	assert.NotNil(t, err)
+
+	_, err = provider.Get(context.Background(), states.GetRequest{
+		ID: "",
+	})
+	assert.NotNil(t, err)
+
+	err = provider.Delete(context.Background(), states.DeleteRequest{
+		ID: "",
+	})
+	assert.NotNil(t, err)
 }
 
 func TestClone(t *testing.T) {

--- a/k8s/controllers/fabric/target_controller.go
+++ b/k8s/controllers/fabric/target_controller.go
@@ -81,6 +81,7 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if err != nil && !v1alpha2.IsNotFound(err) {
 			uErr := r.updateTargetStatusToReconciling(target, err)
 			if uErr != nil {
+				log.Error(uErr, "failed to update target status to reconciling")
 				return ctrl.Result{}, uErr
 			}
 			return ctrl.Result{}, err
@@ -94,6 +95,7 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if generationMatch && time.Since(summary.Time) <= time.Duration(60)*time.Second { //TODO: this is 60 second interval. Make if configurable?
 			err = r.updateTargetStatus(target, summary.Summary)
 			if err != nil {
+				log.Error(err, "failed to update target status")
 				return ctrl.Result{}, err
 			}
 			return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
@@ -103,6 +105,7 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			if err != nil {
 				uErr := r.updateTargetStatusToReconciling(target, err)
 				if uErr != nil {
+					log.Error(uErr, "failed to update target status to reconciling")
 					return ctrl.Result{}, uErr
 				}
 				return ctrl.Result{}, err
@@ -117,6 +120,7 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			if !generationMatch {
 				err = r.updateTargetStatusToReconciling(target, nil)
 				if err != nil {
+					log.Error(err, "failed to update target status to reconciling")
 					return ctrl.Result{}, err
 				}
 			}
@@ -131,6 +135,7 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			if err != nil {
 				uErr := r.updateTargetStatusToReconciling(target, err)
 				if uErr != nil {
+					log.Error(uErr, "failed to update target status to reconciling")
 					return ctrl.Result{}, uErr
 				}
 				return ctrl.Result{}, err
@@ -149,6 +154,7 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 						break loop
 					}
 					if err != nil && !v1alpha2.IsNotFound(err) {
+						log.Error(err, "failed to get target summary")
 						break loop
 					}
 				}
@@ -158,6 +164,7 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			// provider to pick up.
 			controllerutil.RemoveFinalizer(target, myFinalizerName)
 			if err := r.Update(ctx, target); err != nil {
+				log.Error(err, "failed to remove finalizer")
 				return ctrl.Result{}, err
 			}
 		}


### PR DESCRIPTION
- Enable local MQTT test with tag `TEST_MQTT_LOCAL_ENABLED` in the `Go` check pipeline.
- Improve logging
- Guard `request.ID` null in `Get`, `Upsert`, `Delete` functions in `k8s`and `http` state provider. 

Discussion: should we guard null in memory state provider as well? Although empty key is allowed in the in-memory dictionary, storing and deleting states with empty key may cause operation conflicts for example deleting with unexpected empty ID makes that stored by others deleted.