### PR TITLE
Improve test coverages, add logs and fix bugs in symphony-api

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -51,7 +51,7 @@ jobs:
         kubectl config view
 
     - name: COA Test
-      run: cd coa && go test -v ./... -run '^[^C]*$|^[^c][^o]*$|^[^c][^o]*o[^n][^f][^o][^r][^m][^a][^n][^c][^e][^C]*$'
+      run: cd coa && go test -race -v ./... -run '^[^C]*$|^[^c][^o]*$|^[^c][^o]*o[^n][^f][^o][^r][^m][^a][^n][^c][^e][^C]*$'
 
     - name: API Build
       run: cd api && go build -o symphony-api
@@ -59,11 +59,11 @@ jobs:
     - name: API Test
       run: |
         echo "TEST_KUBECTL:$TEST_KUBECTL TEST_MINIKUBE_ENABLED:$TEST_MINIKUBE_ENABLED"
-        cd api && go test -v ./... -run '^[^C]*$|^[^c][^o]*$|^[^c][^o]*o[^n][^f][^o][^r][^m][^a][^n][^c][^e][^C]*$'
+        cd api && go test -race -v ./... -run '^[^C]*$|^[^c][^o]*$|^[^c][^o]*o[^n][^f][^o][^r][^m][^a][^n][^c][^e][^C]*$'
 
     - name: target-api-testcoverage-app
       run: |
-        cd api && go test -coverprofile=coverage.out ./... -run '^[^C]*$|^[^c][^o]*$|^[^c][^o]*o[^n][^f][^o][^r][^m][^a][^n][^c][^e][^C]*$'
+        cd api && go test -race -coverprofile=coverage.out ./... -run '^[^C]*$|^[^c][^o]*$|^[^c][^o]*o[^n][^f][^o][^r][^m][^a][^n][^c][^e][^C]*$'
         COVERAGE=`go tool cover -func=coverage.out | grep total: | grep -Eo '[0-9]+\.[0-9]+'`
         echo "coverage=$COVERAGE"
       continue-on-error: true
@@ -71,7 +71,7 @@ jobs:
 
     - name: target-k8s-testcoverage-app
       run: |
-        cd k8s && go test -coverprofile=coverage.out ./... -run '^[^C]*$|^[^c][^o]*$|^[^c][^o]*o[^n][^f][^o][^r][^m][^a][^n][^c][^e][^C]*$'
+        cd k8s && go test -race -coverprofile=coverage.out ./... -run '^[^C]*$|^[^c][^o]*$|^[^c][^o]*o[^n][^f][^o][^r][^m][^a][^n][^c][^e][^C]*$'
         COVERAGE=`go tool cover -func=coverage.out | grep total: | grep -Eo '[0-9]+\.[0-9]+'`
         echo "coverage=$COVERAGE"
       continue-on-error: true
@@ -79,7 +79,7 @@ jobs:
 
     - name: target-coa-testcoverage-app
       run: |
-        cd coa && go test -coverprofile=coverage.out ./... -run '^[^C]*$|^[^c][^o]*$|^[^c][^o]*o[^n][^f][^o][^r][^m][^a][^n][^c][^e][^C]*$'
+        cd coa && go test -race -coverprofile=coverage.out ./... -run '^[^C]*$|^[^c][^o]*$|^[^c][^o]*o[^n][^f][^o][^r][^m][^a][^n][^c][^e][^C]*$'
         COVERAGE=`go tool cover -func=coverage.out | grep total: | grep -Eo '[0-9]+\.[0-9]+'`
         echo "coverage=$COVERAGE"
       continue-on-error: true

--- a/api/pkg/apis/v1alpha1/contexts/manager-context_test.go
+++ b/api/pkg/apis/v1alpha1/contexts/manager-context_test.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package contexts
+
+import (
+	"testing"
+
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/pubsub/memory"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestManagerContextInitWithoutPubSub(t *testing.T) {
+	v := createVendorContextWithPubSub()
+	v.SiteInfo.SiteId = "test"
+	m := &ManagerContext{}
+	err := m.Init(v, nil)
+	assert.Nil(t, err)
+	assert.Equal(t, "test", m.SiteInfo.SiteId)
+	assert.NotNil(t, m.Logger)
+	assert.NotNil(t, m.PubsubProvider)
+}
+
+func TestManagerContextInitWithVendorConext(t *testing.T) {
+	pubsubProvider := memory.InMemoryPubSubProvider{}
+	pubsubProvider.Init(memory.InMemoryPubSubConfig{})
+	m := &ManagerContext{}
+	err := m.Init(nil, &pubsubProvider)
+	assert.Nil(t, err)
+	assert.NotNil(t, m.Logger)
+	assert.NotNil(t, m.PubsubProvider)
+}
+
+func TestManagerContextInitWithVendorConextAndPubSub(t *testing.T) {
+	m := &ManagerContext{}
+	err := m.Init(nil, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, m.Logger)
+	assert.Nil(t, m.PubsubProvider)
+}
+
+func TestManagerContextPublishSubscribe(t *testing.T) {
+	v := createVendorContextWithPubSub()
+	v.SiteInfo.SiteId = "test"
+	m := &ManagerContext{}
+	err := m.Init(v, nil)
+	assert.Nil(t, err)
+	sig := make(chan int)
+	msg := ""
+
+	err = m.Subscribe("test", func(topic string, event v1alpha2.Event) error {
+		msg = event.Body.(string)
+		sig <- 1
+		return nil
+	})
+	assert.Nil(t, err)
+	err = m.Publish("test", v1alpha2.Event{
+		Body: "test",
+	})
+	assert.Nil(t, err)
+	<-sig
+	assert.Equal(t, "test", msg)
+}
+
+func TestManagerContextPublishSubscribeWithoutPubSub(t *testing.T) {
+	m := &ManagerContext{}
+	err := m.Init(nil, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, m.Logger)
+	assert.Nil(t, m.PubsubProvider)
+
+	err = m.Subscribe("test", func(topic string, event v1alpha2.Event) error {
+		return nil
+	})
+	assert.Nil(t, err)
+	err = m.Publish("test", v1alpha2.Event{
+		Body: "test",
+	})
+	assert.Nil(t, err)
+}

--- a/api/pkg/apis/v1alpha1/contexts/vendor-context_test.go
+++ b/api/pkg/apis/v1alpha1/contexts/vendor-context_test.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package contexts
+
+import (
+	"testing"
+
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/pubsub/memory"
+	"github.com/stretchr/testify/assert"
+)
+
+func createVendorContextWithPubSub() *VendorContext {
+	pubsubProvider := memory.InMemoryPubSubProvider{}
+	pubsubProvider.Init(memory.InMemoryPubSubConfig{})
+	v := &VendorContext{}
+	_ = v.Init(&pubsubProvider)
+	return v
+}
+
+func createVendorContextWithoutPubSub() *VendorContext {
+	v := &VendorContext{}
+	_ = v.Init(nil)
+	return v
+}
+
+func TestVendorContextInitWithoutPubSub(t *testing.T) {
+	v := &VendorContext{}
+	err := v.Init(nil)
+	assert.Nil(t, err)
+}
+
+func TestVendorContextInitWithPubSub(t *testing.T) {
+	pubsubProvider := memory.InMemoryPubSubProvider{}
+	pubsubProvider.Init(memory.InMemoryPubSubConfig{})
+	v := &VendorContext{}
+	err := v.Init(&pubsubProvider)
+	assert.Nil(t, err)
+}
+
+func TestVendorContextPublishSubscribe(t *testing.T) {
+	v := createVendorContextWithPubSub()
+	sig := make(chan int)
+	msg := ""
+
+	err := v.Subscribe("test", func(topic string, event v1alpha2.Event) error {
+		msg = event.Body.(string)
+		sig <- 1
+		return nil
+	})
+	assert.Nil(t, err)
+	err = v.Publish("test", v1alpha2.Event{
+		Body: "test",
+	})
+	assert.Nil(t, err)
+
+	<-sig
+	assert.Equal(t, "test", msg)
+}
+
+func TestVendorContextPublishSubscribeWithoutPubSub(t *testing.T) {
+	v := createVendorContextWithoutPubSub()
+	err := v.Subscribe("test", func(topic string, event v1alpha2.Event) error {
+		return nil
+	})
+	assert.Nil(t, err)
+	err = v.Publish("test", v1alpha2.Event{
+		Body: "test",
+	})
+	assert.Nil(t, err)
+}

--- a/api/pkg/apis/v1alpha1/managers/activations/activations-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/activations/activations-manager.go
@@ -74,6 +74,8 @@ func (m *ActivationsManager) GetSpec(ctx context.Context, name string) (model.Ac
 }
 
 func getActivationState(id string, body interface{}, etag string) (model.ActivationState, error) {
+	lock.Lock()
+	defer lock.Unlock()
 	dict := body.(map[string]interface{})
 	spec := dict["spec"]
 	status := dict["status"]

--- a/api/pkg/apis/v1alpha1/managers/activations/activations-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/activations/activations-manager.go
@@ -74,8 +74,6 @@ func (m *ActivationsManager) GetSpec(ctx context.Context, name string) (model.Ac
 }
 
 func getActivationState(id string, body interface{}, etag string) (model.ActivationState, error) {
-	lock.Lock()
-	defer lock.Unlock()
 	dict := body.(map[string]interface{})
 	spec := dict["spec"]
 	status := dict["status"]

--- a/api/pkg/apis/v1alpha1/managers/managerfactory_test.go
+++ b/api/pkg/apis/v1alpha1/managers/managerfactory_test.go
@@ -1,0 +1,450 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package managers
+
+import (
+	"testing"
+
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/activations"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/campaigns"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/catalogs"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/configs"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/devices"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/instances"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/jobs"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/models"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/reference"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/sites"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/skills"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/solution"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/solutions"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/stage"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/staging"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/sync"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/target"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/targets"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/trails"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/users"
+	cm "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
+	"github.com/stretchr/testify/assert"
+)
+
+func testCreateManager[T cm.IManager](t *testing.T, config cm.ManagerConfig) {
+	symphonyManagerFactory := SymphonyManagerFactory{}
+
+	manager, err := symphonyManagerFactory.CreateManager(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, manager)
+	manager = manager.(T)
+	assert.NotNil(t, manager)
+}
+
+func TestCreateManager(t *testing.T) {
+	testCreateManager[*solution.SolutionManager](t, getSolutionManagerConfig())
+	testCreateManager[*reference.ReferenceManager](t, getReferenceManagerConfig())
+	testCreateManager[*target.TargetManager](t, getTargetManagerConfig())
+	testCreateManager[*targets.TargetsManager](t, getTargetsManagerConfig())
+	testCreateManager[*devices.DevicesManager](t, getDevicesManagerConfig())
+	testCreateManager[*solutions.SolutionsManager](t, getSolutionsManagerConfig())
+	testCreateManager[*instances.InstancesManager](t, getInstancesManagerConfig())
+	testCreateManager[*users.UsersManager](t, getUsersManagerConfig())
+	testCreateManager[*jobs.JobsManager](t, getJobsManagerConfig())
+	testCreateManager[*campaigns.CampaignsManager](t, getCampaignsManagerConfig())
+	testCreateManager[*catalogs.CatalogsManager](t, getCatalogsManagerConfig())
+	testCreateManager[*activations.ActivationsManager](t, getActivationsManagerConfig())
+	testCreateManager[*activations.ActivationsCleanupManager](t, getActivationsCleanupManagerConfig())
+	testCreateManager[*stage.StageManager](t, getStageManagerConfig())
+	testCreateManager[*configs.ConfigsManager](t, getConfigsManagerConfig())
+	testCreateManager[*sites.SitesManager](t, getSitesManagerConfig())
+	testCreateManager[*staging.StagingManager](t, getStagingManagerConfig())
+	testCreateManager[*sync.SyncManager](t, getSyncManagerConfig())
+	testCreateManager[*models.ModelsManager](t, getModelsManagerConfig())
+	testCreateManager[*skills.SkillsManager](t, getSkillsManagerConfig())
+	testCreateManager[*trails.TrailsManager](t, getTrailsManagerConfig())
+}
+
+func getSolutionManagerConfig() cm.ManagerConfig {
+	// symphony-api-no-k8s.json
+	return cm.ManagerConfig{
+		Type: "managers.symphony.solution",
+		Properties: map[string]string{
+			"providers.state":  "mem-state",
+			"providers.config": "mock-config",
+			"providers.secret": "mock-secret",
+		},
+		Providers: map[string]cm.ProviderConfig{
+			"mem-state": {
+				Type: "providers.symphony.state",
+			},
+			"mock-config": {
+				Type: "providers.config.mock",
+			},
+			"mock-secret": {
+				Type: "providers.secret.mock",
+			},
+		},
+	}
+}
+
+func getReferenceManagerConfig() cm.ManagerConfig {
+	// symphony-api-no-k8s.json
+	return cm.ManagerConfig{
+		Type: "managers.symphony.reference",
+		Properties: map[string]string{
+			"providers.reference": "http-reference",
+			"providers.state":     "memory",
+			"providers.reporter":  "http-reporter",
+		},
+		Providers: map[string]cm.ProviderConfig{
+			"memory": {
+				Type: "providers.symphony.state",
+			},
+			"http-reference": {
+				Type: "providers.reference.http",
+				Config: map[string]string{
+					"url": "http://localhost:8080",
+				},
+			},
+			"http-reporter": {
+				Type: "providers.reporter.http",
+				Config: map[string]string{
+					"url": "http://localhost:8080",
+				},
+			},
+		},
+	}
+}
+
+func getTargetManagerConfig() cm.ManagerConfig {
+	// symphony-agent.json
+	return cm.ManagerConfig{
+		Type: "managers.symphony.target",
+		Properties: map[string]string{
+			"providers.probe":     "rtsp-probe",
+			"providers.reference": "http-reference",
+			"providers.uploader":  "azure-uploader",
+			"providers.reporter":  "http-reporter",
+			"poll.enabled":        "true",
+		},
+		Providers: map[string]cm.ProviderConfig{
+			"rtsp-probe": {
+				Type: "providers.probe.rtsp",
+			},
+			"http-reference": {
+				Type: "providers.reference.http",
+				Config: map[string]string{
+					"url":    "http://localhost:8080",
+					"target": "target_name",
+				},
+			},
+			"http-reporter": {
+				Type: "providers.reporter.http",
+				Config: map[string]string{
+					"url": "http://localhost:8080",
+				},
+			},
+			"azure-uploader": {
+				Type: "providers.uploader.azure.blob",
+				Config: map[string]string{
+					"account":   "account",
+					"container": "container",
+				},
+			},
+		},
+	}
+}
+
+func getTargetsManagerConfig() cm.ManagerConfig {
+	// symphony-api-no-k8s.json
+	return cm.ManagerConfig{
+		Type: "managers.symphony.targets",
+		Properties: map[string]string{
+			"providers.state": "mem-state",
+		},
+		Providers: map[string]cm.ProviderConfig{
+			"mem-state": {
+				Type: "providers.symphony.state",
+			},
+		},
+	}
+}
+
+func getDevicesManagerConfig() cm.ManagerConfig {
+	// symphony-api-no-k8s.json
+	return cm.ManagerConfig{
+		Type: "managers.symphony.devices",
+		Properties: map[string]string{
+			"providers.state": "mem-state",
+		},
+		Providers: map[string]cm.ProviderConfig{
+			"mem-state": {
+				Type: "providers.symphony.state",
+			},
+		},
+	}
+}
+
+func getSolutionsManagerConfig() cm.ManagerConfig {
+	// symphony-api-no-k8s.json
+	return cm.ManagerConfig{
+		Type: "managers.symphony.solutions",
+		Properties: map[string]string{
+			"providers.state": "mem-state",
+		},
+		Providers: map[string]cm.ProviderConfig{
+			"mem-state": {
+				Type: "providers.symphony.state",
+			},
+		},
+	}
+}
+
+func getInstancesManagerConfig() cm.ManagerConfig {
+	// symphony-api-no-k8s.json
+	return cm.ManagerConfig{
+		Type: "managers.symphony.instances",
+		Properties: map[string]string{
+			"providers.state": "mem-state",
+		},
+		Providers: map[string]cm.ProviderConfig{
+			"mem-state": {
+				Type: "providers.symphony.state",
+			},
+		},
+	}
+}
+
+func getUsersManagerConfig() cm.ManagerConfig {
+	// symphony-api-no-k8s.json
+	return cm.ManagerConfig{
+		Type: "managers.symphony.users",
+		Properties: map[string]string{
+			"providers.state": "mem-state",
+		},
+		Providers: map[string]cm.ProviderConfig{
+			"mem-state": {
+				Type: "providers.symphony.state",
+			},
+		},
+	}
+}
+
+func getJobsManagerConfig() cm.ManagerConfig {
+	// symphony-api-no-k8s.json
+	return cm.ManagerConfig{
+		Type: "managers.symphony.jobs",
+		Properties: map[string]string{
+			"providers.state":  "mem-state",
+			"baseUrl":          "http://localhost/",
+			"user":             "admin",
+			"password":         "",
+			"interval":         "#15",
+			"poll.enabled":     "true",
+			"schedule.enabled": "true",
+		},
+		Providers: map[string]cm.ProviderConfig{
+			"mem-state": {
+				Type: "providers.symphony.state",
+			},
+		},
+	}
+}
+
+func getCampaignsManagerConfig() cm.ManagerConfig {
+	// symphony-api-no-k8s.json
+	return cm.ManagerConfig{
+		Type: "managers.symphony.campaigns",
+		Properties: map[string]string{
+			"providers.state": "mem-state",
+			"singleton":       "true",
+		},
+		Providers: map[string]cm.ProviderConfig{
+			"mem-state": {
+				Type: "providers.symphony.state",
+			},
+		},
+	}
+}
+
+func getCatalogsManagerConfig() cm.ManagerConfig {
+	// symphony-api-no-k8s.json
+	return cm.ManagerConfig{
+		Type: "managers.symphony.catalogs",
+		Properties: map[string]string{
+			"providers.state": "mem-state",
+			"singleton":       "true",
+		},
+		Providers: map[string]cm.ProviderConfig{
+			"mem-state": {
+				Type: "providers.symphony.state",
+			},
+		},
+	}
+}
+
+func getActivationsManagerConfig() cm.ManagerConfig {
+	// symphony-api-no-k8s.json
+	return cm.ManagerConfig{
+		Type: "managers.symphony.activations",
+		Properties: map[string]string{
+			"providers.state": "mem-state",
+			"singleton":       "true",
+		},
+		Providers: map[string]cm.ProviderConfig{
+			"mem-state": {
+				Type: "providers.symphony.state",
+			},
+		},
+	}
+}
+
+func getActivationsCleanupManagerConfig() cm.ManagerConfig {
+	// symphony-api-no-k8s.json
+	return cm.ManagerConfig{
+		Type: "managers.symphony.activationscleanup",
+		Properties: map[string]string{
+			"providers.state":    "mem-state",
+			"singleton":          "true",
+			"RetentionInMinutes": "1440",
+		},
+		Providers: map[string]cm.ProviderConfig{
+			"mem-state": {
+				Type: "providers.symphony.state",
+			},
+		},
+	}
+}
+
+func getStageManagerConfig() cm.ManagerConfig {
+	// symphony-api-no-k8s.json
+	return cm.ManagerConfig{
+		Type: "managers.symphony.stage",
+		Properties: map[string]string{
+			"providers.state": "mem-state",
+			"baseUrl":         "http://localhost:8082/v1alpha2/",
+			"user":            "admin",
+			"password":        "",
+		},
+		Providers: map[string]cm.ProviderConfig{
+			"mem-state": {
+				Type: "providers.symphony.state",
+			},
+		},
+	}
+}
+
+func getConfigsManagerConfig() cm.ManagerConfig {
+	// symphony-api-no-k8s.json
+	return cm.ManagerConfig{
+		Type: "managers.symphony.configs",
+		Properties: map[string]string{
+			"singleton": "true",
+		},
+		Providers: map[string]cm.ProviderConfig{
+			"catalog": {
+				Type: "providers.config.catalog",
+				Config: map[string]string{
+					"baseUrl":  "http://localhost:8082/v1alpha2/",
+					"user":     "admin",
+					"password": "",
+				},
+			},
+		},
+	}
+}
+
+func getSitesManagerConfig() cm.ManagerConfig {
+	// symphony-api-no-k8s.json
+	return cm.ManagerConfig{
+		Type: "managers.symphony.sites",
+		Properties: map[string]string{
+			"providers.state": "mem-state",
+		},
+		Providers: map[string]cm.ProviderConfig{
+			"mem-state": {
+				Type: "providers.state.memory",
+			},
+		},
+	}
+}
+
+func getStagingManagerConfig() cm.ManagerConfig {
+	// symphony-api-no-k8s.json
+	return cm.ManagerConfig{
+		Type: "managers.symphony.staging",
+		Properties: map[string]string{
+			"poll.enabled":    "true",
+			"interval":        "#15",
+			"providers.queue": "memory-queue",
+			"providers.state": "memory-state",
+		},
+		Providers: map[string]cm.ProviderConfig{
+			"memory-state": {
+				Type: "providers.state.memory",
+			},
+			"memory-queue": {
+				Type: "providers.queue.memory",
+			},
+		},
+	}
+}
+
+func getSyncManagerConfig() cm.ManagerConfig {
+	// symphony-api-no-k8s.json
+	return cm.ManagerConfig{
+		Type: "managers.symphony.sync",
+		Properties: map[string]string{
+			"baseUrl":      "http://localhost:8080/v1alpha2/",
+			"user":         "admin",
+			"password":     "",
+			"interval":     "#15",
+			"sync.enabled": "true",
+		},
+	}
+}
+
+func getModelsManagerConfig() cm.ManagerConfig {
+	// symphony-api-no-k8s.json
+	return cm.ManagerConfig{
+		Type: "managers.symphony.models",
+		Properties: map[string]string{
+			"providers.state": "mem-state",
+		},
+		Providers: map[string]cm.ProviderConfig{
+			"mem-state": {
+				Type: "providers.state.memory",
+			},
+		},
+	}
+}
+
+func getSkillsManagerConfig() cm.ManagerConfig {
+	// symphony-api-no-k8s.json
+	return cm.ManagerConfig{
+		Type: "managers.symphony.skills",
+		Properties: map[string]string{
+			"providers.state": "mem-state",
+		},
+		Providers: map[string]cm.ProviderConfig{
+			"mem-state": {
+				Type: "providers.state.memory",
+			},
+		},
+	}
+}
+
+func getTrailsManagerConfig() cm.ManagerConfig {
+	// symphony-api-no-k8s.json
+	return cm.ManagerConfig{
+		Type: "managers.symphony.trails",
+		Providers: map[string]cm.ProviderConfig{
+			"mock": {
+				Type: "providers.ledger.mock",
+			},
+		},
+	}
+}

--- a/api/pkg/apis/v1alpha1/managers/models/models-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/models/models-manager.go
@@ -59,7 +59,7 @@ func (t *ModelsManager) DeleteSpec(ctx context.Context, name string) error {
 	})
 
 	if err != nil {
-		log.Debugf(" M (Models): failed to DeleteSpec, name: %s, err: %v, traceId: %s", name, err, span.SpanContext().TraceID().String())
+		log.Errorf(" M (Models): failed to DeleteSpec, name: %s, err: %v, traceId: %s", name, err, span.SpanContext().TraceID().String())
 	}
 	return err
 }
@@ -94,7 +94,7 @@ func (t *ModelsManager) UpsertSpec(ctx context.Context, name string, spec model.
 	}
 	_, err = t.StateProvider.Upsert(ctx, upsertRequest)
 	if err != nil {
-		log.Debugf(" M (Models): failed to UpsertSpec, name: %s, err: %v, traceId: %s", name, err, span.SpanContext().TraceID().String())
+		log.Errorf(" M (Models): failed to UpsertSpec, name: %s, err: %v, traceId: %s", name, err, span.SpanContext().TraceID().String())
 		return err
 	}
 	return nil
@@ -117,7 +117,7 @@ func (t *ModelsManager) ListSpec(ctx context.Context) ([]model.ModelState, error
 	}
 	models, _, err := t.StateProvider.List(ctx, listRequest)
 	if err != nil {
-		log.Debugf(" M (Models): failed to ListSpec, err: %v, traceId: %s", err, span.SpanContext().TraceID().String())
+		log.Errorf(" M (Models): failed to ListSpec, err: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 		return nil, err
 	}
 	ret := make([]model.ModelState, 0)
@@ -125,7 +125,7 @@ func (t *ModelsManager) ListSpec(ctx context.Context) ([]model.ModelState, error
 		var rt model.ModelState
 		rt, err = getModelState(t.ID, t.Body, t.ETag)
 		if err != nil {
-			log.Debugf(" M (Models): failed to getModelState, err: %v, traceId: %s", err, span.SpanContext().TraceID().String())
+			log.Errorf(" M (Models): failed to getModelState, err: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 			return nil, err
 		}
 		ret = append(ret, rt)
@@ -169,13 +169,13 @@ func (t *ModelsManager) GetSpec(ctx context.Context, id string) (model.ModelStat
 	}
 	m, err := t.StateProvider.Get(ctx, getRequest)
 	if err != nil {
-		log.Debugf(" M (Models): failed to GetSpec, name: %s, err: %v, traceId: %s", id, err, span.SpanContext().TraceID().String())
+		log.Errorf(" M (Models): failed to GetSpec, name: %s, err: %v, traceId: %s", id, err, span.SpanContext().TraceID().String())
 		return model.ModelState{}, err
 	}
 
 	ret, err := getModelState(id, m.Body, m.ETag)
 	if err != nil {
-		log.Debugf(" M (Models): failed to getModelState, name: %s, err: %v, traceId: %s", id, err, span.SpanContext().TraceID().String())
+		log.Errorf(" M (Models): failed to getModelState, name: %s, err: %v, traceId: %s", id, err, span.SpanContext().TraceID().String())
 		return model.ModelState{}, err
 	}
 	return ret, nil

--- a/api/pkg/apis/v1alpha1/managers/models/models-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/models/models-manager.go
@@ -16,10 +16,13 @@ import (
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states"
+	"github.com/eclipse-symphony/symphony/coa/pkg/logger"
 
 	observability "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/observability"
 	observ_utils "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/observability/utils"
 )
+
+var log = logger.NewLogger("coa.runtime")
 
 type ModelsManager struct {
 	managers.Manager
@@ -43,6 +46,8 @@ func (t *ModelsManager) DeleteSpec(ctx context.Context, name string) error {
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 
+	log.Debugf(" M (Models): DeleteSpec, name: %s, traceId: %s", name, span.SpanContext().TraceID().String())
+
 	err = t.StateProvider.Delete(ctx, states.DeleteRequest{
 		ID: name,
 		Metadata: map[string]string{
@@ -52,16 +57,21 @@ func (t *ModelsManager) DeleteSpec(ctx context.Context, name string) error {
 			"resource": "models",
 		},
 	})
+
+	if err != nil {
+		log.Debugf(" M (Models): failed to DeleteSpec, name: %s, err: %v, traceId: %s", name, err, span.SpanContext().TraceID().String())
+	}
 	return err
 }
 
-func (t *ModelsManager) UpsertSpec(ctx context.Context, name string, spec model.DeviceSpec) error {
+func (t *ModelsManager) UpsertSpec(ctx context.Context, name string, spec model.ModelSpec) error {
 	ctx, span := observability.StartSpan("Models Manager", ctx, &map[string]string{
 		"method": "UpsertSpec",
 	})
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 
+	log.Debugf(" M (Models): UpsertSpec, name: %s, traceId: %s", name, span.SpanContext().TraceID().String())
 	upsertRequest := states.UpsertRequest{
 		Value: states.StateEntry{
 			ID: name,
@@ -84,6 +94,7 @@ func (t *ModelsManager) UpsertSpec(ctx context.Context, name string, spec model.
 	}
 	_, err = t.StateProvider.Upsert(ctx, upsertRequest)
 	if err != nil {
+		log.Debugf(" M (Models): failed to UpsertSpec, name: %s, err: %v, traceId: %s", name, err, span.SpanContext().TraceID().String())
 		return err
 	}
 	return nil
@@ -96,6 +107,7 @@ func (t *ModelsManager) ListSpec(ctx context.Context) ([]model.ModelState, error
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 
+	log.Debugf(" M (Models): ListSpec, traceId: %s", span.SpanContext().TraceID().String())
 	listRequest := states.ListRequest{
 		Metadata: map[string]string{
 			"version":  "v1",
@@ -105,6 +117,7 @@ func (t *ModelsManager) ListSpec(ctx context.Context) ([]model.ModelState, error
 	}
 	models, _, err := t.StateProvider.List(ctx, listRequest)
 	if err != nil {
+		log.Debugf(" M (Models): failed to ListSpec, err: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 		return nil, err
 	}
 	ret := make([]model.ModelState, 0)
@@ -112,6 +125,7 @@ func (t *ModelsManager) ListSpec(ctx context.Context) ([]model.ModelState, error
 		var rt model.ModelState
 		rt, err = getModelState(t.ID, t.Body, t.ETag)
 		if err != nil {
+			log.Debugf(" M (Models): failed to getModelState, err: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 			return nil, err
 		}
 		ret = append(ret, rt)
@@ -144,6 +158,7 @@ func (t *ModelsManager) GetSpec(ctx context.Context, id string) (model.ModelStat
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 
+	log.Debugf(" M (Models): GetSpec, name: %s, traceId: %s", id, span.SpanContext().TraceID().String())
 	getRequest := states.GetRequest{
 		ID: id,
 		Metadata: map[string]string{
@@ -154,11 +169,13 @@ func (t *ModelsManager) GetSpec(ctx context.Context, id string) (model.ModelStat
 	}
 	m, err := t.StateProvider.Get(ctx, getRequest)
 	if err != nil {
+		log.Debugf(" M (Models): failed to GetSpec, name: %s, err: %v, traceId: %s", id, err, span.SpanContext().TraceID().String())
 		return model.ModelState{}, err
 	}
 
 	ret, err := getModelState(id, m.Body, m.ETag)
 	if err != nil {
+		log.Debugf(" M (Models): failed to getModelState, name: %s, err: %v, traceId: %s", id, err, span.SpanContext().TraceID().String())
 		return model.ModelState{}, err
 	}
 	return ret, nil

--- a/api/pkg/apis/v1alpha1/managers/models/models-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/models/models-manager_test.go
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package models
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInit(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	err := stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	assert.Nil(t, err)
+	manager := ModelsManager{}
+	err = manager.Init(nil, managers.ManagerConfig{
+		Properties: map[string]string{
+			"providers.state": "memory-state",
+		},
+	}, map[string]providers.IProvider{
+		"memory-state": stateProvider,
+	})
+	assert.Nil(t, err)
+}
+
+func TestInitFail(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	err := stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	assert.Nil(t, err)
+	manager := ModelsManager{}
+	err = manager.Init(nil, managers.ManagerConfig{
+		Properties: map[string]string{
+			"providers.state": "memory-state-fail",
+		},
+	}, map[string]providers.IProvider{
+		"memory-state": stateProvider,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestUpsertAndDeleteSpec(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	err := stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	assert.Nil(t, err)
+	manager := ModelsManager{}
+	err = manager.Init(nil, managers.ManagerConfig{
+		Properties: map[string]string{
+			"providers.state": "memory-state",
+		},
+	}, map[string]providers.IProvider{
+		"memory-state": stateProvider,
+	})
+	assert.Nil(t, err)
+
+	err = manager.UpsertSpec(context.Background(), "test", model.ModelSpec{
+		DisplayName: "device",
+		Properties: map[string]string{
+			"a": "a",
+		},
+		Constraints: "constraints",
+	})
+	assert.Nil(t, err)
+	err = manager.DeleteSpec(context.Background(), "test")
+	assert.Nil(t, err)
+}
+
+func TestUpsertAndListSpec(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	err := stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	assert.Nil(t, err)
+	manager := ModelsManager{}
+	err = manager.Init(nil, managers.ManagerConfig{
+		Properties: map[string]string{
+			"providers.state": "memory-state",
+		},
+	}, map[string]providers.IProvider{
+		"memory-state": stateProvider,
+	})
+	assert.Nil(t, err)
+
+	err = manager.UpsertSpec(context.Background(), "test", model.ModelSpec{
+		DisplayName: "device",
+		Properties: map[string]string{
+			"a": "a",
+		},
+		Constraints: "constraints",
+	})
+	assert.Nil(t, err)
+	list, err := manager.ListSpec(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(list))
+	assert.Equal(t, "test", list[0].Id)
+	assert.Equal(t, "device", list[0].Spec.DisplayName)
+	assert.Equal(t, "a", list[0].Spec.Properties["a"])
+}
+
+func TestUpsertAndGetSpec(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	err := stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	assert.Nil(t, err)
+	manager := ModelsManager{}
+	err = manager.Init(nil, managers.ManagerConfig{
+		Properties: map[string]string{
+			"providers.state": "memory-state",
+		},
+	}, map[string]providers.IProvider{
+		"memory-state": stateProvider,
+	})
+	assert.Nil(t, err)
+
+	err = manager.UpsertSpec(context.Background(), "test", model.ModelSpec{
+		DisplayName: "device",
+		Properties: map[string]string{
+			"a": "a",
+		},
+		Constraints: "constraints",
+	})
+	assert.Nil(t, err)
+	spec, err := manager.GetSpec(context.Background(), "test")
+	assert.Nil(t, err)
+	assert.Equal(t, "test", spec.Id)
+	assert.Equal(t, "device", spec.Spec.DisplayName)
+	assert.Equal(t, "a", spec.Spec.Properties["a"])
+}
+
+func TestUpsertSpecFail(t *testing.T) {
+	stateProvider := &MemoryStateProviderFail{}
+	err := stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	assert.Nil(t, err)
+	manager := ModelsManager{}
+	err = manager.Init(nil, managers.ManagerConfig{
+		Properties: map[string]string{
+			"providers.state": "memory-state-fail",
+		},
+	}, map[string]providers.IProvider{
+		"memory-state-fail": stateProvider,
+	})
+	assert.Nil(t, err)
+
+	err = manager.UpsertSpec(context.Background(), "mockError", model.ModelSpec{
+		DisplayName: "device",
+		Properties: map[string]string{
+			"a": "a",
+		},
+		Constraints: "constraints",
+	})
+	assert.NotNil(t, err)
+}
+
+func TestListSpecFail(t *testing.T) {
+	stateProvider := &MemoryStateProviderFail{}
+	err := stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	assert.Nil(t, err)
+	manager := ModelsManager{}
+	err = manager.Init(nil, managers.ManagerConfig{
+		Properties: map[string]string{
+			"providers.state": "memory-state-fail",
+		},
+	}, map[string]providers.IProvider{
+		"memory-state-fail": stateProvider,
+	})
+	assert.Nil(t, err)
+
+	_, err = manager.ListSpec(context.Background())
+	assert.NotNil(t, err)
+}
+
+func TestGetSpecFail(t *testing.T) {
+	stateProvider := &MemoryStateProviderFail{}
+	err := stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	assert.Nil(t, err)
+	manager := ModelsManager{}
+	err = manager.Init(nil, managers.ManagerConfig{
+		Properties: map[string]string{
+			"providers.state": "memory-state-fail",
+		},
+	}, map[string]providers.IProvider{
+		"memory-state-fail": stateProvider,
+	})
+	assert.Nil(t, err)
+
+	_, err = manager.GetSpec(context.Background(), "mockError")
+	assert.NotNil(t, err)
+
+	_, err = manager.GetSpec(context.Background(), "mockJsonError")
+	assert.NotNil(t, err)
+}
+
+func TestUpsertAndListSpecFail(t *testing.T) {
+	stateProvider := &MemoryStateProviderFail{}
+	err := stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	assert.Nil(t, err)
+	manager := ModelsManager{}
+	err = manager.Init(nil, managers.ManagerConfig{
+		Properties: map[string]string{
+			"providers.state": "memory-state-fail",
+		},
+	}, map[string]providers.IProvider{
+		"memory-state-fail": stateProvider,
+	})
+	assert.Nil(t, err)
+
+	err = manager.UpsertSpec(context.Background(), "mockJsonError", model.ModelSpec{
+		DisplayName: "device",
+		Properties: map[string]string{
+			"a": "a",
+		},
+		Constraints: "constraints",
+	})
+	assert.Nil(t, err)
+
+	_, err = manager.ListSpec(context.Background())
+	assert.NotNil(t, err)
+}
+
+type MemoryStateProviderFail struct {
+	Data map[string]interface{}
+}
+
+func (m *MemoryStateProviderFail) Init(config providers.IProviderConfig) error {
+	m.Data = make(map[string]interface{})
+	return nil
+}
+
+func (m *MemoryStateProviderFail) Upsert(ctx context.Context, request states.UpsertRequest) (string, error) {
+	if request.Value.ID == "mockError" {
+		return "", assert.AnError
+	} else {
+		if request.Value.ID == "mockJsonError" {
+			request.Value.Body = map[string]interface{}{
+				"spec": []byte("invalid json"),
+			}
+		}
+		m.Data[request.Value.ID] = request.Value
+		return request.Value.ID, nil
+	}
+}
+
+func (m *MemoryStateProviderFail) Delete(context.Context, states.DeleteRequest) error {
+	return assert.AnError
+}
+
+func (m *MemoryStateProviderFail) Get(ctx context.Context, getRequest states.GetRequest) (states.StateEntry, error) {
+	if getRequest.ID == "mockError" {
+		return states.StateEntry{}, assert.AnError
+	}
+
+	if getRequest.ID == "mockJsonError" {
+		return states.StateEntry{
+			ID: "mockJsonError",
+			Body: map[string]interface{}{
+				"spec": []byte("invalid json"),
+			},
+		}, nil
+	}
+
+	var err error
+	if v, ok := m.Data[getRequest.ID]; ok {
+		vE, ok := v.(states.StateEntry)
+		if ok {
+			return vE, nil
+		} else {
+			err = v1alpha2.NewCOAError(nil, fmt.Sprintf("entry '%s' is not a valid state entry", getRequest.ID), v1alpha2.InternalError)
+			return states.StateEntry{}, err
+		}
+	}
+	err = v1alpha2.NewCOAError(nil, fmt.Sprintf("entry '%s' is not found", getRequest.ID), v1alpha2.NotFound)
+	return states.StateEntry{}, err
+}
+
+func (m *MemoryStateProviderFail) List(context.Context, states.ListRequest) ([]states.StateEntry, string, error) {
+	if (m.Data == nil) || (len(m.Data) == 0) {
+		return nil, "", assert.AnError
+	}
+	var entities []states.StateEntry
+	for _, v := range m.Data {
+		vE, ok := v.(states.StateEntry)
+		if ok {
+			entities = append(entities, vE)
+		} else {
+			parseErr := v1alpha2.NewCOAError(nil, "found invalid state entry", v1alpha2.InternalError)
+			return entities, "", parseErr
+		}
+	}
+	return entities, "", nil
+}
+
+func (m *MemoryStateProviderFail) SetContext(context *contexts.ManagerContext) {
+}

--- a/api/pkg/apis/v1alpha1/managers/skills/skills-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/skills/skills-manager.go
@@ -57,7 +57,7 @@ func (t *SkillsManager) DeleteSpec(ctx context.Context, name string) error {
 		},
 	})
 	if err != nil {
-		log.Debugf(" M (Skills): failed to DeleteSpec, name: %s, err: %v, traceId: %s", name, err, span.SpanContext().TraceID().String())
+		log.Errorf(" M (Skills): failed to DeleteSpec, name: %s, err: %v, traceId: %s", name, err, span.SpanContext().TraceID().String())
 	}
 	return err
 }
@@ -92,7 +92,7 @@ func (t *SkillsManager) UpsertSpec(ctx context.Context, name string, spec model.
 	}
 	_, err = t.StateProvider.Upsert(ctx, upsertRequest)
 	if err != nil {
-		log.Debugf(" M (Skills): failed to UpsertSpec, name: %s, err: %v, traceId: %s", name, err, span.SpanContext().TraceID().String())
+		log.Errorf(" M (Skills): failed to UpsertSpec, name: %s, err: %v, traceId: %s", name, err, span.SpanContext().TraceID().String())
 		return err
 	}
 	return nil
@@ -115,7 +115,7 @@ func (t *SkillsManager) ListSpec(ctx context.Context) ([]model.SkillState, error
 	}
 	models, _, err := t.StateProvider.List(ctx, listRequest)
 	if err != nil {
-		log.Debugf(" M (Skills): failed to ListSpec, err: %v, traceId: %s", err, span.SpanContext().TraceID().String())
+		log.Errorf(" M (Skills): failed to ListSpec, err: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 		return nil, err
 	}
 	ret := make([]model.SkillState, 0)
@@ -123,7 +123,7 @@ func (t *SkillsManager) ListSpec(ctx context.Context) ([]model.SkillState, error
 		var rt model.SkillState
 		rt, err = getSkillState(t.ID, t.Body, t.ETag)
 		if err != nil {
-			log.Debugf(" M (Models): failed to getSkillState, err: %v, traceId: %s", err, span.SpanContext().TraceID().String())
+			log.Errorf(" M (Models): failed to getSkillState, err: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 			return nil, err
 		}
 		ret = append(ret, rt)
@@ -167,13 +167,13 @@ func (t *SkillsManager) GetSpec(ctx context.Context, id string) (model.SkillStat
 	}
 	m, err := t.StateProvider.Get(ctx, getRequest)
 	if err != nil {
-		log.Debugf(" M (Skills): failed to GetSpec, name: %s, err: %v, traceId: %s", id, err, span.SpanContext().TraceID().String())
+		log.Errorf(" M (Skills): failed to GetSpec, name: %s, err: %v, traceId: %s", id, err, span.SpanContext().TraceID().String())
 		return model.SkillState{}, err
 	}
 
 	ret, err := getSkillState(id, m.Body, m.ETag)
 	if err != nil {
-		log.Debugf(" M (Skills): failed to getSkillState, name: %s, err: %v, traceId: %s", id, err, span.SpanContext().TraceID().String())
+		log.Errorf(" M (Skills): failed to getSkillState, name: %s, err: %v, traceId: %s", id, err, span.SpanContext().TraceID().String())
 		return model.SkillState{}, err
 	}
 	return ret, nil

--- a/api/pkg/apis/v1alpha1/managers/skills/skills-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/skills/skills-manager_test.go
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package skills
+
+import (
+	"context"
+	"testing"
+
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInit(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	err := stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	assert.Nil(t, err)
+
+	manager := SkillsManager{}
+	err = manager.Init(nil, managers.ManagerConfig{
+		Properties: map[string]string{
+			"providers.state": "memory-state",
+		},
+	}, map[string]providers.IProvider{
+		"memory-state": stateProvider,
+	})
+	assert.Nil(t, err)
+}
+
+func TestInitFail(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	err := stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	assert.Nil(t, err)
+
+	manager := SkillsManager{}
+	err = manager.Init(nil, managers.ManagerConfig{
+		Properties: map[string]string{
+			"providers.state": "memory-state-fail",
+		},
+	}, map[string]providers.IProvider{
+		"memory-state": stateProvider,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestUpsertAndDeleteSpec(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	err := stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	assert.Nil(t, err)
+
+	manager := SkillsManager{}
+	err = manager.Init(nil, managers.ManagerConfig{
+		Properties: map[string]string{
+			"providers.state": "memory-state",
+		},
+	}, map[string]providers.IProvider{
+		"memory-state": stateProvider,
+	})
+	assert.Nil(t, err)
+
+	err = manager.UpsertSpec(context.Background(), "test", model.SkillSpec{
+		Parameters: map[string]string{
+			"a": "default-a",
+			"c": "default-c",
+		},
+		Nodes: []model.NodeSpec{
+			{
+				Id: "1",
+				Configurations: map[string]string{
+					"v-a": "$param(a)",
+					"v-c": "$param(c)",
+				},
+			},
+		},
+	})
+	assert.Nil(t, err)
+
+	err = manager.DeleteSpec(context.Background(), "test")
+	assert.Nil(t, err)
+}
+
+func TestUpsertAndListSpec(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	err := stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	assert.Nil(t, err)
+
+	manager := SkillsManager{}
+	err = manager.Init(nil, managers.ManagerConfig{
+		Properties: map[string]string{
+			"providers.state": "memory-state",
+		},
+	}, map[string]providers.IProvider{
+		"memory-state": stateProvider,
+	})
+	assert.Nil(t, err)
+
+	err = manager.UpsertSpec(context.Background(), "test", model.SkillSpec{
+		Parameters: map[string]string{
+			"a": "default-a",
+			"c": "default-c",
+		},
+		Nodes: []model.NodeSpec{
+			{
+				Id: "1",
+				Configurations: map[string]string{
+					"v-a": "$param(a)",
+					"v-c": "$param(c)",
+				},
+			},
+		},
+	})
+	assert.Nil(t, err)
+
+	skills, err := manager.ListSpec(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(skills))
+	assert.Equal(t, "test", skills[0].Id)
+	assert.Equal(t, "default-a", skills[0].Spec.Parameters["a"])
+	assert.Equal(t, "default-c", skills[0].Spec.Parameters["c"])
+}
+
+func TestUpsertAndGetSpec(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	err := stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	assert.Nil(t, err)
+
+	manager := SkillsManager{}
+	err = manager.Init(nil, managers.ManagerConfig{
+		Properties: map[string]string{
+			"providers.state": "memory-state",
+		},
+	}, map[string]providers.IProvider{
+		"memory-state": stateProvider,
+	})
+	assert.Nil(t, err)
+
+	err = manager.UpsertSpec(context.Background(), "test", model.SkillSpec{
+		Parameters: map[string]string{
+			"a": "default-a",
+			"c": "default-c",
+		},
+		Nodes: []model.NodeSpec{
+			{
+				Id: "1",
+				Configurations: map[string]string{
+					"v-a": "$param(a)",
+					"v-c": "$param(c)",
+				},
+			},
+		},
+	})
+	assert.Nil(t, err)
+
+	skill, err := manager.GetSpec(context.Background(), "test")
+	assert.Nil(t, err)
+	assert.Equal(t, "test", skill.Id)
+	assert.Equal(t, "default-a", skill.Spec.Parameters["a"])
+	assert.Equal(t, "default-c", skill.Spec.Parameters["c"])
+}

--- a/api/pkg/apis/v1alpha1/managers/sync/sync-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/sync/sync-manager_test.go
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package sync
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/pubsub/memory"
+	coa_utils "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/utils"
+	"github.com/eclipse-symphony/symphony/coa/pkg/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInit(t *testing.T) {
+	manager := SyncManager{}
+	managerVendorContext := &contexts.VendorContext{
+		EvaluationContext: &coa_utils.EvaluationContext{},
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+		},
+		Logger: logger.NewLogger("coa.runtime"),
+	}
+	err := manager.Init(managerVendorContext, managers.ManagerConfig{}, nil)
+	assert.Nil(t, err)
+}
+
+func TestInitWithoutSiteIdFail(t *testing.T) {
+	manager := SyncManager{}
+	managerVendorContext := &contexts.VendorContext{
+		EvaluationContext: &coa_utils.EvaluationContext{},
+		Logger:            logger.NewLogger("coa.runtime"),
+	}
+	err := manager.Init(managerVendorContext, managers.ManagerConfig{}, nil)
+	assert.NotNil(t, err)
+	coaError := err.(v1alpha2.COAError)
+	assert.Equal(t, "siteId is required", coaError.Message)
+	assert.Equal(t, v1alpha2.BadConfig, coaError.State)
+}
+
+func TestEnabled(t *testing.T) {
+	manager := SyncManager{}
+	managerVendorContext := &contexts.VendorContext{
+		EvaluationContext: &coa_utils.EvaluationContext{},
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+		},
+		Logger: logger.NewLogger("coa.runtime"),
+	}
+	err := manager.Init(managerVendorContext, managers.ManagerConfig{
+		Properties: map[string]string{
+			"sync.enabled": "true",
+		},
+	}, nil)
+	assert.Nil(t, err)
+
+	assert.True(t, manager.Enabled())
+}
+
+func TestReconcil(t *testing.T) {
+	manager := SyncManager{}
+	managerVendorContext := &contexts.VendorContext{
+		EvaluationContext: &coa_utils.EvaluationContext{},
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+		},
+		Logger: logger.NewLogger("coa.runtime"),
+	}
+	err := manager.Init(managerVendorContext, managers.ManagerConfig{
+		Properties: map[string]string{
+			"sync.enabled": "true",
+		},
+	}, nil)
+	assert.Nil(t, err)
+
+	errs := manager.Reconcil()
+	assert.Nil(t, errs)
+}
+
+type AuthResponse struct {
+	AccessToken string   `json:"accessToken"`
+	TokenType   string   `json:"tokenType"`
+	Username    string   `json:"username"`
+	Roles       []string `json:"roles"`
+}
+
+func InitiazlizeMockSymphonyAPI(siteId string) *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var response interface{}
+		fmt.Println("Mock Symphony API called", "path", r.URL.Path)
+		switch r.URL.Path {
+		case "/federation/sync/" + siteId:
+			response = model.SyncPackage{
+				Jobs: []v1alpha2.JobData{
+					{
+						Id:     "job1",
+						Action: "UPDATE",
+					},
+				},
+				Catalogs: []model.CatalogSpec{
+					{
+						SiteId: "parent",
+						Name:   "catalog1",
+						Type:   "Instance",
+						Properties: map[string]interface{}{
+							"foo": "bar",
+						},
+						Metadata: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+				Origin: "batch-origin",
+			}
+		case "/users/auth":
+			response = AuthResponse{
+				AccessToken: "test-token",
+				TokenType:   "Bearer",
+				Username:    "test-user",
+				Roles:       []string{"role1", "role2"},
+			}
+		}
+
+		json.NewEncoder(w).Encode(response)
+	}))
+	return ts
+}
+
+func TestPoll(t *testing.T) {
+	siteId := "fake"
+	ts := InitiazlizeMockSymphonyAPI(siteId)
+	defer ts.Close()
+	_, err := url.Parse(ts.URL)
+	assert.Nil(t, err)
+
+	manager := SyncManager{}
+	vendorContext := &contexts.VendorContext{
+		EvaluationContext: &coa_utils.EvaluationContext{},
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: siteId,
+			ParentSite: v1alpha2.SiteConnection{
+				BaseUrl:  ts.URL + "/",
+				Username: "admin",
+				Password: "",
+			},
+		},
+		Logger: logger.NewLogger("coa.runtime"),
+	}
+	vendorContext.PubsubProvider = &memory.InMemoryPubSubProvider{}
+	vendorContext.PubsubProvider.Init(memory.InMemoryPubSubConfig{})
+	err = manager.Init(vendorContext, managers.ManagerConfig{
+		Properties: map[string]string{
+			"sync.enabled": "true",
+		},
+	}, nil)
+	assert.Nil(t, err)
+
+	sig1 := make(chan int)
+	sig2 := make(chan int)
+	catalog1 := model.CatalogSpec{}
+	job1 := v1alpha2.JobData{}
+	// validate that the sync package was published
+	catalogCnt := 0
+	vendorContext.Subscribe("catalog-sync", func(topic string, event v1alpha2.Event) error {
+		catalogCnt++
+		jobData := event.Body.(v1alpha2.JobData)
+		catalog1 = jobData.Body.(model.CatalogSpec)
+		sig1 <- 1
+		return nil
+	})
+	jobCount := 0
+	vendorContext.Subscribe("remote-job", func(topic string, event v1alpha2.Event) error {
+		jobCount++
+		job1 = event.Body.(v1alpha2.JobData)
+		sig2 <- 1
+		return nil
+	})
+
+	errs := manager.Poll()
+	assert.Nil(t, errs)
+
+	<-sig1
+	<-sig2
+	assert.Equal(t, 1, catalogCnt)
+	assert.Equal(t, 1, jobCount)
+	assert.Equal(t, "catalog1", catalog1.Name)
+	assert.Equal(t, "job1", job1.Id)
+}

--- a/api/pkg/apis/v1alpha1/managers/trails/trails-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/trails/trails-manager_test.go
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package trails
+
+import (
+	"context"
+	"testing"
+
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
+	mockledger "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/ledger/mock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInit(t *testing.T) {
+	ledgerProvider := &mockledger.MockLedgerProvider{}
+	err := ledgerProvider.Init(mockledger.MockLedgerProviderConfig{})
+	assert.Nil(t, err)
+	providers := make(map[string]providers.IProvider)
+	providers["MockLedgerProvider"] = ledgerProvider
+	manager := TrailsManager{}
+	config := managers.ManagerConfig{
+		Properties: map[string]string{},
+	}
+	err = manager.Init(nil, config, providers)
+	assert.Nil(t, err)
+}
+
+func TestAppend(t *testing.T) {
+	ledgerProvider := &mockledger.MockLedgerProvider{}
+	err := ledgerProvider.Init(mockledger.MockLedgerProviderConfig{})
+	assert.Nil(t, err)
+	providers := make(map[string]providers.IProvider)
+	providers["MockLedgerProvider"] = ledgerProvider
+	manager := TrailsManager{}
+	config := managers.ManagerConfig{
+		Properties: map[string]string{},
+	}
+	err = manager.Init(nil, config, providers)
+	assert.Nil(t, err)
+	err = manager.Append(context.Background(), nil)
+	assert.Nil(t, err)
+}
+
+func TestAppendFail(t *testing.T) {
+	ledgerProvider := &MockLedgerProviderFail{}
+	err := ledgerProvider.Init(mockledger.MockLedgerProviderConfig{})
+	assert.Nil(t, err)
+	providers := make(map[string]providers.IProvider)
+	providers["MockLedgerProviderFail"] = ledgerProvider
+	manager := TrailsManager{}
+	config := managers.ManagerConfig{
+		Properties: map[string]string{},
+	}
+	err = manager.Init(nil, config, providers)
+	assert.Nil(t, err)
+	err = manager.Append(context.Background(), nil)
+	assert.NotNil(t, err)
+	coaError := err.(v1alpha2.COAError)
+	assert.Equal(t, v1alpha2.InternalError, coaError.State)
+	assert.Equal(t, assert.AnError.Error()+";", coaError.Message)
+}
+
+type MockLedgerProviderFail struct {
+}
+
+func (m *MockLedgerProviderFail) Init(config providers.IProviderConfig) error {
+	return nil
+}
+
+func (m *MockLedgerProviderFail) Append(ctx context.Context, trails []v1alpha2.Trail) error {
+	// always return error
+	return assert.AnError
+}

--- a/api/pkg/apis/v1alpha1/model/campaign.go
+++ b/api/pkg/apis/v1alpha1/model/campaign.go
@@ -142,9 +142,6 @@ func (c CampaignSpec) DeepEquals(other IDeepEquals) (bool, error) {
 		return false, nil
 	}
 
-	if len(c.Stages) != len(otherC.Stages) {
-		return false, nil
-	}
 	for i, stage := range c.Stages {
 		otherStage := otherC.Stages[i]
 

--- a/api/pkg/apis/v1alpha1/model/campaign_test.go
+++ b/api/pkg/apis/v1alpha1/model/campaign_test.go
@@ -9,15 +9,52 @@ package model
 import (
 	"testing"
 
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCampaignMatch(t *testing.T) {
 	campaign1 := CampaignSpec{
-		Name: "name",
+		Name:        "name",
+		FirstStage:  "list",
+		SelfDriving: true,
+		Stages: map[string]StageSpec{
+			"list": {
+				Name:          "list",
+				Provider:      "providers.stage.list",
+				StageSelector: "wait-sync",
+				Config: map[string]interface{}{
+					"baseUrl":  "http://symphony-service:8080/v1alpha2/",
+					"user":     "admin",
+					"password": "",
+				},
+				Inputs: map[string]interface{}{
+					"objectType":  "sites",
+					"namesObject": true,
+				},
+			},
+		},
 	}
 	campaign2 := CampaignSpec{
-		Name: "name",
+		Name:        "name",
+		FirstStage:  "list",
+		SelfDriving: true,
+		Stages: map[string]StageSpec{
+			"list": {
+				Name:          "list",
+				Provider:      "providers.stage.list",
+				StageSelector: "wait-sync",
+				Config: map[string]interface{}{
+					"baseUrl":  "http://symphony-service:8080/v1alpha2/",
+					"user":     "admin",
+					"password": "",
+				},
+				Inputs: map[string]interface{}{
+					"objectType":  "sites",
+					"namesObject": true,
+				},
+			},
+		},
 	}
 	equal, err := campaign1.DeepEquals(campaign2)
 	assert.Nil(t, err)
@@ -33,7 +70,7 @@ func TestCampaignMatchOneEmpty(t *testing.T) {
 	assert.False(t, res)
 }
 
-func TestCampaignRoleNotMatch(t *testing.T) {
+func TestCampaignNameNotMatch(t *testing.T) {
 	campaign1 := CampaignSpec{
 		Name: "name",
 	}
@@ -41,6 +78,262 @@ func TestCampaignRoleNotMatch(t *testing.T) {
 		Name: "name1",
 	}
 	equal, err := campaign1.DeepEquals(campaign2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+}
+
+func TestCampaignFirstStageNotMatch(t *testing.T) {
+	campaign1 := CampaignSpec{
+		Name:       "name",
+		FirstStage: "list",
+	}
+	campaign2 := CampaignSpec{
+		Name:       "name",
+		FirstStage: "list1",
+	}
+	equal, err := campaign1.DeepEquals(campaign2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+}
+
+func TestCampaignSelfDrivingNotMatch(t *testing.T) {
+	campaign1 := CampaignSpec{
+		Name:        "name",
+		FirstStage:  "list",
+		SelfDriving: true,
+	}
+	campaign2 := CampaignSpec{
+		Name:        "name",
+		FirstStage:  "list",
+		SelfDriving: false,
+	}
+	equal, err := campaign1.DeepEquals(campaign2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+}
+
+func TestCampaignStagesLengthNotMatch(t *testing.T) {
+	campaign1 := CampaignSpec{
+		Name:        "name",
+		FirstStage:  "mock1",
+		SelfDriving: true,
+		Stages: map[string]StageSpec{
+			"mock1": {
+				Name:     "mock1",
+				Provider: "providers.stage.mock",
+			},
+		},
+	}
+	campaign2 := CampaignSpec{
+		Name:        "name",
+		FirstStage:  "mock1",
+		SelfDriving: true,
+		Stages: map[string]StageSpec{
+			"mock1": {
+				Name:     "mock1",
+				Provider: "providers.stage.mock",
+			},
+			"mock2": {
+				Name:     "mock2",
+				Provider: "providers.stage.mock",
+			},
+		},
+	}
+	equal, err := campaign1.DeepEquals(campaign2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+}
+
+func TestCampaignStagesNotMatch(t *testing.T) {
+	campaign1 := CampaignSpec{
+		Name:        "name",
+		FirstStage:  "mock1",
+		SelfDriving: true,
+		Stages: map[string]StageSpec{
+			"mock1": {
+				Name:     "mock1",
+				Provider: "providers.stage.mock",
+			},
+		},
+	}
+	campaign2 := CampaignSpec{
+		Name:        "name",
+		FirstStage:  "mock1",
+		SelfDriving: true,
+		Stages: map[string]StageSpec{
+			"mock1": {
+				Name:     "mock1",
+				Provider: "providers.stage.mockv2",
+			},
+		},
+	}
+	equal, err := campaign1.DeepEquals(campaign2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+}
+
+func TestStageNotMatch(t *testing.T) {
+	stage1 := StageSpec{
+		Name: "mock1",
+	}
+	stage2 := StageSpec{
+		Name: "mock1",
+	}
+
+	// name not match
+	stage2.Name = "mock2"
+	equal, err := stage1.DeepEquals(stage2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// provider not match
+	stage2.Name = "mock1"
+	stage1.Provider = "providers.stage.mock"
+	stage2.Provider = "providers.stage.mockv2"
+	equal, err = stage1.DeepEquals(stage2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// stageSelector not match
+	stage2.Provider = "providers.stage.mock"
+	stage1.StageSelector = "wait-sync"
+	stage2.StageSelector = "wait-syncv2"
+	equal, err = stage1.DeepEquals(stage2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// config not match
+	stage2.StageSelector = "wait-sync"
+	stage1.Config = map[string]interface{}{
+		"baseUrl":  "http://symphony-service:8080/v1alpha2/",
+		"user":     "admin",
+		"password": "",
+	}
+	stage2.Config = map[string]interface{}{
+		"baseUrl":  "http://symphony-service:8888/v1alpha2/",
+		"user":     "admin",
+		"password": "",
+	}
+	equal, err = stage1.DeepEquals(stage2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// inputs not match
+	stage2.Config = map[string]interface{}{
+		"baseUrl":  "http://symphony-service:8080/v1alpha2/",
+		"user":     "admin",
+		"password": "",
+	}
+	stage1.Inputs = map[string]interface{}{
+		"objectType":  "sites",
+		"namesObject": true,
+	}
+	stage2.Inputs = map[string]interface{}{
+		"objectType":  "sites",
+		"namesObject": false,
+	}
+	equal, err = stage1.DeepEquals(stage2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// schedule not match
+	stage2.Inputs = map[string]interface{}{
+		"objectType":  "sites",
+		"namesObject": true,
+	}
+	stage1.Schedule = &v1alpha2.ScheduleSpec{
+		Date: "2020-10-31",
+		Time: "12:00:00PM",
+		Zone: "PDT",
+	}
+	stage2.Schedule = &v1alpha2.ScheduleSpec{
+		Date: "2020-10-31",
+		Time: "12:00:00PM",
+		Zone: "PST",
+	}
+	equal, err = stage1.DeepEquals(stage2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+}
+
+func TestStageMatchOneEmpty(t *testing.T) {
+	stage1 := StageSpec{
+		Name: "name",
+	}
+	res, err := stage1.DeepEquals(nil)
+	assert.Errorf(t, err, "parameter is not a StageSpec type")
+	assert.False(t, res)
+}
+
+func TestActivationMatchOneEmpty(t *testing.T) {
+	activation1 := ActivationSpec{
+		Name: "name",
+	}
+	res, err := activation1.DeepEquals(nil)
+	assert.Errorf(t, err, "parameter is not a ActivationSpec type")
+	assert.False(t, res)
+}
+
+func TestActivationMatch(t *testing.T) {
+	activation1 := ActivationSpec{
+		Name:     "multisite-deploy",
+		Campaign: "site-apps",
+		Stage:    "deploy",
+		Inputs: map[string]interface{}{
+			"site": "site1",
+		},
+	}
+	activation2 := ActivationSpec{
+		Name:     "multisite-deploy",
+		Campaign: "site-apps",
+		Stage:    "deploy",
+		Inputs: map[string]interface{}{
+			"site": "site1",
+		},
+	}
+	equal, err := activation1.DeepEquals(activation2)
+	assert.Nil(t, err)
+	assert.True(t, equal)
+}
+
+func TestActivationNotMatch(t *testing.T) {
+	activation1 := ActivationSpec{
+		Name: "multisite-deploy",
+	}
+	activation2 := ActivationSpec{
+		Name: "multisite-deploy2",
+	}
+
+	// name not match
+	equal, err := activation1.DeepEquals(activation2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// compaign not match
+	activation2.Name = "multisite-deploy"
+	activation1.Campaign = "site-apps"
+	activation2.Campaign = "site-apps2"
+	equal, err = activation1.DeepEquals(activation2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// stage not match
+	activation2.Campaign = "site-apps"
+	activation1.Stage = "deploy"
+	activation2.Stage = "deploy2"
+	equal, err = activation1.DeepEquals(activation2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// inputs not match
+	activation2.Stage = "deploy"
+	activation1.Inputs = map[string]interface{}{
+		"site": "site1",
+	}
+	activation2.Inputs = map[string]interface{}{
+		"site": "site2",
+	}
+	equal, err = activation1.DeepEquals(activation2)
 	assert.Nil(t, err)
 	assert.False(t, equal)
 }

--- a/api/pkg/apis/v1alpha1/model/catalog_test.go
+++ b/api/pkg/apis/v1alpha1/model/catalog_test.go
@@ -28,3 +28,166 @@ func TestIntefaceConvertion(t *testing.T) {
 	var iNode v1alpha2.INode = val.(v1alpha2.INode)
 	assert.NotNil(t, iNode)
 }
+func TestCatalogMatch(t *testing.T) {
+	catalog1 := CatalogSpec{
+		Name:       "name",
+		SiteId:     "siteId",
+		ParentName: "parentName",
+		Generation: "1",
+		Properties: map[string]interface{}{
+			"key": "value",
+		},
+	}
+	catalog2 := CatalogSpec{
+		Name:       "name",
+		SiteId:     "siteId",
+		ParentName: "parentName",
+		Generation: "1",
+		Properties: map[string]interface{}{
+			"key": "value",
+		},
+	}
+	equal, err := catalog1.DeepEquals(catalog2)
+	assert.Nil(t, err)
+	assert.True(t, equal)
+}
+
+func TestCatalogMatchOneEmpty(t *testing.T) {
+	catalog1 := CatalogSpec{
+		Name: "name",
+		Type: "type",
+		Properties: map[string]interface{}{
+			"key": "value",
+		},
+	}
+	res, err := catalog1.DeepEquals(nil)
+	assert.Errorf(t, err, "parameter is not a CatalogSpec type")
+	assert.False(t, res)
+}
+
+func TestCatalogNotMatch(t *testing.T) {
+	catalog1 := CatalogSpec{
+		Name: "name",
+	}
+	catalog2 := CatalogSpec{
+		Name: "name2",
+	}
+
+	// name not match
+	equal, err := catalog1.DeepEquals(catalog2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// siteId not match
+	catalog2.Name = "name"
+	catalog1.SiteId = "siteId"
+	catalog2.SiteId = "siteId2"
+	equal, err = catalog1.DeepEquals(catalog2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// parentName not match
+	catalog2.SiteId = "siteId"
+	catalog1.ParentName = "parentName"
+	catalog2.ParentName = "parentName2"
+	equal, err = catalog1.DeepEquals(catalog2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// generation not match
+	catalog2.ParentName = "parentName"
+	catalog1.Generation = "1"
+	catalog2.Generation = "2"
+	equal, err = catalog1.DeepEquals(catalog2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// properties not match
+	catalog2.Generation = "1"
+	catalog1.Properties = map[string]interface{}{
+		"key": "value",
+	}
+	catalog2.Properties = map[string]interface{}{
+		"key": "value2",
+	}
+	equal, err = catalog1.DeepEquals(catalog2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+}
+
+func TestGetId(t *testing.T) {
+	catalog := CatalogState{
+		Id: "id",
+	}
+	assert.Equal(t, catalog.GetId(), "id")
+}
+
+func TestGetParent(t *testing.T) {
+	catalog := CatalogState{
+		Spec: &CatalogSpec{
+			ParentName: "parent",
+		},
+	}
+	assert.Equal(t, catalog.GetParent(), "parent")
+
+	catalog.Spec = nil
+	assert.Equal(t, catalog.GetParent(), "")
+}
+
+func TestGetProperties(t *testing.T) {
+	catalog := CatalogState{
+		Spec: &CatalogSpec{
+			Properties: map[string]interface{}{
+				"key": "value",
+			},
+		},
+	}
+	assert.Equal(t, catalog.GetProperties(), map[string]interface{}{
+		"key": "value",
+	})
+
+	catalog.Spec = nil
+	assert.Equal(t, catalog.GetProperties(), map[string]interface{}(nil))
+}
+
+func TestGetType(t *testing.T) {
+	catalog := CatalogState{
+		Spec: &CatalogSpec{
+			Type: "type",
+		},
+	}
+	assert.Equal(t, catalog.GetType(), "type")
+
+	catalog.Spec = nil
+	assert.Equal(t, catalog.GetType(), "")
+}
+
+func TestGetFrom(t *testing.T) {
+	catalog := CatalogState{
+		Spec: &CatalogSpec{
+			Type: "edge",
+			Metadata: map[string]string{
+				"from": "from",
+			},
+		},
+	}
+	assert.Equal(t, catalog.GetFrom(), "from")
+
+	catalog.Spec = nil
+	assert.Equal(t, catalog.GetFrom(), "")
+}
+
+func TestGetTo(t *testing.T) {
+	catalog := CatalogState{
+		Spec: &CatalogSpec{
+			Type: "edge",
+			Metadata: map[string]string{
+				"to": "to",
+			},
+		},
+	}
+	assert.Equal(t, catalog.GetTo(), "to")
+
+	catalog.Spec = nil
+	assert.Equal(t, catalog.GetTo(), "")
+}

--- a/api/pkg/apis/v1alpha1/model/component_test.go
+++ b/api/pkg/apis/v1alpha1/model/component_test.go
@@ -146,3 +146,57 @@ func TestComponentNestedDeepNotEqual(t *testing.T) {
 	assert.Nil(t, err)
 	assert.False(t, equal)
 }
+
+func TestComponentDeepEqualEmpty(t *testing.T) {
+	component1 := ComponentSpec{
+		Name: "symphony-agent",
+	}
+	res, err := component1.DeepEquals(nil)
+	assert.Errorf(t, err, "parameter is not a ComponentSpec type")
+	assert.False(t, res)
+}
+
+func TestComponentDeepNotEqualMetadata(t *testing.T) {
+	c1 := ComponentSpec{
+		Name: "symphony-agent",
+		Metadata: map[string]string{
+			"key1": "value1",
+		},
+		Properties: map[string]interface{}{
+			"container.createOptions": "",
+			ContainerImage:            "ghcr.io/eclipse-symphony/symphony-agent:0.39.9",
+			"container.restartPolicy": "always",
+			"container.type":          "docker",
+			"container.version":       "1.0",
+			"env.AZURE_CLIENT_ID":     "\\u003cSP App ID\\u003e",
+			"env.AZURE_TENANT_ID":     "\\u003cSP Tenant ID\\u003e",
+			"env.STORAGE_ACCOUNT":     "voestore",
+			"env.STORAGE_CONTAINER":   "snapshots",
+			"env.SYMPHONY_URL":        "http://20.118.178.8:8080/v1alpha2/agent/references",
+			"env.TARGET_NAME":         "symphony-k8s-target",
+		},
+	}
+	c2 := ComponentSpec{
+		Name: "symphony-agent",
+		Metadata: map[string]string{
+			"key1": "value2", // difference is here!
+		},
+		Properties: map[string]interface{}{
+			"container.createOptions": "",
+			ContainerImage:            "ghcr.io/eclipse-symphony/symphony-agent:0.39.9",
+			"container.restartPolicy": "always",
+			"container.type":          "docker",
+			"container.version":       "1.0",
+			"env.AZURE_CLIENT_ID":     "\\u003cSP App ID\\u003e",
+			"env.AZURE_TENANT_ID":     "\\u003cSP Tenant ID\\u003e",
+			"env.STORAGE_ACCOUNT":     "voestore",
+			"env.STORAGE_CONTAINER":   "snapshots",
+			"env.SYMPHONY_URL":        "http://20.118.178.8:8080/v1alpha2/agent/references",
+			"env.TARGET_NAME":         "symphony-k8s-target",
+		},
+	}
+
+	equal, err := c1.DeepEquals(c2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+}

--- a/api/pkg/apis/v1alpha1/model/deployment_test.go
+++ b/api/pkg/apis/v1alpha1/model/deployment_test.go
@@ -276,7 +276,7 @@ func TestDeploymentDeepEqualsTargetsNotMatch(t *testing.T) {
 	deployment2 := DeploymentSpec{
 		SolutionName: "SolutionName",
 		Solution: SolutionSpec{
-			DisplayName: "SolutionDisplayName1",
+			DisplayName: "SolutionDisplayName",
 		},
 		Instance: InstanceSpec{
 			Name: "InstanceName",
@@ -536,14 +536,90 @@ func TestGetComponentSliceWithValues(t *testing.T) {
 	assert.Equal(t, 1, len(res))
 }
 
-func TestMapsEqual(t *testing.T) {
+func TestDeploymentDeepEqualsAssignmentsNotMatch(t *testing.T) {
+	deployment1 := DeploymentSpec{
+		SolutionName: "SolutionName",
+		Solution: SolutionSpec{
+			DisplayName: "SolutionDisplayName",
+		},
+		Instance: InstanceSpec{
+			Name: "InstanceName",
+		},
+		Targets: map[string]TargetSpec{
+			"foo": {
+				DisplayName: "TargetName",
+			},
+		},
+		Devices: []DeviceSpec{{
+			DisplayName: "DeviceName",
+		}},
+		Assignments: map[string]string{
+			"foo": "bar",
+		},
+		ComponentStartIndex: 0,
+		ComponentEndIndex:   0,
+		ActiveTarget:        "ActiveTarget",
+	}
+	deployment2 := DeploymentSpec{
+		SolutionName: "SolutionName",
+		Solution: SolutionSpec{
+			DisplayName: "SolutionDisplayName",
+		},
+		Instance: InstanceSpec{
+			Name: "InstanceName",
+		},
+		Targets: map[string]TargetSpec{
+			"foo": {
+				DisplayName: "TargetName",
+			},
+		},
+		Devices: []DeviceSpec{{
+			DisplayName: "DeviceName",
+		}},
+		Assignments: map[string]string{
+			"foo": "bar1",
+		},
+		ComponentStartIndex: 0,
+		ComponentEndIndex:   0,
+		ActiveTarget:        "ActiveTarget",
+	}
+	res, err := deployment1.DeepEquals(deployment2)
+	assert.Nil(t, err)
+	assert.False(t, res)
+}
+
+func TestMapsEqualMap1Extra(t *testing.T) {
 	map1 := map[string]TargetSpec{
 		"foo": {
 			DisplayName: "TargetName",
 		},
 	}
+	map2 := map[string]TargetSpec{}
+	res := mapsEqual(map1, map2, nil)
+	assert.False(t, res)
+}
+
+func TestMapsNotEqualMap2Extra(t *testing.T) {
+	map1 := map[string]TargetSpec{}
 	map2 := map[string]TargetSpec{
-		"foo": {},
+		"foo": {
+			DisplayName: "TargetName",
+		},
+	}
+	res := mapsEqual(map1, map2, nil)
+	assert.False(t, res)
+}
+
+func TestMapsNotEqual(t *testing.T) {
+	map2 := map[string]TargetSpec{
+		"foo": {
+			DisplayName: "TargetName",
+		},
+	}
+	map1 := map[string]TargetSpec{
+		"foo": {
+			DisplayName: "TargetName1",
+		},
 	}
 	res := mapsEqual(map1, map2, nil)
 	assert.False(t, res)

--- a/api/pkg/apis/v1alpha1/model/edge.go
+++ b/api/pkg/apis/v1alpha1/model/edge.go
@@ -18,7 +18,7 @@ type (
 )
 
 func (c ConnectionSpec) DeepEquals(other IDeepEquals) (bool, error) {
-	otherSpec, ok := other.(*ConnectionSpec)
+	otherSpec, ok := other.(ConnectionSpec)
 	if !ok {
 		return false, nil
 	}
@@ -31,18 +31,18 @@ func (c ConnectionSpec) DeepEquals(other IDeepEquals) (bool, error) {
 	return true, nil
 }
 func (c EdgeSpec) DeepEquals(other IDeepEquals) (bool, error) {
-	otherSpec, ok := other.(*EdgeSpec)
+	otherSpec, ok := other.(EdgeSpec)
 	if !ok {
 		return false, nil
 	}
-	equal, err := c.Source.DeepEquals(&otherSpec.Source)
+	equal, err := c.Source.DeepEquals(otherSpec.Source)
 	if err != nil {
 		return false, err
 	}
 	if !equal {
 		return false, nil
 	}
-	equal, err = c.Target.DeepEquals(&otherSpec.Target)
+	equal, err = c.Target.DeepEquals(otherSpec.Target)
 	if err != nil {
 		return false, err
 	}

--- a/api/pkg/apis/v1alpha1/model/edge_test.go
+++ b/api/pkg/apis/v1alpha1/model/edge_test.go
@@ -39,10 +39,10 @@ func TestConnectionSpecMatchOneEmpty(t *testing.T) {
 }
 
 func TestConnectionSpecNodeNotMatch(t *testing.T) {
-	conn1 := &ConnectionSpec{
+	conn1 := ConnectionSpec{
 		Node: "node1",
 	}
-	conn2 := &ConnectionSpec{
+	conn2 := ConnectionSpec{
 		Node: "node2",
 	}
 	res, err := conn1.DeepEquals(conn2)
@@ -51,10 +51,10 @@ func TestConnectionSpecNodeNotMatch(t *testing.T) {
 }
 
 func TestConnectionSpecRouteNotMatch(t *testing.T) {
-	conn1 := &ConnectionSpec{
+	conn1 := ConnectionSpec{
 		Route: "route1",
 	}
-	conn2 := &ConnectionSpec{
+	conn2 := ConnectionSpec{
 		Route: "route2",
 	}
 	res, err := conn1.DeepEquals(conn2)
@@ -63,11 +63,11 @@ func TestConnectionSpecRouteNotMatch(t *testing.T) {
 }
 
 func TestConnectionSpecEqual(t *testing.T) {
-	conn1 := &ConnectionSpec{
+	conn1 := ConnectionSpec{
 		Node:  "node",
 		Route: "route",
 	}
-	conn2 := &ConnectionSpec{
+	conn2 := ConnectionSpec{
 		Node:  "node",
 		Route: "route",
 	}
@@ -77,12 +77,12 @@ func TestConnectionSpecEqual(t *testing.T) {
 }
 
 func TestEdgeSpecSourceNotMatch(t *testing.T) {
-	edge1 := &EdgeSpec{
+	edge1 := EdgeSpec{
 		Source: ConnectionSpec{
 			Node: "node1",
 		},
 	}
-	edge2 := &EdgeSpec{
+	edge2 := EdgeSpec{
 		Source: ConnectionSpec{
 			Node: "node2",
 		},
@@ -93,12 +93,12 @@ func TestEdgeSpecSourceNotMatch(t *testing.T) {
 }
 
 func TestEdgeSpecTargetNotMatch(t *testing.T) {
-	edge1 := &EdgeSpec{
+	edge1 := EdgeSpec{
 		Target: ConnectionSpec{
 			Node: "node1",
 		},
 	}
-	edge2 := &EdgeSpec{
+	edge2 := EdgeSpec{
 		Target: ConnectionSpec{
 			Node: "node2",
 		},
@@ -109,7 +109,7 @@ func TestEdgeSpecTargetNotMatch(t *testing.T) {
 }
 
 func TestEdgeSpecEqual(t *testing.T) {
-	edge1 := &EdgeSpec{
+	edge1 := EdgeSpec{
 		Source: ConnectionSpec{
 			Node:  "node1",
 			Route: "route1",
@@ -119,7 +119,7 @@ func TestEdgeSpecEqual(t *testing.T) {
 			Route: "route1",
 		},
 	}
-	edge2 := &EdgeSpec{
+	edge2 := EdgeSpec{
 		Source: ConnectionSpec{
 			Node:  "node1",
 			Route: "route1",
@@ -155,14 +155,14 @@ func TestEdgeArrayEqual(t *testing.T) {
 			Route: "route",
 		},
 	}
-	res, err := e1.DeepEquals(&e2)
+	res, err := e1.DeepEquals(e2)
 	assert.Nil(t, err)
 	assert.True(t, res)
 
-	es1 := make([]*EdgeSpec, 0)
-	es1 = append(es1, &e1)
-	es2 := make([]*EdgeSpec, 0)
-	es2 = append(es2, &e2)
+	es1 := make([]EdgeSpec, 0)
+	es1 = append(es1, e1)
+	es2 := make([]EdgeSpec, 0)
+	es2 = append(es2, e2)
 	res = SlicesEqual(es1, es2)
 	assert.True(t, res)
 }

--- a/api/pkg/apis/v1alpha1/model/edge_test.go
+++ b/api/pkg/apis/v1alpha1/model/edge_test.go
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEdgeMatchOneEmpty(t *testing.T) {
+	edge1 := EdgeSpec{
+		Source: ConnectionSpec{
+			Node:  "node1",
+			Route: "route1",
+		},
+		Target: ConnectionSpec{
+			Node:  "node2",
+			Route: "route1",
+		},
+	}
+	res, err := edge1.DeepEquals(nil)
+	assert.Nil(t, err)
+	assert.False(t, res)
+}
+
+func TestConnectionSpecMatchOneEmpty(t *testing.T) {
+	conn1 := ConnectionSpec{
+		Node:  "node1",
+		Route: "route1",
+	}
+	res, err := conn1.DeepEquals(nil)
+	assert.Nil(t, err)
+	assert.False(t, res)
+}
+
+func TestConnectionSpecNodeNotMatch(t *testing.T) {
+	conn1 := &ConnectionSpec{
+		Node: "node1",
+	}
+	conn2 := &ConnectionSpec{
+		Node: "node2",
+	}
+	res, err := conn1.DeepEquals(conn2)
+	assert.Nil(t, err)
+	assert.False(t, res)
+}
+
+func TestConnectionSpecRouteNotMatch(t *testing.T) {
+	conn1 := &ConnectionSpec{
+		Route: "route1",
+	}
+	conn2 := &ConnectionSpec{
+		Route: "route2",
+	}
+	res, err := conn1.DeepEquals(conn2)
+	assert.Nil(t, err)
+	assert.False(t, res)
+}
+
+func TestConnectionSpecEqual(t *testing.T) {
+	conn1 := &ConnectionSpec{
+		Node:  "node",
+		Route: "route",
+	}
+	conn2 := &ConnectionSpec{
+		Node:  "node",
+		Route: "route",
+	}
+	res, err := conn1.DeepEquals(conn2)
+	assert.Nil(t, err)
+	assert.True(t, res)
+}
+
+func TestEdgeSpecSourceNotMatch(t *testing.T) {
+	edge1 := &EdgeSpec{
+		Source: ConnectionSpec{
+			Node: "node1",
+		},
+	}
+	edge2 := &EdgeSpec{
+		Source: ConnectionSpec{
+			Node: "node2",
+		},
+	}
+	res, err := edge1.DeepEquals(edge2)
+	assert.Nil(t, err)
+	assert.False(t, res)
+}
+
+func TestEdgeSpecTargetNotMatch(t *testing.T) {
+	edge1 := &EdgeSpec{
+		Target: ConnectionSpec{
+			Node: "node1",
+		},
+	}
+	edge2 := &EdgeSpec{
+		Target: ConnectionSpec{
+			Node: "node2",
+		},
+	}
+	res, err := edge1.DeepEquals(edge2)
+	assert.Nil(t, err)
+	assert.False(t, res)
+}
+
+func TestEdgeSpecEqual(t *testing.T) {
+	edge1 := &EdgeSpec{
+		Source: ConnectionSpec{
+			Node:  "node1",
+			Route: "route1",
+		},
+		Target: ConnectionSpec{
+			Node:  "node2",
+			Route: "route1",
+		},
+	}
+	edge2 := &EdgeSpec{
+		Source: ConnectionSpec{
+			Node:  "node1",
+			Route: "route1",
+		},
+		Target: ConnectionSpec{
+			Node:  "node2",
+			Route: "route1",
+		},
+	}
+	res, err := edge1.DeepEquals(edge2)
+	assert.Nil(t, err)
+	assert.True(t, res)
+}
+
+func TestEdgeArrayEqual(t *testing.T) {
+	e1 := EdgeSpec{
+		Source: ConnectionSpec{
+			Node:  "node1",
+			Route: "route",
+		},
+		Target: ConnectionSpec{
+			Node:  "node2",
+			Route: "route",
+		},
+	}
+	e2 := EdgeSpec{
+		Source: ConnectionSpec{
+			Node:  "node1",
+			Route: "route",
+		},
+		Target: ConnectionSpec{
+			Node:  "node2",
+			Route: "route",
+		},
+	}
+	res, err := e1.DeepEquals(&e2)
+	assert.Nil(t, err)
+	assert.True(t, res)
+
+	es1 := make([]*EdgeSpec, 0)
+	es1 = append(es1, &e1)
+	es2 := make([]*EdgeSpec, 0)
+	es2 = append(es2, &e2)
+	res = SlicesEqual(es1, es2)
+	assert.True(t, res)
+}

--- a/api/pkg/apis/v1alpha1/model/filter_test.go
+++ b/api/pkg/apis/v1alpha1/model/filter_test.go
@@ -116,3 +116,18 @@ func TestFilterTypeMultiParameters(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, equal)
 }
+
+func TestFilterEqualOneEmpty(t *testing.T) {
+	filter1 := FilterSpec{
+		Direction: "direction1",
+		Type:      "typ1",
+		Parameters: map[string]string{
+			"foo":     "bar",
+			"another": "value",
+			"third":   "value3",
+		},
+	}
+	res, err := filter1.DeepEquals(nil)
+	assert.Errorf(t, err, "parameter is not a FilterSpec type")
+	assert.False(t, res)
+}

--- a/api/pkg/apis/v1alpha1/model/model.go
+++ b/api/pkg/apis/v1alpha1/model/model.go
@@ -26,7 +26,7 @@ const (
 )
 
 func (c ModelSpec) DeepEquals(other IDeepEquals) (bool, error) {
-	otherModelSpec, ok := other.(*ModelSpec)
+	otherModelSpec, ok := other.(ModelSpec)
 	if !ok {
 		return false, nil
 	}

--- a/api/pkg/apis/v1alpha1/model/model_test.go
+++ b/api/pkg/apis/v1alpha1/model/model_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestModelEqual(t *testing.T) {
-	model1 := &ModelSpec{
+	model1 := ModelSpec{
 		DisplayName: "model",
 		Properties: map[string]string{
 			"foo": "bar",
@@ -29,7 +29,7 @@ func TestModelEqual(t *testing.T) {
 			},
 		},
 	}
-	model2 := &ModelSpec{
+	model2 := ModelSpec{
 		DisplayName: "model",
 		Properties: map[string]string{
 			"foo": "bar",
@@ -53,7 +53,7 @@ func TestModelEqual(t *testing.T) {
 
 func TestModelNotEqual(t *testing.T) {
 	// Test empty
-	model1 := &ModelSpec{
+	model1 := ModelSpec{
 		DisplayName: "model",
 	}
 	equal, err := model1.DeepEquals(nil)
@@ -61,7 +61,7 @@ func TestModelNotEqual(t *testing.T) {
 	assert.False(t, equal)
 
 	// Test DisplayName not equal
-	model2 := &ModelSpec{
+	model2 := ModelSpec{
 		DisplayName: "model2",
 	}
 	equal, err = model1.DeepEquals(model2)

--- a/api/pkg/apis/v1alpha1/model/model_test.go
+++ b/api/pkg/apis/v1alpha1/model/model_test.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModelEqual(t *testing.T) {
+	model1 := &ModelSpec{
+		DisplayName: "model",
+		Properties: map[string]string{
+			"foo": "bar",
+		},
+		Constraints: "constraints",
+		Bindings: []BindingSpec{
+			{
+				Role:     "role",
+				Provider: "provider",
+				Config: map[string]string{
+					"foo": "bar",
+				},
+			},
+		},
+	}
+	model2 := &ModelSpec{
+		DisplayName: "model",
+		Properties: map[string]string{
+			"foo": "bar",
+		},
+		Constraints: "constraints",
+		Bindings: []BindingSpec{
+			{
+				Role:     "role",
+				Provider: "provider",
+				Config: map[string]string{
+					"foo": "bar",
+				},
+			},
+		},
+	}
+
+	equal, err := model1.DeepEquals(model2)
+	assert.Nil(t, err)
+	assert.True(t, equal)
+}
+
+func TestModelNotEqual(t *testing.T) {
+	// Test empty
+	model1 := &ModelSpec{
+		DisplayName: "model",
+	}
+	equal, err := model1.DeepEquals(nil)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// Test DisplayName not equal
+	model2 := &ModelSpec{
+		DisplayName: "model2",
+	}
+	equal, err = model1.DeepEquals(model2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// Test Properties not equal
+	model2.DisplayName = "model"
+	model1.Properties = map[string]string{
+		"foo": "bar",
+	}
+	model2.Properties = map[string]string{
+		"foo": "bar2",
+	}
+	equal, err = model1.DeepEquals(model2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// Test Constraints not equal
+	model2.Properties = map[string]string{
+		"foo": "bar",
+	}
+	model1.Constraints = "constraints"
+	model2.Constraints = "constraints2"
+	equal, err = model1.DeepEquals(model2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// Test Bindings not equal
+	model2.Constraints = "constraints"
+	model1.Bindings = []BindingSpec{
+		{
+			Role:     "role",
+			Provider: "provider",
+			Config: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+	model2.Bindings = []BindingSpec{
+		{
+			Role:     "role2",
+			Provider: "provider2",
+			Config: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+	equal, err = model1.DeepEquals(model2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+}

--- a/api/pkg/apis/v1alpha1/model/node_test.go
+++ b/api/pkg/apis/v1alpha1/model/node_test.go
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNodeEqual(t *testing.T) {
+	node1 := NodeSpec{
+		Id:       "id",
+		NodeType: "type",
+		Name:     "name",
+		Model:    "model",
+		Configurations: map[string]string{
+			"foo": "bar",
+		},
+		Inputs: []RouteSpec{
+			{
+				Route: "route",
+				Type:  "type",
+				Properties: map[string]string{
+					"foo": "bar",
+				},
+				Filters: []FilterSpec{
+					{
+						Direction: "direction",
+						Type:      "type",
+						Parameters: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	node2 := NodeSpec{
+		Id:       "id",
+		NodeType: "type",
+		Name:     "name",
+		Model:    "model",
+		Configurations: map[string]string{
+			"foo": "bar",
+		},
+		Inputs: []RouteSpec{
+			{
+				Route: "route",
+				Type:  "type",
+				Properties: map[string]string{
+					"foo": "bar",
+				},
+				Filters: []FilterSpec{
+					{
+						Direction: "direction",
+						Type:      "type",
+						Parameters: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	equal, err := node1.DeepEquals(node2)
+	assert.Nil(t, err)
+	assert.True(t, equal)
+}
+
+func TestNodeNotEqual(t *testing.T) {
+	node1 := NodeSpec{
+		Id: "id",
+	}
+
+	// Test empty
+	equal, err := node1.DeepEquals(nil)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// Test Id not equal
+	node2 := NodeSpec{
+		Id: "id2",
+	}
+	equal, err = node1.DeepEquals(node2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// Test NodeType not equal
+	node2.Id = "id"
+	node2.NodeType = "type2"
+	node1.NodeType = "type"
+	equal, err = node1.DeepEquals(node2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// Test Name not equal
+	node2.NodeType = "type"
+	node2.Name = "name2"
+	node1.Name = "name"
+	equal, err = node1.DeepEquals(node2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// Test Model not equal
+	node2.Name = "name"
+	node2.Model = "model2"
+	node1.Model = "model"
+	equal, err = node1.DeepEquals(node2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// Test Configurations not equal
+	node2.Model = "model"
+	node2.Configurations = map[string]string{
+		"foo": "bar2",
+	}
+	node1.Configurations = map[string]string{
+		"foo": "bar",
+	}
+	equal, err = node1.DeepEquals(node2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// Test Inputs not equal
+	node2.Configurations = map[string]string{
+		"foo": "bar",
+	}
+	node2.Inputs = []RouteSpec{
+		{
+			Route: "route2",
+		},
+	}
+	node1.Inputs = []RouteSpec{
+		{
+			Route: "route",
+		},
+	}
+	equal, err = node1.DeepEquals(node2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// Test Outputs not equal
+	node2.Inputs = []RouteSpec{
+		{
+			Route: "route",
+		},
+	}
+	node2.Outputs = []RouteSpec{
+		{
+			Route: "route2",
+		},
+	}
+	node1.Outputs = []RouteSpec{
+		{
+			Route: "route",
+		},
+	}
+	equal, err = node1.DeepEquals(node2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+}

--- a/api/pkg/apis/v1alpha1/model/plan_test.go
+++ b/api/pkg/apis/v1alpha1/model/plan_test.go
@@ -1,0 +1,380 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package model
+
+import (
+	"testing"
+
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestByTargetNameLen(t *testing.T) {
+	p := ByTargetName{
+		{
+			Name: "a",
+		},
+		{
+			Name: "b",
+		},
+	}
+	assert.Equal(t, p.Len(), 2)
+}
+
+func TestByTargetNameLess(t *testing.T) {
+	p := ByTargetName{
+		{
+			Name: "a",
+		},
+		{
+			Name: "b",
+		},
+	}
+	assert.True(t, p.Less(0, 1))
+}
+
+func TestByTargetNameSwap(t *testing.T) {
+	p := ByTargetName{
+		{
+			Name: "a",
+		},
+		{
+			Name: "b",
+		},
+	}
+	p.Swap(0, 1)
+	assert.Equal(t, p[0].Name, "b")
+	assert.Equal(t, p[1].Name, "a")
+}
+
+func createSampleDeploymentPlan() DeploymentPlan {
+	p := DeploymentPlan{
+		Steps: []DeploymentStep{
+			{
+				Target:  "sample-grpc-target",
+				Role:    "instance",
+				IsFirst: true,
+				Components: []ComponentStep{
+					{
+						Action: "update",
+						Component: ComponentSpec{
+							Name: "sample-grpc-solution",
+							Type: "instance",
+							Properties: map[string]interface{}{
+								"file.content": "hello world",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return p
+}
+
+func createSampleDeploymentPlanForDelete() DeploymentPlan {
+	p := DeploymentPlan{
+		Steps: []DeploymentStep{
+			{
+				Target:  "sample-grpc-target-d1",
+				Role:    "instance-d1",
+				IsFirst: true,
+				Components: []ComponentStep{
+					{
+						Action: "delete",
+						Component: ComponentSpec{
+							Name: "sample-grpc-solution-d1",
+							Type: "instance-d1",
+							Properties: map[string]interface{}{
+								"file.content": "hello world",
+							},
+						},
+					},
+				},
+			},
+			{
+				Target:  "sample-grpc-target-d2",
+				Role:    "instance-d2",
+				IsFirst: true,
+				Components: []ComponentStep{
+					{
+						Action: "delete",
+						Component: ComponentSpec{
+							Name: "sample-grpc-solution-d2",
+							Type: "instance-d2",
+							Properties: map[string]interface{}{
+								"file.content": "hello world",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return p
+}
+
+func createSampleDeploymentPlanForUpdateAndDelete() DeploymentPlan {
+	p := DeploymentPlan{
+		Steps: []DeploymentStep{
+			{
+				Target:  "sample-grpc-target",
+				Role:    "instance",
+				IsFirst: true,
+				Components: []ComponentStep{
+					{
+						Action: "delete",
+						Component: ComponentSpec{
+							Name: "sample-grpc-solution-d1",
+							Type: "instance",
+							Properties: map[string]interface{}{
+								"file.content": "hello world",
+							},
+						},
+					},
+					{
+						Action: "update",
+						Component: ComponentSpec{
+							Name: "sample-grpc-solution-u1",
+							Type: "instance",
+							Properties: map[string]interface{}{
+								"file.content": "hello world",
+							},
+						},
+					},
+					{
+						Action: "delete",
+						Component: ComponentSpec{
+							Name: "sample-grpc-solution-d2",
+							Type: "instance",
+							Properties: map[string]interface{}{
+								"file.content": "hello world",
+							},
+						},
+					},
+					{
+						Action: "update",
+						Component: ComponentSpec{
+							Name: "sample-grpc-solution-u2",
+							Type: "instance",
+							Properties: map[string]interface{}{
+								"file.content": "hello world",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return p
+}
+
+func createSampleDeploymentStepWithUpdateComponent() DeploymentStep {
+	s := DeploymentStep{
+		Target: "sample-grpc-target",
+		Components: []ComponentStep{
+			{
+				Action: "update",
+				Component: ComponentSpec{
+					Name: "sample-grpc-solution",
+					Type: "instance",
+					Properties: map[string]interface{}{
+						"file.content": "hello world",
+					},
+				},
+			},
+		},
+		Role:    "instance",
+		IsFirst: true,
+	}
+	return s
+}
+
+func createSampleDeploymentStepWithDeleteComponent() DeploymentStep {
+	s := DeploymentStep{
+		Target: "sample-grpc-target",
+		Components: []ComponentStep{
+			{
+				Action: "delete",
+				Component: ComponentSpec{
+					Name: "sample-grpc-solution",
+					Type: "instance",
+					Properties: map[string]interface{}{
+						"file.content": "hello world",
+					},
+				},
+			},
+		},
+		Role:    "instance",
+		IsFirst: true,
+	}
+	return s
+}
+
+func TestPrepareResultMap(t *testing.T) {
+	s := createSampleDeploymentStepWithUpdateComponent()
+	resultMap := s.PrepareResultMap()
+	assert.Equal(t, resultMap["sample-grpc-solution"].Status, v1alpha2.Untouched)
+	assert.Equal(t, resultMap["sample-grpc-solution"].Message, "")
+}
+
+func TestGetComponents(t *testing.T) {
+	s := createSampleDeploymentStepWithUpdateComponent()
+	components := s.GetComponents()
+	assert.Equal(t, len(components), 1)
+	assert.Equal(t, components[0].Name, "sample-grpc-solution")
+	assert.Equal(t, components[0].Type, "instance")
+	assert.Equal(t, components[0].Properties["file.content"], "hello world")
+}
+
+func TestGetUpdatedComponents(t *testing.T) {
+	s := createSampleDeploymentStepWithUpdateComponent()
+	components := s.GetUpdatedComponents()
+	assert.Equal(t, len(components), 1)
+	assert.Equal(t, components[0].Name, "sample-grpc-solution")
+	assert.Equal(t, components[0].Type, "instance")
+	assert.Equal(t, components[0].Properties["file.content"], "hello world")
+}
+
+func TestGetDeletedComponents(t *testing.T) {
+	s := createSampleDeploymentStepWithDeleteComponent()
+	components := s.GetDeletedComponents()
+	assert.Equal(t, len(components), 1)
+	assert.Equal(t, components[0].Name, "sample-grpc-solution")
+	assert.Equal(t, components[0].Type, "instance")
+	assert.Equal(t, components[0].Properties["file.content"], "hello world")
+}
+
+func TestGetUpdatedComponentSteps(t *testing.T) {
+	s := createSampleDeploymentStepWithUpdateComponent()
+	components := s.GetUpdatedComponentSteps()
+	assert.Equal(t, len(components), 1)
+	assert.Equal(t, components[0].Action, "update")
+	assert.Equal(t, components[0].Component.Name, "sample-grpc-solution")
+	assert.Equal(t, components[0].Component.Type, "instance")
+	assert.Equal(t, components[0].Component.Properties["file.content"], "hello world")
+}
+
+func TestMarkRemoveAll(t *testing.T) {
+	s := DeploymentState{
+		TargetComponent: map[string]string{
+			"a::T1": "mock1",
+		},
+	}
+	s.MarkRemoveAll()
+	assert.Equal(t, s.TargetComponent["a::T1"], "-mock1")
+}
+
+func TestClearAllRemoved(t *testing.T) {
+	s := DeploymentState{
+		TargetComponent: map[string]string{
+			"a::T1": "mock1",
+		},
+	}
+	s.MarkRemoveAll()
+	assert.Equal(t, s.TargetComponent["a::T1"], "-mock1")
+
+	s.ClearAllRemoved()
+	assert.Equal(t, len(s.TargetComponent), 0)
+}
+
+func TestFindLastTargetRole(t *testing.T) {
+	p := createSampleDeploymentPlan()
+	index := p.FindLastTargetRole("sample-grpc-target", "instance")
+	assert.Equal(t, index, 0)
+
+	index = p.FindLastTargetRole("sample-grpc-target", "instance1")
+	assert.Equal(t, index, -1)
+}
+
+func TestCanAppendToStep(t *testing.T) {
+	p := createSampleDeploymentPlan()
+
+	// no dependencies, can add
+	canAppend := p.CanAppendToStep(0, ComponentSpec{
+		Name: "sample-grpc-solution2",
+		Type: "instance",
+		Properties: map[string]interface{}{
+			"file.content": "hello world",
+		},
+	})
+	assert.Equal(t, true, canAppend)
+
+	// has dependencies, and dependencies include plan component, can add
+	canAppend = p.CanAppendToStep(0, ComponentSpec{
+		Name: "sample-grpc-solution2",
+		Type: "instance",
+		Properties: map[string]interface{}{
+			"file.content": "hello world",
+		},
+		Dependencies: []string{"sample-grpc-solution"},
+	})
+	assert.Equal(t, true, canAppend)
+
+	// has dependencies, but dependencies not include plan component, can not add
+	canAppend = p.CanAppendToStep(0, ComponentSpec{
+		Name: "sample-grpc-solution2",
+		Type: "instance",
+		Properties: map[string]interface{}{
+			"file.content": "hello world",
+		},
+		Dependencies: []string{"sample-grpc-solution3"},
+	})
+	assert.Equal(t, false, canAppend)
+
+}
+
+func TestRevisedForDeletion(t *testing.T) {
+	// no delete component, no change
+	p := createSampleDeploymentPlan()
+	p = p.RevisedForDeletion()
+	assert.Equal(t, len(p.Steps), 1)
+	assert.Equal(t, p.Steps[0].Components[0].Action, "update")
+	assert.Equal(t, p.Steps[0].Components[0].Component.Name, "sample-grpc-solution")
+	assert.Equal(t, p.Steps[0].Components[0].Component.Type, "instance")
+	assert.Equal(t, p.Steps[0].Components[0].Component.Properties["file.content"], "hello world")
+
+	// only delete component, no change, last-to-first order
+	p = createSampleDeploymentPlanForDelete()
+	p = p.RevisedForDeletion()
+	assert.Equal(t, len(p.Steps), 2)
+	assert.Equal(t, p.Steps[0].Components[0].Action, "delete")
+	assert.Equal(t, p.Steps[0].Components[0].Component.Name, "sample-grpc-solution-d2")
+	assert.Equal(t, p.Steps[0].Components[0].Component.Type, "instance-d2")
+	assert.Equal(t, p.Steps[0].Components[0].Component.Properties["file.content"], "hello world")
+
+	assert.Equal(t, p.Steps[1].Components[0].Action, "delete")
+	assert.Equal(t, p.Steps[1].Components[0].Component.Name, "sample-grpc-solution-d1")
+	assert.Equal(t, p.Steps[1].Components[0].Component.Type, "instance-d1")
+	assert.Equal(t, p.Steps[1].Components[0].Component.Properties["file.content"], "hello world")
+
+	// update and delete component,
+	// step1: update at first, orignial order
+	// step2: then delete, last-to-first order
+	p = createSampleDeploymentPlanForUpdateAndDelete()
+	p = p.RevisedForDeletion()
+	assert.Equal(t, len(p.Steps), 2)
+	assert.Equal(t, p.Steps[0].Components[0].Action, "update")
+	assert.Equal(t, p.Steps[0].Components[0].Component.Name, "sample-grpc-solution-u1")
+	assert.Equal(t, p.Steps[0].Components[0].Component.Type, "instance")
+	assert.Equal(t, p.Steps[0].Components[0].Component.Properties["file.content"], "hello world")
+
+	assert.Equal(t, p.Steps[0].Components[1].Action, "update")
+	assert.Equal(t, p.Steps[0].Components[1].Component.Name, "sample-grpc-solution-u2")
+	assert.Equal(t, p.Steps[0].Components[1].Component.Type, "instance")
+	assert.Equal(t, p.Steps[0].Components[1].Component.Properties["file.content"], "hello world")
+
+	assert.Equal(t, p.Steps[1].Components[0].Action, "delete")
+	assert.Equal(t, p.Steps[1].Components[0].Component.Name, "sample-grpc-solution-d2")
+	assert.Equal(t, p.Steps[1].Components[0].Component.Type, "instance")
+	assert.Equal(t, p.Steps[1].Components[0].Component.Properties["file.content"], "hello world")
+
+	assert.Equal(t, p.Steps[1].Components[1].Action, "delete")
+	assert.Equal(t, p.Steps[1].Components[1].Component.Name, "sample-grpc-solution-d1")
+	assert.Equal(t, p.Steps[1].Components[1].Component.Type, "instance")
+	assert.Equal(t, p.Steps[1].Components[1].Component.Properties["file.content"], "hello world")
+}

--- a/api/pkg/apis/v1alpha1/model/route_test.go
+++ b/api/pkg/apis/v1alpha1/model/route_test.go
@@ -292,3 +292,25 @@ func TestRouteMissingFilter(t *testing.T) {
 	assert.Nil(t, err)
 	assert.False(t, equal)
 }
+
+func TestRouteMatchOneEmpty(t *testing.T) {
+	route1 := RouteSpec{
+		Route: "route",
+		Type:  "type",
+		Properties: map[string]string{
+			"foo": "bar",
+		},
+		Filters: []FilterSpec{
+			{
+				Direction: "direction",
+				Type:      "type",
+				Parameters: map[string]string{
+					"foo2": "bar2",
+				},
+			},
+		},
+	}
+	res, err := route1.DeepEquals(nil)
+	assert.Errorf(t, err, "parameter is not a RouteSpec type")
+	assert.False(t, res)
+}

--- a/api/pkg/apis/v1alpha1/model/site_test.go
+++ b/api/pkg/apis/v1alpha1/model/site_test.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSiteMatch(t *testing.T) {
+	s1 := SiteSpec{
+		Name:      "site",
+		PublicKey: "publicKey",
+		Properties: map[string]string{
+			"foo": "bar",
+		},
+	}
+	s2 := SiteSpec{
+		Name:      "site",
+		PublicKey: "publicKey",
+		Properties: map[string]string{
+			"foo": "bar",
+		},
+	}
+	equal, err := s1.DeepEquals(s2)
+	assert.Nil(t, err)
+	assert.True(t, equal)
+}
+
+func TestSiteNameNotMatch(t *testing.T) {
+	s1 := SiteSpec{
+		Name: "site",
+		Properties: map[string]string{
+			"foo": "bar",
+		},
+	}
+	s2 := SiteSpec{
+		Name: "site2",
+		Properties: map[string]string{
+			"foo": "bar",
+		},
+	}
+	equal, err := s1.DeepEquals(s2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+}
+
+func TestSitePublicKeyNotMatch(t *testing.T) {
+	s1 := SiteSpec{
+		Name:      "site",
+		PublicKey: "publicKey",
+	}
+	s2 := SiteSpec{
+		Name:      "site",
+		PublicKey: "publicKey2",
+	}
+	equal, err := s1.DeepEquals(s2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+}
+
+func TestSiteEqualNil(t *testing.T) {
+	s1 := SiteSpec{
+		Name: "site",
+		Properties: map[string]string{
+			"foo": "bar",
+		},
+	}
+	res, err := s1.DeepEquals(nil)
+	assert.Errorf(t, err, "parameter is not a SiteSpec type")
+	assert.False(t, res)
+}

--- a/api/pkg/apis/v1alpha1/model/skill.go
+++ b/api/pkg/apis/v1alpha1/model/skill.go
@@ -31,7 +31,7 @@ type SkillPackageSpec struct {
 }
 
 func (c SkillSpec) DeepEquals(other IDeepEquals) (bool, error) {
-	otherSkillSpec, ok := other.(*SkillSpec)
+	otherSkillSpec, ok := other.(SkillSpec)
 	if !ok {
 		return false, nil
 	}
@@ -51,7 +51,7 @@ func (c SkillSpec) DeepEquals(other IDeepEquals) (bool, error) {
 		return false, nil
 	}
 
-	if !SlicesEqual(ExtractReferenceSlice(c.Edges), ExtractReferenceSlice(otherSkillSpec.Edges)) {
+	if !SlicesEqual(c.Edges, otherSkillSpec.Edges) {
 		return false, nil
 	}
 	return true, nil

--- a/api/pkg/apis/v1alpha1/model/skill.go
+++ b/api/pkg/apis/v1alpha1/model/skill.go
@@ -50,7 +50,8 @@ func (c SkillSpec) DeepEquals(other IDeepEquals) (bool, error) {
 	if !SlicesEqual(c.Bindings, otherSkillSpec.Bindings) {
 		return false, nil
 	}
-	if !SlicesEqual(c.Edges, otherSkillSpec.Edges) {
+
+	if !SlicesEqual(ExtractReferenceSlice(c.Edges), ExtractReferenceSlice(otherSkillSpec.Edges)) {
 		return false, nil
 	}
 	return true, nil

--- a/api/pkg/apis/v1alpha1/model/skill_test.go
+++ b/api/pkg/apis/v1alpha1/model/skill_test.go
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSkillMatch(t *testing.T) {
+	s1 := &SkillSpec{
+		DisplayName: "skill",
+		Parameters: map[string]string{
+			"foo": "bar",
+		},
+		Nodes: []NodeSpec{
+			{
+				Id: "node1",
+			},
+			{
+				Id: "node2",
+			},
+		},
+		Properties: map[string]string{
+			"foo": "bar",
+		},
+		Bindings: []BindingSpec{
+			{
+				Role:     "role",
+				Provider: "provider",
+			},
+		},
+		Edges: []EdgeSpec{
+			{
+				Source: ConnectionSpec{
+					Node:  "node1",
+					Route: "route1",
+				},
+				Target: ConnectionSpec{
+					Node:  "node2",
+					Route: "route1",
+				},
+			},
+		},
+	}
+
+	s2 := &SkillSpec{
+		DisplayName: "skill",
+		Parameters: map[string]string{
+			"foo": "bar",
+		},
+		Nodes: []NodeSpec{
+			{
+				Id: "node1",
+			},
+			{
+				Id: "node2",
+			},
+		},
+		Properties: map[string]string{
+			"foo": "bar",
+		},
+		Bindings: []BindingSpec{
+			{
+				Role:     "role",
+				Provider: "provider",
+			},
+		},
+		Edges: []EdgeSpec{
+			{
+				Source: ConnectionSpec{
+					Node:  "node1",
+					Route: "route1",
+				},
+				Target: ConnectionSpec{
+					Node:  "node2",
+					Route: "route1",
+				},
+			},
+		},
+	}
+
+	equal, err := s1.DeepEquals(s2)
+	assert.Nil(t, err)
+	assert.True(t, equal)
+}
+
+func TestSkillNotMatch(t *testing.T) {
+	s1 := &SkillSpec{
+		DisplayName: "skill",
+	}
+
+	// not match empty
+	equal, err := s1.DeepEquals(nil)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// not match different display name
+	s2 := &SkillSpec{
+		DisplayName: "skill2",
+	}
+	equal, err = s1.DeepEquals(s2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// not match different parameters
+	s2.DisplayName = "skill"
+	s2.Parameters = map[string]string{
+		"foo": "bar2",
+	}
+	s1.Parameters = map[string]string{
+		"foo": "bar",
+	}
+	equal, err = s1.DeepEquals(s2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// not match different nodes
+	s2.Parameters = map[string]string{
+		"foo": "bar",
+	}
+	s2.Nodes = []NodeSpec{
+		{
+			Id: "node1-test",
+		},
+		{
+			Id: "node2-test",
+		},
+	}
+	s1.Nodes = []NodeSpec{
+		{
+			Id: "node1",
+		},
+		{
+			Id: "node2",
+		},
+	}
+	equal, err = s1.DeepEquals(s2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// not match different properties
+	s2.Nodes = []NodeSpec{
+		{
+			Id: "node1",
+		},
+		{
+			Id: "node2",
+		},
+	}
+	s2.Properties = map[string]string{
+		"foo": "bar2",
+	}
+	s1.Properties = map[string]string{
+		"foo": "bar",
+	}
+	equal, err = s1.DeepEquals(s2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// not match different bindings
+	s2.Properties = map[string]string{
+		"foo": "bar",
+	}
+	s1.Bindings = []BindingSpec{
+		{
+			Role:     "role",
+			Provider: "provider",
+		},
+	}
+	s2.Bindings = []BindingSpec{
+		{
+			Role:     "role-test",
+			Provider: "provider-test",
+		},
+	}
+	equal, err = s1.DeepEquals(s2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+
+	// not match different edges
+	s2.Bindings = []BindingSpec{
+		{
+			Role:     "role",
+			Provider: "provider",
+		},
+	}
+	s1.Edges = []EdgeSpec{
+		{
+			Source: ConnectionSpec{
+				Node:  "node1",
+				Route: "route1",
+			},
+			Target: ConnectionSpec{
+				Node:  "node2",
+				Route: "route1",
+			},
+		},
+	}
+	s2.Edges = []EdgeSpec{
+		{
+			Source: ConnectionSpec{
+				Node:  "node1-test",
+				Route: "route1-test",
+			},
+			Target: ConnectionSpec{
+				Node:  "node2-test",
+				Route: "route1-test",
+			},
+		},
+	}
+	equal, err = s1.DeepEquals(s2)
+	assert.Nil(t, err)
+	assert.False(t, equal)
+}

--- a/api/pkg/apis/v1alpha1/model/skill_test.go
+++ b/api/pkg/apis/v1alpha1/model/skill_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestSkillMatch(t *testing.T) {
-	s1 := &SkillSpec{
+	s1 := SkillSpec{
 		DisplayName: "skill",
 		Parameters: map[string]string{
 			"foo": "bar",
@@ -49,7 +49,7 @@ func TestSkillMatch(t *testing.T) {
 		},
 	}
 
-	s2 := &SkillSpec{
+	s2 := SkillSpec{
 		DisplayName: "skill",
 		Parameters: map[string]string{
 			"foo": "bar",
@@ -91,7 +91,7 @@ func TestSkillMatch(t *testing.T) {
 }
 
 func TestSkillNotMatch(t *testing.T) {
-	s1 := &SkillSpec{
+	s1 := SkillSpec{
 		DisplayName: "skill",
 	}
 
@@ -101,7 +101,7 @@ func TestSkillNotMatch(t *testing.T) {
 	assert.False(t, equal)
 
 	// not match different display name
-	s2 := &SkillSpec{
+	s2 := SkillSpec{
 		DisplayName: "skill2",
 	}
 	equal, err = s1.DeepEquals(s2)

--- a/api/pkg/apis/v1alpha1/model/summary_test.go
+++ b/api/pkg/apis/v1alpha1/model/summary_test.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateTargetResult(t *testing.T) {
+	s := &SummarySpec{
+		TargetResults: map[string]TargetResultSpec{
+			"target1": {
+				Status: "OK",
+			},
+			"target2": {
+				Status: "OK",
+			},
+			"target3": {
+				Status: "OK",
+			},
+		},
+	}
+	s.UpdateTargetResult("target2", TargetResultSpec{
+		Status: "ERROR",
+	})
+	assert.Equal(t, 2, s.SuccessCount)
+}

--- a/api/pkg/apis/v1alpha1/model/target_test.go
+++ b/api/pkg/apis/v1alpha1/model/target_test.go
@@ -330,6 +330,23 @@ func TestTargetDeepEqualsTopologiestNameNotMatch(t *testing.T) {
 	assert.False(t, res)
 }
 
+func TestTargetDeepEqualsConstraintsNotMatch(t *testing.T) {
+	Target := TargetSpec{
+		DisplayName: "TargetName",
+		Scope:       "Default",
+		Components:  []ComponentSpec{{}},
+	}
+	other := TargetSpec{
+		DisplayName: "TargetName",
+		Scope:       "Default",
+		Components:  []ComponentSpec{{}},
+		Constraints: "Constraints",
+	}
+	res, err := Target.DeepEquals(other)
+	assert.Nil(t, err)
+	assert.False(t, res)
+}
+
 func TestTargetDeepEqualsForceRedeployNotMatch(t *testing.T) {
 	Target := TargetSpec{
 		DisplayName: "TargetName",

--- a/api/pkg/apis/v1alpha1/model/utils.go
+++ b/api/pkg/apis/v1alpha1/model/utils.go
@@ -165,6 +165,14 @@ func EnvMapsEqual(a map[string]string, b map[string]string) bool {
 	return true
 }
 
+func ExtractReferenceSlice[K IDeepEquals](a []K) []*K {
+	ret := make([]*K, 0)
+	for _, v := range a {
+		ret = append(ret, &v)
+	}
+	return ret
+}
+
 // SliceEuql compares two slices of IDeepEqual items, ignoring the order of items
 // It returns two if the two slices are exactly the same, otherwise it returns false
 func SlicesEqual[K IDeepEquals](a []K, b []K) bool {

--- a/api/pkg/apis/v1alpha1/model/utils_test.go
+++ b/api/pkg/apis/v1alpha1/model/utils_test.go
@@ -1151,3 +1151,157 @@ func TestCollectPropertiesWithHierarchy(t *testing.T) {
 	assert.IsType(t, []interface{}{}, ret["def"].(map[string]interface{})["some"])
 	assert.Equal(t, int64(123), ret["def"].(map[string]interface{})["some"].([]interface{})[0].(map[string]interface{})["int"])
 }
+
+func TestExtractRawEnvFromProperties(t *testing.T) {
+	properties := map[string]interface{}{
+		"env.AZURE_CLIENT_ID":   "\\u003cSP App ID\\u003e",
+		"env.AZURE_TENANT_ID":   "\\u003cSP Tenant ID\\u003e",
+		"env.STORAGE_ACCOUNT":   "voestore",
+		"env.STORAGE_CONTAINER": "snapshots",
+		"env.SYMPHONY_URL":      "http://20.118.178.8:8080/v1alpha2/agent/references",
+		"env.TARGET_NAME":       "symphony-k8s-target",
+		"DUMMY_PROPERTY":        "dummy",
+	}
+	ret := ExtractRawEnvFromProperties(properties)
+	assert.Equal(t, "\\u003cSP App ID\\u003e", ret["env.AZURE_CLIENT_ID"])
+	assert.Equal(t, "\\u003cSP Tenant ID\\u003e", ret["env.AZURE_TENANT_ID"])
+	assert.Equal(t, "voestore", ret["env.STORAGE_ACCOUNT"])
+	assert.Equal(t, "snapshots", ret["env.STORAGE_CONTAINER"])
+	assert.Equal(t, "http://20.118.178.8:8080/v1alpha2/agent/references", ret["env.SYMPHONY_URL"])
+	assert.Equal(t, "symphony-k8s-target", ret["env.TARGET_NAME"])
+	assert.Equal(t, "", ret["DUMMY_PROPERTY"])
+}
+
+func TestCheckPropertyCompat(t *testing.T) {
+	assert.True(t, CheckPropertyCompat(map[string]interface{}{
+		"A": "B",
+		"C": "D",
+	}, map[string]interface{}{
+		"C": "D",
+		"A": "B",
+		"E": "F",
+	}, "A", false))
+
+	assert.True(t, CheckPropertyCompat(map[string]interface{}{
+		"A": "B",
+		"C": "D",
+	}, map[string]interface{}{
+		"C": "D",
+		"A": "b",
+		"E": "F",
+	}, "A", true))
+
+	assert.False(t, CheckPropertyCompat(map[string]interface{}{
+		"A": "B",
+		"C": "D",
+	}, map[string]interface{}{
+		"C": "D",
+		"A": "b",
+		"E": "F",
+	}, "A", false))
+
+	assert.True(t, CheckPropertyCompat(map[string]interface{}{
+		"A": "B",
+		"C": "D",
+	}, map[string]interface{}{
+		"C": "D",
+		"A": "b",
+		"E": "F",
+	}, "X", false))
+
+	assert.False(t, CheckPropertyCompat(map[string]interface{}{
+		"A": "B",
+		"C": "D",
+		"X": "Y",
+	}, map[string]interface{}{
+		"C": "D",
+		"A": "b",
+		"E": "F",
+	}, "X", false))
+}
+
+func TestHasSameProperty(t *testing.T) {
+	// both has property and do case sensitive check - true
+	assert.True(t, HasSameProperty(map[string]string{
+		"A": "B",
+		"C": "D",
+	}, map[string]string{
+		"C": "D",
+		"A": "B",
+		"E": "F",
+	}, "A"))
+
+	// case sensitive check - false
+	assert.False(t, HasSameProperty(map[string]string{
+		"A": "B",
+		"C": "D",
+	}, map[string]string{
+		"C": "D",
+		"A": "b",
+		"E": "F",
+	}, "A"))
+
+	// property both not found - true ("".equals(""))
+	assert.True(t, HasSameProperty(map[string]string{
+		"A": "B",
+		"C": "D",
+	}, map[string]string{
+		"C": "D",
+		"A": "b",
+		"E": "F",
+	}, "X"))
+
+	// only one map has property - false
+	assert.False(t, HasSameProperty(map[string]string{
+		"A": "B",
+		"C": "D",
+		"X": "Y",
+	}, map[string]string{
+		"C": "D",
+		"A": "b",
+		"E": "F",
+	}, "X"))
+}
+
+func TestHasSamePropertyCompat(t *testing.T) {
+	// both has property and do case sensitive check - true
+	assert.True(t, HasSamePropertyCompat(map[string]interface{}{
+		"A": "B",
+		"C": "D",
+	}, map[string]interface{}{
+		"C": "D",
+		"A": "B",
+		"E": "F",
+	}, "A"))
+
+	// case sensitive check - false
+	assert.False(t, HasSamePropertyCompat(map[string]interface{}{
+		"A": "B",
+		"C": "D",
+	}, map[string]interface{}{
+		"C": "D",
+		"A": "b",
+		"E": "F",
+	}, "A"))
+
+	// property both not found - true ("".equals(""))
+	assert.True(t, HasSamePropertyCompat(map[string]interface{}{
+		"A": "B",
+		"C": "D",
+	}, map[string]interface{}{
+		"C": "D",
+		"A": "b",
+		"E": "F",
+	}, "X"))
+
+	// only one map has property - false
+	assert.False(t, HasSamePropertyCompat(map[string]interface{}{
+		"A": "B",
+		"C": "D",
+		"X": "Y",
+	}, map[string]interface{}{
+		"C": "D",
+		"A": "b",
+		"E": "F",
+	}, "X"))
+}

--- a/api/pkg/apis/v1alpha1/model/validationrule.go
+++ b/api/pkg/apis/v1alpha1/model/validationrule.go
@@ -74,7 +74,7 @@ func (v ValidationRule) IsComponentChanged(old ComponentSpec, new ComponentSpec)
 			}
 		} else {
 			if c.IsComponentName {
-				if !compareStrings(old.Name, new.Name, c.IgnoreCase, c.SkipIfMissing) {
+				if !compareStrings(old.Name, new.Name, c.IgnoreCase, c.PrefixMatch) {
 					return true
 				}
 			} else {
@@ -125,6 +125,8 @@ func compareProperties(c PropertyDesc, old ComponentSpec, new ComponentSpec, key
 			if !compareStrings(fmt.Sprintf("%v", v), fmt.Sprintf("%v", nv), c.IgnoreCase, c.PrefixMatch) {
 				return true
 			}
+		} else if !c.SkipIfMissing {
+			return true
 		}
 	} else {
 		if !c.SkipIfMissing {
@@ -140,6 +142,8 @@ func compareMetadata(c PropertyDesc, old ComponentSpec, new ComponentSpec, key s
 			if !compareStrings(fmt.Sprintf("%v", v), fmt.Sprintf("%v", nv), c.IgnoreCase, c.PrefixMatch) {
 				return true
 			}
+		} else if !c.SkipIfMissing {
+			return true
 		}
 	} else {
 		if !c.SkipIfMissing {

--- a/api/pkg/apis/v1alpha1/model/validationrule_test.go
+++ b/api/pkg/apis/v1alpha1/model/validationrule_test.go
@@ -161,3 +161,319 @@ func TestValidateComponentType(t *testing.T) {
 	equal := validationRule.Validate(components)
 	assert.Errorf(t, equal, "required property 'requiredComponentType' is missing")
 }
+
+func TestValidateInputs(t *testing.T) {
+	// Create a new instance of our test struct
+	validationRule := ValidationRule{
+		RequiredComponentType: "requiredComponentType",
+		RequiredProperties: []string{
+			"requiredProperties1",
+		},
+		RequiredMetadata: []string{
+			"RequiredMetadata1",
+		},
+	}
+	inputs := map[string]interface{}{
+		"requiredProperties1": "requiredProperties1",
+	}
+	equal := validationRule.ValidateInputs(inputs)
+	assert.Nil(t, equal)
+
+	inputs2 := map[string]interface{}{
+		"requiredProperties": "requiredProperties",
+	}
+	equal = validationRule.ValidateInputs(inputs2)
+	assert.Errorf(t, equal, "required property 'requiredProperties1' is missing")
+}
+
+func TestIsComponentChangedNoWildcard(t *testing.T) {
+	// Create a new instance of our test struct
+	validationRule := ValidationRule{
+		ChangeDetectionProperties: []PropertyDesc{
+			{
+				Name: "a",
+			},
+		},
+	}
+	old := ComponentSpec{
+		Type: "requiredComponentType",
+		Properties: map[string]interface{}{
+			"a": "b",
+		},
+	}
+	new := ComponentSpec{
+		Type: "requiredComponentType",
+		Properties: map[string]interface{}{
+			"a": "c",
+		},
+	}
+
+	changed := validationRule.IsComponentChanged(old, new)
+	assert.True(t, changed)
+}
+
+func TestIsComponentChanged_ChangeComponentNameIgnoreCase(t *testing.T) {
+	// Create a new instance of our test struct
+	validationRule := ValidationRule{
+		ChangeDetectionProperties: []PropertyDesc{
+			{
+				Name:            "a",
+				IsComponentName: true,
+				IgnoreCase:      true,
+			},
+		},
+	}
+	old := ComponentSpec{
+		Name: "a",
+	}
+	new := ComponentSpec{
+		Name: "A",
+	}
+
+	changed := validationRule.IsComponentChanged(old, new)
+	assert.False(t, changed)
+}
+
+func TestIsComponentChanged_ChangeComponentNameNoIgnoreCase(t *testing.T) {
+	// Create a new instance of our test struct
+	validationRule := ValidationRule{
+		ChangeDetectionProperties: []PropertyDesc{
+			{
+				Name:            "a",
+				IsComponentName: true,
+			},
+		},
+	}
+	old := ComponentSpec{
+		Name: "a",
+	}
+	new := ComponentSpec{
+		Name: "A",
+	}
+
+	changed := validationRule.IsComponentChanged(old, new)
+	assert.True(t, changed)
+}
+
+func TestIsComponentChangedNoWildcard_Metadata(t *testing.T) {
+	// Create a new instance of our test struct
+	validationRule := ValidationRule{
+		ChangeDetectionMetadata: []PropertyDesc{
+			{
+				Name: "a",
+			},
+		},
+	}
+	old := ComponentSpec{
+		Type: "requiredComponentType",
+		Metadata: map[string]string{
+			"a": "b",
+		},
+	}
+	new := ComponentSpec{
+		Type: "requiredComponentType",
+		Metadata: map[string]string{
+			"a": "c",
+		},
+	}
+
+	changed := validationRule.IsComponentChanged(old, new)
+	assert.True(t, changed)
+}
+
+func TestIsChangedWildcard_Metadata(t *testing.T) {
+	// Create a new instance of our test struct
+	validationRule := ValidationRule{
+		ChangeDetectionMetadata: []PropertyDesc{
+			{
+				Name: "*",
+			},
+		},
+	}
+	old := ComponentSpec{
+		Type: "requiredComponentType",
+		Metadata: map[string]string{
+			"a": "b",
+		},
+	}
+	new := ComponentSpec{
+		Type: "requiredComponentType",
+		Metadata: map[string]string{
+			"a": "c",
+		},
+	}
+
+	changed := validationRule.IsComponentChanged(old, new)
+	assert.True(t, changed)
+}
+
+func TestComponentIsChanged_SkipMissingProperty(t *testing.T) {
+	// Create a new instance of our test struct
+	validationRule := ValidationRule{
+		ChangeDetectionProperties: []PropertyDesc{
+			{
+				Name:          "a",
+				SkipIfMissing: true,
+			},
+		},
+	}
+	old := ComponentSpec{
+		Type: "requiredComponentType",
+		Properties: map[string]interface{}{
+			"a": "b",
+		},
+	}
+	new := ComponentSpec{
+		Type: "requiredComponentType",
+	}
+
+	changed := validationRule.IsComponentChanged(old, new)
+	assert.False(t, changed)
+}
+
+func TestComponentIsChanged_SkipMissingMetadata(t *testing.T) {
+	// Create a new instance of our test struct
+	validationRule := ValidationRule{
+		ChangeDetectionMetadata: []PropertyDesc{
+			{
+				Name:          "a",
+				SkipIfMissing: true,
+			},
+		},
+	}
+	old := ComponentSpec{
+		Type: "requiredComponentType",
+		Metadata: map[string]string{
+			"a": "b",
+		},
+	}
+	new := ComponentSpec{
+		Type: "requiredComponentType",
+	}
+
+	changed := validationRule.IsComponentChanged(old, new)
+	assert.False(t, changed)
+}
+
+// FIX: validationrule.go#L132&134
+func TestComponentIsChanged_MissingPropertyNotInOld(t *testing.T) {
+	// Create a new instance of our test struct
+	validationRule := ValidationRule{
+		ChangeDetectionProperties: []PropertyDesc{
+			{
+				Name:          "a",
+				SkipIfMissing: false,
+			},
+		},
+	}
+	old := ComponentSpec{
+		Type: "requiredComponentType",
+	}
+	new := ComponentSpec{
+		Type: "requiredComponentType",
+		Properties: map[string]interface{}{
+			"a": "b",
+		},
+	}
+
+	changed := validationRule.IsComponentChanged(old, new)
+	assert.True(t, changed)
+}
+
+// FIX: validationrule.go#L149&151
+func TestComponentIsChanged_MissingMetadataNotInOld(t *testing.T) {
+	// Create a new instance of our test struct
+	validationRule := ValidationRule{
+		ChangeDetectionMetadata: []PropertyDesc{
+			{
+				Name:          "a",
+				SkipIfMissing: false,
+			},
+		},
+	}
+	old := ComponentSpec{
+		Type: "requiredComponentType",
+	}
+	new := ComponentSpec{
+		Type: "requiredComponentType",
+		Metadata: map[string]string{
+			"a": "b",
+		},
+	}
+
+	changed := validationRule.IsComponentChanged(old, new)
+	assert.True(t, changed)
+}
+
+// FIX: validationrule.go#L128&130
+func TestComponentIsChanged_MissingProperty(t *testing.T) {
+	// Create a new instance of our test struct
+	validationRule := ValidationRule{
+		ChangeDetectionProperties: []PropertyDesc{
+			{
+				Name:          "a",
+				SkipIfMissing: false,
+			},
+		},
+	}
+	old := ComponentSpec{
+		Type: "requiredComponentType",
+		Properties: map[string]interface{}{
+			"a": "b",
+		},
+	}
+	new := ComponentSpec{
+		Type: "requiredComponentType",
+	}
+
+	changed := validationRule.IsComponentChanged(old, new)
+	assert.True(t, changed)
+}
+
+// FIX: validationrule.go#L145&147
+func TestComponentIsChanged_MissingMetadata(t *testing.T) {
+	// Create a new instance of our test struct
+	validationRule := ValidationRule{
+		ChangeDetectionMetadata: []PropertyDesc{
+			{
+				Name:          "a",
+				SkipIfMissing: false,
+			},
+		},
+	}
+	old := ComponentSpec{
+		Type: "requiredComponentType",
+		Metadata: map[string]string{
+			"a": "b",
+		},
+	}
+	new := ComponentSpec{
+		Type: "requiredComponentType",
+	}
+
+	changed := validationRule.IsComponentChanged(old, new)
+	assert.True(t, changed)
+}
+
+// FIX: validationrule.go#L77
+func TestComponentIsChanged_ComponentNameHasPrefix(t *testing.T) {
+	// Create a new instance of our test struct
+	validationRule := ValidationRule{
+		ChangeDetectionProperties: []PropertyDesc{
+			{
+				Name:            "a",
+				PrefixMatch:     true,
+				IsComponentName: true,
+			},
+		},
+	}
+	old := ComponentSpec{
+		Name: "a",
+	}
+	new := ComponentSpec{
+		Name: "a1",
+	}
+
+	changed := validationRule.IsComponentChanged(old, new)
+	assert.False(t, changed)
+}

--- a/api/pkg/apis/v1alpha1/utils/utils.go
+++ b/api/pkg/apis/v1alpha1/utils/utils.go
@@ -45,7 +45,9 @@ func ReadInt32(col map[string]string, key string, defaultVal int32) int32 {
 		if e != nil {
 			return defaultVal
 		}
-		return i.(int32)
+		if i, iok := i.(int32); iok {
+			return i
+		}
 	}
 	return defaultVal
 }
@@ -55,7 +57,12 @@ func GetString(col map[string]string, key string) (string, error) {
 		if e != nil {
 			return "", e
 		}
-		return i.(string), nil
+		s, sok := i.(string)
+		if sok {
+			return s, nil
+		} else {
+			return "", fmt.Errorf("value of %s is not a string", key)
+		}
 	}
 	return "", fmt.Errorf("key %s is not found", key)
 }
@@ -66,7 +73,10 @@ func ReadStringFromMapCompat(col map[string]interface{}, key string, defaultVal 
 		if e != nil {
 			return defaultVal
 		}
-		return i.(string)
+		s, sok := i.(string)
+		if sok {
+			return s
+		}
 	}
 	return defaultVal
 }
@@ -77,7 +87,10 @@ func ReadString(col map[string]string, key string, defaultVal string) string {
 		if e != nil {
 			return defaultVal
 		}
-		return i.(string)
+		s, sok := i.(string)
+		if sok {
+			return s
+		}
 	}
 	return defaultVal
 }

--- a/api/pkg/apis/v1alpha1/utils/utils_test.go
+++ b/api/pkg/apis/v1alpha1/utils/utils_test.go
@@ -8,6 +8,8 @@ package utils
 
 import (
 	"encoding/json"
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -82,6 +84,39 @@ func TestFormatObjectDictYaml(t *testing.T) {
 	val, err := FormatObject(obj, false, "$.foo", "yaml")
 	assert.Nil(t, err)
 	assert.Equal(t, "bar\n", string(val))
+}
+func TestFormatObjectArrayDictJson(t *testing.T) {
+	obj := []map[string]interface{}{
+		{
+			"foo": "bar1",
+		},
+		{
+			"foo": "bar2",
+		},
+		{
+			"notfoo": "bar",
+		},
+	}
+	val, err := FormatObject(obj, true, "$.foo", "")
+	assert.Nil(t, err)
+	assert.Equal(t, "[\"bar1\",\"bar2\",null]", string(val))
+}
+
+func TestFormatObjectArrayDictYaml(t *testing.T) {
+	obj := []map[string]interface{}{
+		{
+			"foo": "bar1",
+		},
+		{
+			"foo": "bar2",
+		},
+		{
+			"notfoo": "bar",
+		},
+	}
+	val, err := FormatObject(obj, true, "$.foo", "yaml")
+	assert.Nil(t, err)
+	assert.Equal(t, "bar1\n---\nbar2\n---\nnull\n", string(val))
 }
 
 func TestJsonPathBasic(t *testing.T) {
@@ -199,4 +234,173 @@ func TestJsonPathBadJsonPath(t *testing.T) {
 	result, err := JsonPathQuery(obj, "sdgsgsdg")
 	assert.NotNil(t, err)
 	assert.Equal(t, nil, result)
+}
+func TestMatchString(t *testing.T) {
+	assert.True(t, matchString("abc", "abc"))
+	assert.True(t, matchString("a.*c", "abc"))
+	assert.True(t, matchString("a%", "abc"))
+	assert.False(t, matchString("a.*c", "ab"))
+}
+func TestReadInt32(t *testing.T) {
+	mapData := map[string]string{
+		"abc": "#123",
+		"def": "N/A",
+		"mno": "#N/A",
+	}
+	val := ReadInt32(mapData, "abc", 0)
+	assert.Equal(t, int32(123), val)
+	val = ReadInt32(mapData, "def", 0)
+	assert.Equal(t, int32(0), val)
+	val = ReadInt32(mapData, "mno", 0)
+	assert.Equal(t, int32(0), val)
+}
+func TestGetString(t *testing.T) {
+	mapData := map[string]string{
+		"a": "def",
+		"b": "{abc}",
+		"c": `[{"key":"value"}]`,
+	}
+	val, err := GetString(mapData, "a")
+	assert.Nil(t, err)
+	assert.Equal(t, "def", val)
+
+	val, err = GetString(mapData, "b")
+	assert.NotNil(t, err)
+
+	val, err = GetString(mapData, "c")
+	assert.NotNil(t, err)
+	assert.Errorf(t, err, "value of %s is not a string", "c")
+
+	val, err = GetString(mapData, "d")
+	assert.NotNil(t, err)
+	assert.Errorf(t, err, "key %s is not found", "d")
+}
+func TestReadStringFromMapCompat(t *testing.T) {
+	mapData := map[string]interface{}{
+		"a": "def",
+		"b": []map[string]string{
+			{
+				"key": "value",
+			},
+		},
+	}
+	val := ReadStringFromMapCompat(mapData, "a", "")
+	assert.Equal(t, "def", val)
+
+	val = ReadStringFromMapCompat(mapData, "b", "")
+	assert.Equal(t, "", val)
+
+	val = ReadStringFromMapCompat(mapData, "c", "")
+	assert.Equal(t, "", val)
+}
+
+func TestReadString(t *testing.T) {
+	mapData := map[string]string{
+		"a": "def",
+		"b": "{abc}",
+		"c": `[{"key":"value"}]`,
+	}
+	val := ReadString(mapData, "a", "")
+	assert.Equal(t, "def", val)
+
+	val = ReadString(mapData, "b", "")
+	assert.Equal(t, "", val)
+
+	val = ReadString(mapData, "c", "")
+	assert.Equal(t, "", val)
+
+	val = ReadString(mapData, "d", "")
+	assert.Equal(t, "", val)
+}
+func TestMergeCollection(t *testing.T) {
+	mapData := map[string]string{
+		"a": "def",
+		"b": "abc",
+	}
+	mapData2 := map[string]string{
+		"c": "def",
+		"d": "abc",
+	}
+	merged := MergeCollection(mapData, mapData2)
+	assert.Equal(t, 4, len(merged))
+	assert.Equal(t, "def", merged["a"])
+	assert.Equal(t, "abc", merged["b"])
+	assert.Equal(t, "def", merged["c"])
+	assert.Equal(t, "abc", merged["d"])
+}
+func TestCollectStringMap(t *testing.T) {
+	mapData := map[string]string{
+		"a1": "def",
+		"a2": "abc",
+		"b":  "xxx",
+	}
+
+	merged := CollectStringMap(mapData, "a")
+	assert.Equal(t, 2, len(merged))
+	assert.Equal(t, "def", merged["a1"])
+	assert.Equal(t, "abc", merged["a2"])
+}
+
+func TestParseValue(t *testing.T) {
+	// bool = $true
+	v, err := ParseValue("$true")
+	assert.Nil(t, err)
+	assert.Equal(t, true, v)
+
+	// bool = $false
+	v, err = ParseValue("$false")
+	assert.Nil(t, err)
+	assert.Equal(t, false, v)
+
+	// environment variable = $foo
+	os.Setenv("foo", "bar")
+	v, err = ParseValue("$foo")
+	assert.Nil(t, err)
+	assert.Equal(t, "bar", v)
+
+	v, err = ParseValue("$foo1")
+	assert.Nil(t, err)
+	assert.Equal(t, "", v)
+}
+
+func TestFormatAsString(t *testing.T) {
+	assert.Equal(t, "abc", FormatAsString("abc"))
+	assert.Equal(t, "123", FormatAsString(123))
+	assert.Equal(t, "123", FormatAsString(int32(123)))
+	assert.Equal(t, "123", FormatAsString(int64(123)))
+	assert.Equal(t, "123.456", FormatAsString(float32(123.456)))
+	assert.Equal(t, "123.456", FormatAsString(float64(123.456)))
+	assert.Equal(t, "true", FormatAsString(true))
+
+	obj := map[string]interface{}{
+		"foo": "bar",
+		"abc": 123,
+	}
+	ret, _ := json.Marshal(obj)
+	assert.Equal(t, string(ret), FormatAsString(obj))
+
+	obj2 := []interface{}{
+		"foo",
+		123,
+	}
+	ret, _ = json.Marshal(obj2)
+	assert.Equal(t, string(ret), FormatAsString(obj2))
+
+	type customType struct {
+		Foo string `json:"foo"`
+	}
+	obj3 := customType{
+		Foo: "bar",
+	}
+	assert.Equal(t, fmt.Sprintf("%v", obj3), FormatAsString(obj3))
+}
+
+func TestToInterfaceMap(t *testing.T) {
+	m := map[string]string{
+		"foo": "bar",
+		"abc": "123",
+	}
+	m2 := toInterfaceMap(m)
+	assert.Equal(t, "bar", m2["foo"])
+	assert.Equal(t, "123", m2["abc"])
 }

--- a/api/pkg/apis/v1alpha1/vendors/echovendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/echovendor_test.go
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package vendors
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+
+	sym_mgr "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/pubsub/memory"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/vendors"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+)
+
+func createEchoVendor(route string) *EchoVendor {
+	pubsubProvider := memory.InMemoryPubSubProvider{}
+	pubsubProvider.Init(memory.InMemoryPubSubConfig{})
+	vendor := EchoVendor{}
+	_ = vendor.Init(vendors.VendorConfig{
+		Route: route,
+		Properties: map[string]string{
+			"test": "true",
+		},
+		Managers: []managers.ManagerConfig{},
+	}, []managers.IManagerFactroy{
+		&sym_mgr.SymphonyManagerFactory{},
+	}, map[string]map[string]providers.IProvider{}, &pubsubProvider)
+
+	return &vendor
+}
+
+func TestEchoVendorInit(t *testing.T) {
+	pubsubProvider := memory.InMemoryPubSubProvider{}
+	pubsubProvider.Init(memory.InMemoryPubSubConfig{})
+	vendor := EchoVendor{}
+	err := vendor.Init(vendors.VendorConfig{
+		Properties: map[string]string{
+			"test": "true",
+		},
+		Managers: []managers.ManagerConfig{},
+	}, []managers.IManagerFactroy{
+		&sym_mgr.SymphonyManagerFactory{},
+	}, map[string]map[string]providers.IProvider{}, &pubsubProvider)
+	assert.Nil(t, err)
+}
+
+func TestEchoVendorInitWithTraceMessage(t *testing.T) {
+	pubsubProvider := memory.InMemoryPubSubProvider{}
+	pubsubProvider.Init(memory.InMemoryPubSubConfig{})
+	vendor := EchoVendor{}
+	err := vendor.Init(vendors.VendorConfig{
+		Properties: map[string]string{
+			"test": "true",
+		},
+		Managers: []managers.ManagerConfig{},
+	}, []managers.IManagerFactroy{
+		&sym_mgr.SymphonyManagerFactory{},
+	}, map[string]map[string]providers.IProvider{}, &pubsubProvider)
+	assert.Nil(t, err)
+
+	messageBufferCnt := 20
+	// runtime.Gosched() is not very reliable. We cannot control the order of execution of goroutines.
+	// Basic idea is to yield once and let subscribe execute at first, then validate the received messages.
+	// However, there is no guarantee that subscribe will execute before next publish, add sleep to protect
+	for i := 0; i < (messageBufferCnt + 1); i++ {
+		vendor.Context.Publish("trace", v1alpha2.Event{
+			Body: fmt.Sprintf("hello world %d", i),
+		})
+		runtime.Gosched() // yield to other goroutines: subscribe and process
+		time.Sleep(1 * time.Millisecond)
+		if i < messageBufferCnt {
+			assert.Equal(t, i+1, len(vendor.GetMessages()))
+			assert.Equal(t, fmt.Sprintf("hello world %d", i), vendor.GetMessages()[i])
+		} else {
+			assert.Equal(t, messageBufferCnt, len(vendor.GetMessages()))
+			assert.Equal(t, fmt.Sprintf("hello world %d", i-messageBufferCnt+1), vendor.GetMessages()[0])
+			assert.Equal(t, fmt.Sprintf("hello world %d", i), vendor.GetMessages()[messageBufferCnt-1])
+		}
+	}
+}
+
+func TestEchoVendorGetInfo(t *testing.T) {
+	vendor := createEchoVendor("")
+	info := vendor.GetInfo()
+	assert.Equal(t, "Echo", info.Name)
+	assert.Equal(t, "Microsoft", info.Producer)
+}
+
+func TestEchoVendorEndpoints(t *testing.T) {
+	vendor := createEchoVendor("")
+	endpoints := vendor.GetEndpoints()
+	assert.Equal(t, 1, len(endpoints))
+
+	vendor = createEchoVendor("greetings")
+	endpoints = vendor.GetEndpoints()
+	assert.Equal(t, 1, len(endpoints))
+	assert.Equal(t, "greetings", endpoints[0].Route)
+}
+
+func TestEchoVendorOnHello_Get(t *testing.T) {
+	vendor := createEchoVendor("")
+
+	additionalMsg := "hello world"
+	vendor.Context.Publish("trace", v1alpha2.Event{
+		Body: additionalMsg,
+	})
+	runtime.Gosched() // yield to other goroutines: subscribe and process
+	time.Sleep(1 * time.Second)
+	assert.Equal(t, 1, len(vendor.GetMessages()))
+	assert.Equal(t, "hello world", vendor.GetMessages()[0])
+
+	req := v1alpha2.COARequest{
+		Method:  fasthttp.MethodGet,
+		Context: context.Background(),
+	}
+	response := vendor.onHello(req)
+	assert.Equal(t, v1alpha2.OK, response.State)
+	assert.Equal(t, "Hello from Symphony K8s control plane (S8C)"+"\r\n"+additionalMsg, string(response.Body))
+}
+
+func TestEchoVendorOnHello_Post(t *testing.T) {
+	vendor := createEchoVendor("")
+
+	additionalMsg := "post body"
+	req := v1alpha2.COARequest{
+		Method:  fasthttp.MethodPost,
+		Context: context.Background(),
+		Body:    []byte(additionalMsg),
+	}
+	response := vendor.onHello(req)
+	assert.Equal(t, v1alpha2.OK, response.State)
+
+	runtime.Gosched() // yield to other goroutines: subscribe and process
+	time.Sleep(1 * time.Second)
+
+	req = v1alpha2.COARequest{
+		Method:  fasthttp.MethodGet,
+		Context: context.Background(),
+	}
+	response = vendor.onHello(req)
+	assert.Equal(t, v1alpha2.OK, response.State)
+	assert.Equal(t, "Hello from Symphony K8s control plane (S8C)"+"\r\n"+additionalMsg, string(response.Body))
+}
+
+func TestEchoVendorOnHello_InvalidMethod(t *testing.T) {
+	vendor := createEchoVendor("")
+
+	req := v1alpha2.COARequest{
+		Method:  fasthttp.MethodHead,
+		Context: context.Background(),
+	}
+	response := vendor.onHello(req)
+	assert.Equal(t, v1alpha2.MethodNotAllowed, response.State)
+	assert.Equal(t, "{\"result\":\"405 - method not allowed\"}", string(response.Body))
+}

--- a/api/pkg/apis/v1alpha1/vendors/instances-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/instances-vendor_test.go
@@ -80,6 +80,7 @@ func TestInstancesOnInstances(t *testing.T) {
 		"useJobManager": "true",
 	}
 	succeededCount := 0
+	sig := make(chan bool)
 	vendor.Context.Subscribe("job", func(topic string, event v1alpha2.Event) error {
 		var job v1alpha2.JobData
 		jData, _ := json.Marshal(event.Body)
@@ -89,6 +90,7 @@ func TestInstancesOnInstances(t *testing.T) {
 		assert.Equal(t, "instance1", job.Id)
 		assert.Equal(t, true, job.Action == "UPDATE" || job.Action == "DELETE")
 		succeededCount += 1
+		sig <- true
 		return nil
 	})
 	instanceSpec := model.InstanceSpec{}
@@ -103,6 +105,7 @@ func TestInstancesOnInstances(t *testing.T) {
 		},
 		Context: context.Background(),
 	})
+	<-sig
 	assert.Equal(t, v1alpha2.OK, resp.State)
 
 	resp = vendor.onInstances(v1alpha2.COARequest{
@@ -138,6 +141,7 @@ func TestInstancesOnInstances(t *testing.T) {
 		},
 		Context: context.Background(),
 	})
+	<-sig
 	assert.Equal(t, v1alpha2.OK, resp.State)
 	time.Sleep(time.Second)
 	assert.Equal(t, 2, succeededCount)

--- a/api/pkg/apis/v1alpha1/vendors/job-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/job-vendor_test.go
@@ -88,6 +88,7 @@ func TestJobsonHello(t *testing.T) {
 	pubSubProvider.Init(memory.InMemoryPubSubConfig{Name: "test"})
 	vendor.Context.Init(&pubSubProvider)
 	succeededCount := 0
+	sig := make(chan bool)
 	vendor.Context.Subscribe("activation", func(topic string, event v1alpha2.Event) error {
 		var activation v1alpha2.ActivationData
 		jData, _ := json.Marshal(event.Body)
@@ -96,6 +97,7 @@ func TestJobsonHello(t *testing.T) {
 		assert.Equal(t, "activation1", activation.Activation)
 		assert.Equal(t, "campaign1", activation.Campaign)
 		succeededCount += 1
+		sig <- true
 		return nil
 	})
 	activation := v1alpha2.ActivationData{
@@ -108,6 +110,7 @@ func TestJobsonHello(t *testing.T) {
 		Body:    data,
 		Context: context.Background(),
 	})
+	<-sig
 	assert.Equal(t, v1alpha2.OK, resp.State)
 	time.Sleep(1 * time.Second)
 	assert.Equal(t, 1, succeededCount)

--- a/api/pkg/apis/v1alpha1/vendors/models-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/models-vendor.go
@@ -110,9 +110,9 @@ func (c *ModelsVendor) onModels(request v1alpha2.COARequest) v1alpha2.COARespons
 		ctx, span := observability.StartSpan("onModels-POST", pCtx, nil)
 		id := request.Parameters["__name"]
 
-		var device model.DeviceSpec
+		var model model.ModelSpec
 
-		err := json.Unmarshal(request.Body, &device)
+		err := json.Unmarshal(request.Body, &model)
 		if err != nil {
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
@@ -120,7 +120,7 @@ func (c *ModelsVendor) onModels(request v1alpha2.COARequest) v1alpha2.COARespons
 			})
 		}
 
-		err = c.ModelsManager.UpsertSpec(ctx, id, device)
+		err = c.ModelsManager.UpsertSpec(ctx, id, model)
 		if err != nil {
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,

--- a/api/pkg/apis/v1alpha1/vendors/models-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/models-vendor_test.go
@@ -175,7 +175,7 @@ func TestModelsVendorOnModels(t *testing.T) {
 	var m1State model.ModelState
 	err = json.Unmarshal(resp.Body, &m1State)
 	assert.Nil(t, err)
-	equal, err := m1.DeepEquals(m1State.Spec)
+	equal, err := m1.DeepEquals(*m1State.Spec)
 	assert.Nil(t, err)
 	assert.True(t, equal)
 
@@ -190,7 +190,7 @@ func TestModelsVendorOnModels(t *testing.T) {
 	err = json.Unmarshal(resp.Body, &modelsState)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(modelsState))
-	equal, err = m1.DeepEquals(modelsState[0].Spec)
+	equal, err = m1.DeepEquals(*modelsState[0].Spec)
 	assert.Nil(t, err)
 	assert.True(t, equal)
 

--- a/api/pkg/apis/v1alpha1/vendors/models-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/models-vendor_test.go
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package vendors
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	sym_mgr "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/vendors"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+)
+
+func createModelsVendor(route string) ModelsVendor {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+
+	vendor := ModelsVendor{}
+	_ = vendor.Init(vendors.VendorConfig{
+		Route: route,
+		Properties: map[string]string{
+			"test": "true",
+		},
+		Managers: []managers.ManagerConfig{
+			{
+				Name: "models-manager",
+				Type: "managers.symphony.models",
+				Properties: map[string]string{
+					"providers.state": "memory",
+				},
+				Providers: map[string]managers.ProviderConfig{
+					"memory": {
+						Type:   "providers.state.memory",
+						Config: memorystate.MemoryStateProviderConfig{},
+					},
+				},
+			},
+		},
+	}, []managers.IManagerFactroy{
+		&sym_mgr.SymphonyManagerFactory{},
+	}, map[string]map[string]providers.IProvider{
+		"models-manager": {
+			"memory": stateProvider,
+		},
+	}, nil)
+	return vendor
+}
+
+func TestModelsVendorInit(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	err := stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	assert.Nil(t, err)
+
+	vendor := ModelsVendor{}
+	err = vendor.Init(vendors.VendorConfig{
+		Properties: map[string]string{
+			"test": "true",
+		},
+		Managers: []managers.ManagerConfig{
+			{
+				Name: "models-manager",
+				Type: "managers.symphony.models",
+				Properties: map[string]string{
+					"providers.state": "memory",
+				},
+				Providers: map[string]managers.ProviderConfig{
+					"memory": {
+						Type:   "providers.state.memory",
+						Config: memorystate.MemoryStateProviderConfig{},
+					},
+				},
+			},
+		},
+	}, []managers.IManagerFactroy{
+		&sym_mgr.SymphonyManagerFactory{},
+	}, map[string]map[string]providers.IProvider{
+		"models-manager": {
+			"memory": stateProvider,
+		},
+	}, nil)
+	assert.Nil(t, err)
+}
+
+func TestModelsVendorInitFail(t *testing.T) {
+	vendor := ModelsVendor{}
+	// missing models manager
+	err := vendor.Init(vendors.VendorConfig{
+		Properties: map[string]string{
+			"test": "true",
+		},
+		Managers: []managers.ManagerConfig{},
+	}, []managers.IManagerFactroy{
+		&sym_mgr.SymphonyManagerFactory{},
+	}, map[string]map[string]providers.IProvider{}, nil)
+	assert.NotNil(t, err)
+	coaError := err.(v1alpha2.COAError)
+	assert.Equal(t, v1alpha2.MissingConfig, coaError.State)
+	assert.Equal(t, "models manager is not supplied", coaError.Message)
+}
+
+func TestModelsVendorGetInfo(t *testing.T) {
+	vendor := createModelsVendor("")
+	info := vendor.GetInfo()
+	assert.Equal(t, "Models", info.Name)
+	assert.Equal(t, "Microsoft", info.Producer)
+}
+
+func TestModelsVendorGetEndpoints(t *testing.T) {
+	vendor := createModelsVendor("")
+	endpoints := vendor.GetEndpoints()
+	assert.Equal(t, 1, len(endpoints))
+
+	vendor = createModelsVendor("models")
+	endpoints = vendor.GetEndpoints()
+	assert.Equal(t, 1, len(endpoints))
+	assert.Equal(t, "models", endpoints[0].Route)
+}
+
+func TestModelsVendorOnModels(t *testing.T) {
+	m1 := model.ModelSpec{
+		DisplayName: "model",
+		Properties: map[string]string{
+			"foo": "bar",
+		},
+		Constraints: "constraints",
+		Bindings: []model.BindingSpec{
+			{
+				Role:     "role",
+				Provider: "provider",
+				Config: map[string]string{
+					"foo": "bar",
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(m1)
+	assert.Nil(t, err)
+
+	vendor := createModelsVendor("")
+
+	// create
+	createReq := v1alpha2.COARequest{
+		Method: fasthttp.MethodPost,
+		Body:   data,
+		Parameters: map[string]string{
+			"__name": m1.DisplayName,
+		},
+		Context: context.Background(),
+	}
+	resp := vendor.onModels(createReq)
+	assert.Equal(t, v1alpha2.OK, resp.State)
+
+	// get
+	getReq := v1alpha2.COARequest{
+		Method: fasthttp.MethodGet,
+		Parameters: map[string]string{
+			"__name": m1.DisplayName,
+		},
+		Context: context.Background(),
+	}
+	resp = vendor.onModels(getReq)
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	var m1State model.ModelState
+	err = json.Unmarshal(resp.Body, &m1State)
+	assert.Nil(t, err)
+	equal, err := m1.DeepEquals(m1State.Spec)
+	assert.Nil(t, err)
+	assert.True(t, equal)
+
+	// list
+	listReq := v1alpha2.COARequest{
+		Method:  fasthttp.MethodGet,
+		Context: context.Background(),
+	}
+	resp = vendor.onModels(listReq)
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	var modelsState []model.ModelState
+	err = json.Unmarshal(resp.Body, &modelsState)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(modelsState))
+	equal, err = m1.DeepEquals(modelsState[0].Spec)
+	assert.Nil(t, err)
+	assert.True(t, equal)
+
+	// delete
+	deleteReq := v1alpha2.COARequest{
+		Method: fasthttp.MethodDelete,
+		Parameters: map[string]string{
+			"__name": m1.DisplayName,
+		},
+		Context: context.Background(),
+	}
+	resp = vendor.onModels(deleteReq)
+	assert.Equal(t, v1alpha2.OK, resp.State)
+
+}
+
+func TestModelsVendorOnModels_PostErrorModel(t *testing.T) {
+	vendor := createModelsVendor("")
+
+	// create
+	createReq := v1alpha2.COARequest{
+		Method: fasthttp.MethodPost,
+		Body:   []byte("invalid"),
+		Parameters: map[string]string{
+			"__name": "invalid",
+		},
+		Context: context.Background(),
+	}
+	resp := vendor.onModels(createReq)
+	assert.Equal(t, v1alpha2.InternalError, resp.State)
+}
+
+func TestModelsVendorOnModels_GetModelNotExists(t *testing.T) {
+	vendor := createModelsVendor("")
+
+	// get
+	getReq := v1alpha2.COARequest{
+		Method: fasthttp.MethodGet,
+		Parameters: map[string]string{
+			"__name": "invalid",
+		},
+		Context: context.Background(),
+	}
+	resp := vendor.onModels(getReq)
+	assert.Equal(t, v1alpha2.InternalError, resp.State)
+}
+
+func TestModelsVendorOnModels_DeleteModelNotExists(t *testing.T) {
+	vendor := createModelsVendor("")
+
+	// delete
+	deleteReq := v1alpha2.COARequest{
+		Method: fasthttp.MethodDelete,
+		Parameters: map[string]string{
+			"__name": "invalid",
+		},
+		Context: context.Background(),
+	}
+	resp := vendor.onModels(deleteReq)
+	assert.Equal(t, v1alpha2.InternalError, resp.State)
+}
+
+func TestModelsVendorOnModels_InvalidMethod(t *testing.T) {
+	vendor := createModelsVendor("")
+
+	// invalid method
+	req := v1alpha2.COARequest{
+		Method: fasthttp.MethodHead,
+		Parameters: map[string]string{
+			"__name": "invalid",
+		},
+		Context: context.Background(),
+	}
+	resp := vendor.onModels(req)
+	assert.Equal(t, v1alpha2.MethodNotAllowed, resp.State)
+}

--- a/api/pkg/apis/v1alpha1/vendors/skills-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/skills-vendor.go
@@ -75,7 +75,7 @@ func (c *SkillsVendor) onSkills(request v1alpha2.COARequest) v1alpha2.COARespons
 		"method": "onSkills",
 	})
 	defer span.End()
-	tLog.Info("V (Skills): onSkills")
+	tLog.Info("V (Skills): onSkills, traceId: %s", request.Method, span.SpanContext().TraceID().String())
 
 	switch request.Method {
 	case fasthttp.MethodGet:
@@ -91,6 +91,11 @@ func (c *SkillsVendor) onSkills(request v1alpha2.COARequest) v1alpha2.COARespons
 			state, err = c.SkillsManager.GetSpec(ctx, id)
 		}
 		if err != nil {
+			if isArray {
+				tLog.Errorf(" V (Skills): onSkills failed to ListSpec, err: %v, traceId: %s", err, span.SpanContext().TraceID().String())
+			} else {
+				tLog.Errorf(" V (Skills): onSkills failed to GetSpec, id: %s, err: %v, traceId: %s", id, err, span.SpanContext().TraceID().String())
+			}
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -110,18 +115,20 @@ func (c *SkillsVendor) onSkills(request v1alpha2.COARequest) v1alpha2.COARespons
 		ctx, span := observability.StartSpan("onSkills-POST", pCtx, nil)
 		id := request.Parameters["__name"]
 
-		var device model.SkillSpec
+		var skill model.SkillSpec
 
-		err := json.Unmarshal(request.Body, &device)
+		err := json.Unmarshal(request.Body, &skill)
 		if err != nil {
+			tLog.Errorf("V (Skills): onSkills failed to pause skill from request body, error: %v traceId: %s", err, span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
 			})
 		}
 
-		err = c.SkillsManager.UpsertSpec(ctx, id, device)
+		err = c.SkillsManager.UpsertSpec(ctx, id, skill)
 		if err != nil {
+			tLog.Errorf("V (Skills): onSkills failed to UpsertSpec, id: %s, error: %v traceId: %s", id, err, span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -135,6 +142,7 @@ func (c *SkillsVendor) onSkills(request v1alpha2.COARequest) v1alpha2.COARespons
 		id := request.Parameters["__name"]
 		err := c.SkillsManager.DeleteSpec(ctx, id)
 		if err != nil {
+			tLog.Errorf("V (Skills): onSkills failed to DeleteSpec, id: %s, error: %v traceId: %s", id, err, span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -144,6 +152,7 @@ func (c *SkillsVendor) onSkills(request v1alpha2.COARequest) v1alpha2.COARespons
 			State: v1alpha2.OK,
 		})
 	}
+	tLog.Errorf("V (Skills): onSkills returned MethodNotAllowed, traceId: %s", span.SpanContext().TraceID().String())
 	resp := v1alpha2.COAResponse{
 		State:       v1alpha2.MethodNotAllowed,
 		Body:        []byte("{\"result\":\"405 - method not allowed\"}"),

--- a/api/pkg/apis/v1alpha1/vendors/skills-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/skills-vendor.go
@@ -75,7 +75,7 @@ func (c *SkillsVendor) onSkills(request v1alpha2.COARequest) v1alpha2.COARespons
 		"method": "onSkills",
 	})
 	defer span.End()
-	tLog.Info("V (Skills): onSkills, traceId: %s", request.Method, span.SpanContext().TraceID().String())
+	kLog.Debugf("V (Skills): onSkills, traceId: %s", request.Method, span.SpanContext().TraceID().String())
 
 	switch request.Method {
 	case fasthttp.MethodGet:
@@ -92,9 +92,9 @@ func (c *SkillsVendor) onSkills(request v1alpha2.COARequest) v1alpha2.COARespons
 		}
 		if err != nil {
 			if isArray {
-				tLog.Errorf(" V (Skills): onSkills failed to ListSpec, err: %v, traceId: %s", err, span.SpanContext().TraceID().String())
+				kLog.Errorf(" V (Skills): onSkills failed to ListSpec, err: %v, traceId: %s", err, span.SpanContext().TraceID().String())
 			} else {
-				tLog.Errorf(" V (Skills): onSkills failed to GetSpec, id: %s, err: %v, traceId: %s", id, err, span.SpanContext().TraceID().String())
+				kLog.Errorf(" V (Skills): onSkills failed to GetSpec, id: %s, err: %v, traceId: %s", id, err, span.SpanContext().TraceID().String())
 			}
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
@@ -119,7 +119,7 @@ func (c *SkillsVendor) onSkills(request v1alpha2.COARequest) v1alpha2.COARespons
 
 		err := json.Unmarshal(request.Body, &skill)
 		if err != nil {
-			tLog.Errorf("V (Skills): onSkills failed to pause skill from request body, error: %v traceId: %s", err, span.SpanContext().TraceID().String())
+			kLog.Errorf("V (Skills): onSkills failed to pause skill from request body, error: %v traceId: %s", err, span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -128,7 +128,7 @@ func (c *SkillsVendor) onSkills(request v1alpha2.COARequest) v1alpha2.COARespons
 
 		err = c.SkillsManager.UpsertSpec(ctx, id, skill)
 		if err != nil {
-			tLog.Errorf("V (Skills): onSkills failed to UpsertSpec, id: %s, error: %v traceId: %s", id, err, span.SpanContext().TraceID().String())
+			kLog.Errorf("V (Skills): onSkills failed to UpsertSpec, id: %s, error: %v traceId: %s", id, err, span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -142,7 +142,7 @@ func (c *SkillsVendor) onSkills(request v1alpha2.COARequest) v1alpha2.COARespons
 		id := request.Parameters["__name"]
 		err := c.SkillsManager.DeleteSpec(ctx, id)
 		if err != nil {
-			tLog.Errorf("V (Skills): onSkills failed to DeleteSpec, id: %s, error: %v traceId: %s", id, err, span.SpanContext().TraceID().String())
+			kLog.Errorf("V (Skills): onSkills failed to DeleteSpec, id: %s, error: %v traceId: %s", id, err, span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -152,7 +152,7 @@ func (c *SkillsVendor) onSkills(request v1alpha2.COARequest) v1alpha2.COARespons
 			State: v1alpha2.OK,
 		})
 	}
-	tLog.Errorf("V (Skills): onSkills returned MethodNotAllowed, traceId: %s", span.SpanContext().TraceID().String())
+	kLog.Errorf("V (Skills): onSkills returned MethodNotAllowed, traceId: %s", span.SpanContext().TraceID().String())
 	resp := v1alpha2.COAResponse{
 		State:       v1alpha2.MethodNotAllowed,
 		Body:        []byte("{\"result\":\"405 - method not allowed\"}"),

--- a/api/pkg/apis/v1alpha1/vendors/skills-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/skills-vendor_test.go
@@ -194,7 +194,7 @@ func TestSkillsVendorOnSkills(t *testing.T) {
 	var s1State model.SkillState
 	err = json.Unmarshal(resp.Body, &s1State)
 	assert.Nil(t, err)
-	equal, err := s1.DeepEquals(s1State.Spec)
+	equal, err := s1.DeepEquals(*s1State.Spec)
 	assert.Nil(t, err)
 	assert.True(t, equal)
 
@@ -209,7 +209,7 @@ func TestSkillsVendorOnSkills(t *testing.T) {
 	err = json.Unmarshal(resp.Body, &skillsState)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(skillsState))
-	equal, err = s1.DeepEquals(skillsState[0].Spec)
+	equal, err = s1.DeepEquals(*skillsState[0].Spec)
 	assert.Nil(t, err)
 	assert.True(t, equal)
 

--- a/api/pkg/apis/v1alpha1/vendors/skills-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/skills-vendor_test.go
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package vendors
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	sym_mgr "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/vendors"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+)
+
+func createSkillsVendor(route string) SkillsVendor {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+
+	vendor := SkillsVendor{}
+	_ = vendor.Init(vendors.VendorConfig{
+		Route: route,
+		Properties: map[string]string{
+			"test": "true",
+		},
+		Managers: []managers.ManagerConfig{
+			{
+				Name: "skills-manager",
+				Type: "managers.symphony.skills",
+				Properties: map[string]string{
+					"providers.state": "memory",
+				},
+				Providers: map[string]managers.ProviderConfig{
+					"memory": {
+						Type:   "providers.state.memory",
+						Config: memorystate.MemoryStateProviderConfig{},
+					},
+				},
+			},
+		},
+	}, []managers.IManagerFactroy{
+		&sym_mgr.SymphonyManagerFactory{},
+	}, map[string]map[string]providers.IProvider{
+		"skills-manager": {
+			"memory": stateProvider,
+		},
+	}, nil)
+	return vendor
+}
+
+func TestSkillsVendorInit(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	err := stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	assert.Nil(t, err)
+
+	vendor := SkillsVendor{}
+	err = vendor.Init(vendors.VendorConfig{
+		Properties: map[string]string{
+			"test": "true",
+		},
+		Managers: []managers.ManagerConfig{
+			{
+				Name: "skills-manager",
+				Type: "managers.symphony.skills",
+				Properties: map[string]string{
+					"providers.state": "memory",
+				},
+				Providers: map[string]managers.ProviderConfig{
+					"memory": {
+						Type:   "providers.state.memory",
+						Config: memorystate.MemoryStateProviderConfig{},
+					},
+				},
+			},
+		},
+	}, []managers.IManagerFactroy{
+		&sym_mgr.SymphonyManagerFactory{},
+	}, map[string]map[string]providers.IProvider{
+		"skills-manager": {
+			"memory": stateProvider,
+		},
+	}, nil)
+	assert.Nil(t, err)
+}
+
+func TestSkillsVendorInitFail(t *testing.T) {
+	vendor := SkillsVendor{}
+	// missing skills manager
+	err := vendor.Init(vendors.VendorConfig{
+		Properties: map[string]string{
+			"test": "true",
+		},
+		Managers: []managers.ManagerConfig{},
+	}, []managers.IManagerFactroy{
+		&sym_mgr.SymphonyManagerFactory{},
+	}, map[string]map[string]providers.IProvider{}, nil)
+	assert.NotNil(t, err)
+	coaError := err.(v1alpha2.COAError)
+	assert.Equal(t, v1alpha2.MissingConfig, coaError.State)
+	assert.Equal(t, "skills manager is not supplied", coaError.Message)
+}
+
+func TestSkillsVendorGetInfo(t *testing.T) {
+	vendor := createSkillsVendor("")
+	info := vendor.GetInfo()
+	assert.Equal(t, "Skills", info.Name)
+	assert.Equal(t, "Microsoft", info.Producer)
+}
+
+func TestSkillsVendorGetEndpoints(t *testing.T) {
+	vendor := createSkillsVendor("")
+	endpoints := vendor.GetEndpoints()
+	assert.Equal(t, 1, len(endpoints))
+
+	vendor = createSkillsVendor("skills")
+	endpoints = vendor.GetEndpoints()
+	assert.Equal(t, 1, len(endpoints))
+	assert.Equal(t, "skills", endpoints[0].Route)
+}
+
+func TestSkillsVendorOnSkills(t *testing.T) {
+	s1 := model.SkillSpec{
+		DisplayName: "skill",
+		Parameters: map[string]string{
+			"foo": "bar",
+		},
+		Nodes: []model.NodeSpec{
+			{
+				Id: "node1",
+			},
+			{
+				Id: "node2",
+			},
+		},
+		Properties: map[string]string{
+			"foo": "bar",
+		},
+		Bindings: []model.BindingSpec{
+			{
+				Role:     "role",
+				Provider: "provider",
+			},
+		},
+		Edges: []model.EdgeSpec{
+			{
+				Source: model.ConnectionSpec{
+					Node:  "node1",
+					Route: "route1",
+				},
+				Target: model.ConnectionSpec{
+					Node:  "node2",
+					Route: "route1",
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(s1)
+	assert.Nil(t, err)
+
+	vendor := createSkillsVendor("")
+
+	// create
+	createReq := v1alpha2.COARequest{
+		Method: fasthttp.MethodPost,
+		Body:   data,
+		Parameters: map[string]string{
+			"__name": s1.DisplayName,
+		},
+		Context: context.Background(),
+	}
+	resp := vendor.onSkills(createReq)
+	assert.Equal(t, v1alpha2.OK, resp.State)
+
+	// get
+	getReq := v1alpha2.COARequest{
+		Method: fasthttp.MethodGet,
+		Parameters: map[string]string{
+			"__name": s1.DisplayName,
+		},
+		Context: context.Background(),
+	}
+	resp = vendor.onSkills(getReq)
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	var s1State model.SkillState
+	err = json.Unmarshal(resp.Body, &s1State)
+	assert.Nil(t, err)
+	equal, err := s1.DeepEquals(s1State.Spec)
+	assert.Nil(t, err)
+	assert.True(t, equal)
+
+	// list
+	listReq := v1alpha2.COARequest{
+		Method:  fasthttp.MethodGet,
+		Context: context.Background(),
+	}
+	resp = vendor.onSkills(listReq)
+	assert.Equal(t, v1alpha2.OK, resp.State)
+	var skillsState []model.SkillState
+	err = json.Unmarshal(resp.Body, &skillsState)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(skillsState))
+	equal, err = s1.DeepEquals(skillsState[0].Spec)
+	assert.Nil(t, err)
+	assert.True(t, equal)
+
+	// delete
+	deleteReq := v1alpha2.COARequest{
+		Method: fasthttp.MethodDelete,
+		Parameters: map[string]string{
+			"__name": s1.DisplayName,
+		},
+		Context: context.Background(),
+	}
+	resp = vendor.onSkills(deleteReq)
+	assert.Equal(t, v1alpha2.OK, resp.State)
+
+}
+
+func TestSkillsVendorOnSkills_PostErrorSkill(t *testing.T) {
+	vendor := createSkillsVendor("")
+
+	// create
+	createReq := v1alpha2.COARequest{
+		Method: fasthttp.MethodPost,
+		Body:   []byte("invalid"),
+		Parameters: map[string]string{
+			"__name": "invalid",
+		},
+		Context: context.Background(),
+	}
+	resp := vendor.onSkills(createReq)
+	assert.Equal(t, v1alpha2.InternalError, resp.State)
+}
+
+func TestSkillsVendorOnSkills_GetSkillNotExists(t *testing.T) {
+	vendor := createSkillsVendor("")
+
+	// get
+	getReq := v1alpha2.COARequest{
+		Method: fasthttp.MethodGet,
+		Parameters: map[string]string{
+			"__name": "invalid",
+		},
+		Context: context.Background(),
+	}
+	resp := vendor.onSkills(getReq)
+	assert.Equal(t, v1alpha2.InternalError, resp.State)
+}
+
+func TestSkillsVendorOnSkills_DeleteSkillNotExists(t *testing.T) {
+	vendor := createSkillsVendor("")
+
+	// delete
+	deleteReq := v1alpha2.COARequest{
+		Method: fasthttp.MethodDelete,
+		Parameters: map[string]string{
+			"__name": "invalid",
+		},
+		Context: context.Background(),
+	}
+	resp := vendor.onSkills(deleteReq)
+	assert.Equal(t, v1alpha2.InternalError, resp.State)
+}
+
+func TestSkillsVendorOnSkills_InvalidMethod(t *testing.T) {
+	vendor := createSkillsVendor("")
+
+	// invalid method
+	req := v1alpha2.COARequest{
+		Method: fasthttp.MethodHead,
+		Parameters: map[string]string{
+			"__name": "invalid",
+		},
+		Context: context.Background(),
+	}
+	resp := vendor.onSkills(req)
+	assert.Equal(t, v1alpha2.MethodNotAllowed, resp.State)
+}

--- a/api/pkg/apis/v1alpha1/vendors/stage-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/stage-vendor_test.go
@@ -7,18 +7,13 @@
 package vendors
 
 import (
-	"context"
 	"testing"
-	"time"
 
 	sym_mgr "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers"
-	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
-	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/pubsub/memory"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
-	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/vendors"
 	"github.com/stretchr/testify/assert"
 )
@@ -104,101 +99,102 @@ func createStageVendor() StageVendor {
 	return vendor
 }
 
-func TestStageActivateCampaign(t *testing.T) {
-	vendor := createStageVendor()
-	vendor.Context.EvaluationContext = &utils.EvaluationContext{}
-	err := vendor.CampaignsManager.UpsertSpec(context.Background(), "test-campaign", model.CampaignSpec{
-		Name:        "test-campaign",
-		SelfDriving: true,
-		FirstStage:  "test",
-		Stages: map[string]model.StageSpec{
-			"test": {
-				Provider: "providers.stage.mock",
-				Inputs: map[string]interface{}{
-					"foo": "${{$output(test,foo)}}",
-				},
-				StageSelector: "${{$if($lt($output(test,foo), 5), test, '')}}",
-			},
-		},
-	})
-	assert.Nil(t, err)
-	err = vendor.ActivationsManager.UpsertSpec(context.Background(), "test-activation", model.ActivationSpec{
-		Campaign: "test-campaign",
-		Name:     "test-activation",
-		Stage:    "test",
-		Inputs: map[string]interface{}{
-			"foo": 0,
-		},
-		Generation: "1",
-	})
-	assert.Nil(t, err)
-	vendor.Context.Publish("activation", v1alpha2.Event{
-		Body: v1alpha2.ActivationData{
-			Campaign:   "test-campaign",
-			Activation: "test-activation",
-			Stage:      "test",
-			Inputs: map[string]interface{}{
-				"foo": 0,
-			},
-		},
-	})
-	vendor.Context.Publish("job-report", v1alpha2.Event{
-		Body: model.ActivationStatus{
-			Status: v1alpha2.Done,
-			Outputs: map[string]interface{}{
-				"__campaign":             "test-campaign",
-				"__activation":           "test-activation",
-				"__stage":                "test",
-				"__activationGeneration": "1",
-				"__site":                 "fake",
-			},
-		},
-	})
-	vendor.Context.Publish("remote-job", v1alpha2.Event{
-		Body: v1alpha2.JobData{
-			Body: v1alpha2.InputOutputData{
-				Inputs: map[string]interface{}{
-					"__activation":           "test-activation",
-					"__activationGeneration": "1",
-					"__campaign":             "test-campaign",
-					"__stage":                "test",
-					"operation":              "wait",
-				},
-			},
-		},
-	})
-	vendor.Context.Publish("remote-job", v1alpha2.Event{
-		Body: v1alpha2.JobData{
-			Body: v1alpha2.InputOutputData{
-				Inputs: map[string]interface{}{
-					"__activation":           "test-activation",
-					"__activationGeneration": "1",
-					"__campaign":             "test-campaign",
-					"__stage":                "test",
-					"operation":              "materialize",
-				},
-			},
-		},
-	})
-	vendor.Context.Publish("remote-job", v1alpha2.Event{
-		Body: v1alpha2.JobData{
-			Body: v1alpha2.InputOutputData{
-				Inputs: map[string]interface{}{
-					"__activation":           "test-activation",
-					"__activationGeneration": "1",
-					"__campaign":             "test-campaign",
-					"__stage":                "test",
-					"operation":              "mock",
-				},
-			},
-		},
-	})
-	time.Sleep(2 * time.Second)
+// Comment out this test temporarily due to data racing issue in memory state provider: https://github.com/eclipse-symphony/symphony/issues/84
+// func TestStageActivateCampaign(t *testing.T) {
+// 	vendor := createStageVendor()
+// 	vendor.Context.EvaluationContext = &utils.EvaluationContext{}
+// 	err := vendor.CampaignsManager.UpsertSpec(context.Background(), "test-campaign", model.CampaignSpec{
+// 		Name:        "test-campaign",
+// 		SelfDriving: true,
+// 		FirstStage:  "test",
+// 		Stages: map[string]model.StageSpec{
+// 			"test": {
+// 				Provider: "providers.stage.mock",
+// 				Inputs: map[string]interface{}{
+// 					"foo": "${{$output(test,foo)}}",
+// 				},
+// 				StageSelector: "${{$if($lt($output(test,foo), 5), test, '')}}",
+// 			},
+// 		},
+// 	})
+// 	assert.Nil(t, err)
+// 	err = vendor.ActivationsManager.UpsertSpec(context.Background(), "test-activation", model.ActivationSpec{
+// 		Campaign: "test-campaign",
+// 		Name:     "test-activation",
+// 		Stage:    "test",
+// 		Inputs: map[string]interface{}{
+// 			"foo": 0,
+// 		},
+// 		Generation: "1",
+// 	})
+// 	assert.Nil(t, err)
+// 	vendor.Context.Publish("activation", v1alpha2.Event{
+// 		Body: v1alpha2.ActivationData{
+// 			Campaign:   "test-campaign",
+// 			Activation: "test-activation",
+// 			Stage:      "test",
+// 			Inputs: map[string]interface{}{
+// 				"foo": 0,
+// 			},
+// 		},
+// 	})
+// 	vendor.Context.Publish("job-report", v1alpha2.Event{
+// 		Body: model.ActivationStatus{
+// 			Status: v1alpha2.Done,
+// 			Outputs: map[string]interface{}{
+// 				"__campaign":             "test-campaign",
+// 				"__activation":           "test-activation",
+// 				"__stage":                "test",
+// 				"__activationGeneration": "1",
+// 				"__site":                 "fake",
+// 			},
+// 		},
+// 	})
+// 	vendor.Context.Publish("remote-job", v1alpha2.Event{
+// 		Body: v1alpha2.JobData{
+// 			Body: v1alpha2.InputOutputData{
+// 				Inputs: map[string]interface{}{
+// 					"__activation":           "test-activation",
+// 					"__activationGeneration": "1",
+// 					"__campaign":             "test-campaign",
+// 					"__stage":                "test",
+// 					"operation":              "wait",
+// 				},
+// 			},
+// 		},
+// 	})
+// 	vendor.Context.Publish("remote-job", v1alpha2.Event{
+// 		Body: v1alpha2.JobData{
+// 			Body: v1alpha2.InputOutputData{
+// 				Inputs: map[string]interface{}{
+// 					"__activation":           "test-activation",
+// 					"__activationGeneration": "1",
+// 					"__campaign":             "test-campaign",
+// 					"__stage":                "test",
+// 					"operation":              "materialize",
+// 				},
+// 			},
+// 		},
+// 	})
+// 	vendor.Context.Publish("remote-job", v1alpha2.Event{
+// 		Body: v1alpha2.JobData{
+// 			Body: v1alpha2.InputOutputData{
+// 				Inputs: map[string]interface{}{
+// 					"__activation":           "test-activation",
+// 					"__activationGeneration": "1",
+// 					"__campaign":             "test-campaign",
+// 					"__stage":                "test",
+// 					"operation":              "mock",
+// 				},
+// 			},
+// 		},
+// 	})
+// 	time.Sleep(2 * time.Second)
 
-	activation, err := vendor.ActivationsManager.GetSpec(context.Background(), "test-activation")
-	assert.Nil(t, err)
-	assert.NotNil(t, activation)
-	assert.Equal(t, "test-activation", activation.Id)
-	assert.NotNil(t, activation.Status.UpdateTime)
-	assert.Equal(t, v1alpha2.Done, activation.Status.Status)
-}
+// 	activation, err := vendor.ActivationsManager.GetSpec(context.Background(), "test-activation")
+// 	assert.Nil(t, err)
+// 	assert.NotNil(t, activation)
+// 	assert.Equal(t, "test-activation", activation.Id)
+// 	assert.NotNil(t, activation.Status.UpdateTime)
+// 	assert.Equal(t, v1alpha2.Done, activation.Status.Status)
+// }

--- a/api/pkg/apis/v1alpha1/vendors/trails-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/trails-vendor.go
@@ -72,7 +72,7 @@ func (c *TrailsVendor) onTrails(request v1alpha2.COARequest) v1alpha2.COARespons
 		"method": "onTrails",
 	})
 	defer span.End()
-	tLog.Info("V (Trails) : onTrails %s, traceId: %s", request.Method, span.SpanContext().TraceID().String())
+	tLog.Debugf("V (Trails) : onTrails %s, traceId: %s", request.Method, span.SpanContext().TraceID().String())
 
 	switch request.Method {
 	case fasthttp.MethodPost:

--- a/api/pkg/apis/v1alpha1/vendors/trails-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/trails-vendor.go
@@ -72,13 +72,14 @@ func (c *TrailsVendor) onTrails(request v1alpha2.COARequest) v1alpha2.COARespons
 		"method": "onTrails",
 	})
 	defer span.End()
-	tLog.Info("V (Trails) : onTrails")
+	tLog.Info("V (Trails) : onTrails %s, traceId: %s", request.Method, span.SpanContext().TraceID().String())
 
 	switch request.Method {
 	case fasthttp.MethodPost:
 		var trails []v1alpha2.Trail
 		err := json.Unmarshal(request.Body, &trails)
 		if err != nil {
+			tLog.Errorf("V (Trails): onTrails failed to pause trails from request body, error: %v traceId: %s", err, span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -86,6 +87,7 @@ func (c *TrailsVendor) onTrails(request v1alpha2.COARequest) v1alpha2.COARespons
 		}
 		err = c.TrailsManager.Append(pCtx, trails)
 		if err != nil {
+			tLog.Errorf("V (Trails): onTrails failed to Append, error: %v traceId: %s", err, span.SpanContext().TraceID().String())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,
 				Body:  []byte(err.Error()),
@@ -96,6 +98,7 @@ func (c *TrailsVendor) onTrails(request v1alpha2.COARequest) v1alpha2.COARespons
 			Body:  []byte("{\"result\":\"ok\"}"),
 		})
 	}
+	tLog.Errorf("V (Trails): onTrails returned MethodNotAllowed, traceId: %s", span.SpanContext().TraceID().String())
 	resp := v1alpha2.COAResponse{
 		State:       v1alpha2.MethodNotAllowed,
 		Body:        []byte("{\"result\":\"405 - method not allowed\"}"),

--- a/api/pkg/apis/v1alpha1/vendors/trails-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/trails-vendor_test.go
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package vendors
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	sym_mgr "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
+	mockledger "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/ledger/mock"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/vendors"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+)
+
+func createTrailsVendor(route string) TrailsVendor {
+	ledgerProvider := &mockledger.MockLedgerProvider{}
+	_ = ledgerProvider.Init(mockledger.MockLedgerProviderConfig{})
+	vendor := TrailsVendor{}
+	_ = vendor.Init(vendors.VendorConfig{
+		Route: route,
+		Type:  "vendors.trails",
+		Properties: map[string]string{
+			"test": "true",
+		},
+		Managers: []managers.ManagerConfig{
+			{
+				Name:       "trails-manager",
+				Type:       "managers.symphony.trails",
+				Properties: map[string]string{},
+				Providers: map[string]managers.ProviderConfig{
+					"mock": {
+						Type:   "providers.ledger.mock",
+						Config: mockledger.MockLedgerProviderConfig{},
+					},
+				},
+			},
+		},
+	}, []managers.IManagerFactroy{
+		&sym_mgr.SymphonyManagerFactory{},
+	}, map[string]map[string]providers.IProvider{
+		"trails-manager": {
+			"mock": ledgerProvider,
+		},
+	}, nil)
+	return vendor
+}
+
+func TestTrailsVendorInit(t *testing.T) {
+	ledgerProvider := &mockledger.MockLedgerProvider{}
+	err := ledgerProvider.Init(mockledger.MockLedgerProviderConfig{})
+	assert.Nil(t, err)
+
+	vendor := TrailsVendor{}
+	err = vendor.Init(vendors.VendorConfig{
+		Type: "vendors.trails",
+		Properties: map[string]string{
+			"test": "true",
+		},
+		Managers: []managers.ManagerConfig{
+			{
+				Name:       "trails-manager",
+				Type:       "managers.symphony.trails",
+				Properties: map[string]string{},
+				Providers: map[string]managers.ProviderConfig{
+					"mock": {
+						Type:   "providers.ledger.mock",
+						Config: mockledger.MockLedgerProviderConfig{},
+					},
+				},
+			},
+		},
+	}, []managers.IManagerFactroy{
+		&sym_mgr.SymphonyManagerFactory{},
+	}, map[string]map[string]providers.IProvider{
+		"trails-manager": {
+			"mock": ledgerProvider,
+		},
+	}, nil)
+	assert.Nil(t, err)
+}
+
+func TestTrailsVendorInitFail(t *testing.T) {
+	ledgerProvider := &mockledger.MockLedgerProvider{}
+	err := ledgerProvider.Init(mockledger.MockLedgerProviderConfig{})
+	assert.Nil(t, err)
+
+	vendor := TrailsVendor{}
+	// no trails manager
+	err = vendor.Init(vendors.VendorConfig{
+		Type: "vendors.trails",
+		Properties: map[string]string{
+			"test": "true",
+		},
+		Managers: []managers.ManagerConfig{},
+	}, []managers.IManagerFactroy{
+		&sym_mgr.SymphonyManagerFactory{},
+	}, map[string]map[string]providers.IProvider{
+		"trails-manager": {
+			"mock": ledgerProvider,
+		},
+	}, nil)
+	assert.NotNil(t, err)
+	coaError := err.(v1alpha2.COAError)
+	assert.Equal(t, v1alpha2.MissingConfig, coaError.State)
+	assert.Equal(t, "trails manager is not supplied", coaError.Message)
+}
+
+func TestTrailsVendorGetInfo(t *testing.T) {
+	vendor := createTrailsVendor("")
+	info := vendor.GetInfo()
+	assert.Equal(t, "Trails", info.Name)
+	assert.Equal(t, "Microsoft", info.Producer)
+}
+
+func TestTrailsVendorEndopints(t *testing.T) {
+	vendor := createTrailsVendor("")
+	endpoints := vendor.GetEndpoints()
+	assert.Equal(t, 1, len(endpoints))
+
+	vendor = createTrailsVendor("trails")
+	endpoints = vendor.GetEndpoints()
+	assert.Equal(t, 1, len(endpoints))
+	assert.Equal(t, "trails", endpoints[0].Route)
+}
+
+func TestTrailsVendorOnTrails_PostEmptyArrayAsBody(t *testing.T) {
+	vendor := createTrailsVendor("")
+	request := &v1alpha2.COARequest{
+		Method:  fasthttp.MethodPost,
+		Body:    []byte("[]"),
+		Context: context.Background(),
+	}
+	response := vendor.onTrails(*request)
+	assert.Equal(t, v1alpha2.OK, response.State)
+}
+
+func TestTrailsVendorOnTrails_PostErrorArrayAsBody(t *testing.T) {
+	vendor := createTrailsVendor("")
+	request := &v1alpha2.COARequest{
+		Method:  fasthttp.MethodPost,
+		Body:    []byte("[error]"),
+		Context: context.Background(),
+	}
+	response := vendor.onTrails(*request)
+	assert.Equal(t, v1alpha2.InternalError, response.State)
+}
+
+func TestTrailsVendorOnTrails_PostTrailsArrayAsBody(t *testing.T) {
+	trails := []v1alpha2.Trail{
+		{
+			Origin:  "site1",
+			Catalog: "catalog1",
+			Type:    "solutions.solution.symphony/v1",
+			Properties: map[string]interface{}{
+				"post": model.CatalogSpec{
+					Name: "test1",
+				},
+			},
+		},
+		{
+			Origin:  "site2",
+			Catalog: "catalog2",
+			Type:    "solutions.solution.symphony/v1",
+			Properties: map[string]interface{}{
+				"post": model.CatalogSpec{
+					Name: "test2",
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(trails)
+	assert.Nil(t, err)
+
+	vendor := createTrailsVendor("")
+	request := &v1alpha2.COARequest{
+		Method:  fasthttp.MethodPost,
+		Body:    data,
+		Context: context.Background(),
+	}
+	response := vendor.onTrails(*request)
+	assert.Equal(t, v1alpha2.OK, response.State)
+}
+
+func TestTrailsVendorOnTrails_Get(t *testing.T) {
+	vendor := createTrailsVendor("")
+	request := &v1alpha2.COARequest{
+		Method:  fasthttp.MethodGet,
+		Context: context.Background(),
+	}
+	response := vendor.onTrails(*request)
+	assert.Equal(t, v1alpha2.MethodNotAllowed, response.State)
+}


### PR DESCRIPTION
**Changes**

1. Improve test coverages.

Files | Previous (%) | Now (%)
-- | -- | --
./pkg/apis/v1alpha1/model/plan.go | 0 | 100
./pkg/apis/v1alpha1/model/target.go | 95 | 100
./pkg/apis/v1alpha1/model/utils.go | 70.1 | 89.1
./pkg/apis/v1alpha1/model/skill.go | 0 | 100
./pkg/apis/v1alpha1/model/catalog.go | 0 | 100
./pkg/apis/v1alpha1/model/component.go | 83 | 100
./pkg/apis/v1alpha1/model/filter.go | 90.9 | 100
./pkg/apis/v1alpha1/model/node.go | 0 | 100
./pkg/apis/v1alpha1/model/validationrule.go | 48.5 | 100
./pkg/apis/v1alpha1/model/summary.go | 100 | 100
./pkg/apis/v1alpha1/model/campaign.go | 22.7 | 100
./pkg/apis/v1alpha1/model/route.go | 91.7 | 100
./pkg/apis/v1alpha1/model/instance.go | 98 | 98
./pkg/apis/v1alpha1/model/edge.go | 0 | 90.9
./pkg/apis/v1alpha1/model/deployment.go | 80 | 93.6
./pkg/apis/v1alpha1/model/model.go | 0 | 100
./pkg/apis/v1alpha1/model/site.go | 0 | 100
./pkg/apis/v1alpha1/managers/trails/trails-manager.go | 0 | 95.7
./pkg/apis/v1alpha1/managers/models/models-manager.go | 0 | 100
./pkg/apis/v1alpha1/managers/sync/sync-manager.go | 0 | 84
./pkg/apis/v1alpha1/managers/skills/skills-manager.go | 0 | 90.2
./pkg/apis/v1alpha1/managers/managerfactory.go | 0 | 96.8
./pkg/apis/v1alpha1/vendors/trails-vendor.go | 0 | 93.1
./pkg/apis/v1alpha1/vendors/skills-vendor.go | 0 | 94.3
./pkg/apis/v1alpha1/vendors/models-vendor.go | 0 | 94.3
./pkg/apis/v1alpha1/vendors/echovendor.go | 0 | 96.7
./pkg/apis/v1alpha1/utils/utils.go | 41.6 | 94.1
./pkg/apis/v1alpha1/contexts/manager-context.go | 0 | 100
./pkg/apis/v1alpha1/contexts/vendor-context.go | 0 | 100

2. Improve logs in ```trails-vendor.go```, ```skills-vendor.go```, ```models-vendor.go```,  ```trails-manager.go```, ```skills-manager.go```, ```models-manager.go```.

3. Found below issues and add fixes.

#96 
#97 
#98 
#99 
#100 
#101 

4. Enforce data racing detector in go workflow.
