### PR TITLE
unit tests for stage providers

### DIFF
--- a/api/pkg/apis/v1alpha1/providers/providerfactory.go
+++ b/api/pkg/apis/v1alpha1/providers/providerfactory.go
@@ -581,6 +581,8 @@ func CreateProviderForTargetRole(context *contexts.ManagerContext, role string, 
 					if err != nil {
 						return nil, err
 					}
+					provider.Context = context
+					return provider, nil
 				case "providers.target.mock":
 					provider := &tgtmock.MockTargetProvider{}
 					err := provider.InitWithMap(binding.Config)

--- a/api/pkg/apis/v1alpha1/providers/providerfactory_test.go
+++ b/api/pkg/apis/v1alpha1/providers/providerfactory_test.go
@@ -1,0 +1,686 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package providers
+
+import (
+	"testing"
+
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	catalogconfig "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/config/catalog"
+	memorygraph "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/graph/memory"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/stage/counter"
+	symphonystage "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/stage/create"
+	delaystage "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/stage/delay"
+	httpstage "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/stage/http"
+	liststage "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/stage/list"
+	materialize "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/stage/materialize"
+	mockstage "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/stage/mock"
+	patchstage "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/stage/patch"
+	remotestage "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/stage/remote"
+	scriptstage "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/stage/script"
+	waitstage "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/stage/wait"
+	k8sstate "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/states/k8s"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/adb"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/azure/adu"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/azure/iotedge"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/configmap"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/docker"
+	targethttp "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/http"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/ingress"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/k8s"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/kubectl"
+	tgtmock "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/mock"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/proxy"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/script"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/staging"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/win10/sideload"
+	mockconfig "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/config/mock"
+	mockledger "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/ledger/mock"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/probe/rtsp"
+	mempubsub "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/pubsub/memory"
+	memoryqueue "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/queue/memory"
+	cvref "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/reference/customvision"
+	httpref "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/reference/http"
+	k8sref "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/reference/k8s"
+	httpreporter "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/reporter/http"
+	k8sreporter "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/reporter/k8s"
+	mocksecret "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/secret/mock"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/httpstate"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/uploader/azure/blob"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateProvider(t *testing.T) {
+	providerfactory := SymphonyProviderFactory{}
+	provider, err := providerfactory.CreateProvider("providers.state.memory", memorystate.MemoryStateProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*memorystate.MemoryStateProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.state.k8s", k8sstate.K8sStateProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*k8sstate.K8sStateProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.config.k8scatalog", k8sstate.K8sStateProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*k8sstate.K8sStateProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.state.http", httpstate.HttpStateProviderConfig{Url: "http://localhost:3500/v1.0/state/statestore"})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*httpstate.HttpStateProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.reference.k8s", k8sref.K8sReferenceProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*k8sref.K8sReferenceProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.reference.customvision", cvref.CustomVisionReferenceProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*cvref.CustomVisionReferenceProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.reference.http", httpref.HTTPReferenceProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*httpref.HTTPReferenceProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.reporter.k8s", k8sreporter.K8sReporterConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*k8sreporter.K8sReporter))
+
+	provider, err = providerfactory.CreateProvider("providers.reporter.http", httpreporter.HTTPReporterConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*httpreporter.HTTPReporter))
+
+	provider, err = providerfactory.CreateProvider("providers.probe.rtsp", rtsp.RTSPProbeProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*rtsp.RTSPProbeProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.uploader.azure.blob", blob.AzureBlobUploaderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*blob.AzureBlobUploader))
+
+	provider, err = providerfactory.CreateProvider("providers.ledger.mock", mockledger.MockLedgerProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*mockledger.MockLedgerProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.stage.counter", counter.CounterStageProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*counter.CounterStageProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.target.azure.iotedge", iotedge.IoTEdgeTargetProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*iotedge.IoTEdgeTargetProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.target.azure.adu", adu.ADUTargetProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*adu.ADUTargetProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.target.k8s", k8s.K8sTargetProviderConfig{ConfigType: "path"})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*k8s.K8sTargetProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.target.docker", docker.DockerTargetProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*docker.DockerTargetProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.target.ingress", ingress.IngressTargetProviderConfig{ConfigType: "path"})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*ingress.IngressTargetProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.target.kubectl", kubectl.KubectlTargetProviderConfig{ConfigType: "path"})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*kubectl.KubectlTargetProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.target.staging", staging.StagingTargetProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*staging.StagingTargetProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.target.script", script.ScriptProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*script.ScriptProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.target.http", targethttp.HttpTargetProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*targethttp.HttpTargetProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.target.win10.sideload", sideload.Win10SideLoadProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*sideload.Win10SideLoadProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.target.adb", adb.AdbProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*adb.AdbProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.target.proxy", proxy.ProxyUpdateProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*proxy.ProxyUpdateProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.target.mock", tgtmock.MockTargetProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*tgtmock.MockTargetProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.target.configmap", configmap.ConfigMapTargetProviderConfig{ConfigType: "path"})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*configmap.ConfigMapTargetProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.config.mock", mockconfig.MockConfigProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*mockconfig.MockConfigProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.config.catalog", catalogconfig.CatalogConfigProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*catalogconfig.CatalogConfigProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.secret.mock", mocksecret.MockSecretProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*mocksecret.MockSecretProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.pubsub.memory", mempubsub.InMemoryPubSubConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*mempubsub.InMemoryPubSubProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.stage.mock", mockstage.MockStageProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*mockstage.MockStageProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.stage.http", httpstage.HttpStageProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*httpstage.HttpStageProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.stage.create", symphonystage.CreateStageProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*symphonystage.CreateStageProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.stage.script", scriptstage.ScriptStageProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*scriptstage.ScriptStageProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.stage.patch", patchstage.PatchStageProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*patchstage.PatchStageProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.stage.list", liststage.ListStageProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*liststage.ListStageProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.stage.remote", remotestage.RemoteStageProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*remotestage.RemoteStageProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.stage.wait", waitstage.WaitStageProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*waitstage.WaitStageProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.stage.delay", delaystage.DelayStageProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*delaystage.DelayStageProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.stage.materialize", materialize.MaterializeStageProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*materialize.MaterializeStageProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.queue.memory", memoryqueue.MemoryQueueProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*memoryqueue.MemoryQueueProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.graph.memory", memorygraph.MemoryGraphProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*memorygraph.MemoryGraphProvider))
+}
+
+func TestCreateProviderForTargetRole(t *testing.T) {
+	targetSpec := model.TargetSpec{
+		DisplayName: "target",
+		Topologies: []model.TopologySpec{
+			{
+				Bindings: []model.BindingSpec{
+					{
+						Role:     "memorystate",
+						Provider: "providers.state.memory",
+						Config:   map[string]string{},
+					},
+					{
+						Role:     "k8sstate",
+						Provider: "providers.state.k8s",
+						Config:   map[string]string{},
+					},
+					{
+						Role:     "k8scatalog",
+						Provider: "providers.config.k8scatalog",
+						Config:   map[string]string{},
+					},
+					{
+						Role:     "httpstate",
+						Provider: "providers.state.http",
+						Config: map[string]string{
+							"url": "http://localhost:3500/v1.0/state/statestore",
+						},
+					},
+					{
+						Role:     "k8sref",
+						Provider: "providers.reference.k8s",
+						Config:   map[string]string{},
+					},
+					{
+						Role:     "cvref",
+						Provider: "providers.reference.customvision",
+						Config: map[string]string{
+							"key": "fakekey",
+						},
+					},
+					{
+						Role:     "httpref",
+						Provider: "providers.reference.http",
+						Config:   map[string]string{},
+					},
+					{
+						Role:     "mockledger",
+						Provider: "providers.ledger.mock",
+						Config:   map[string]string{},
+					},
+					{
+						Role:     "counter",
+						Provider: "providers.stage.counter",
+						Config:   map[string]string{},
+					},
+					{
+						Role:     "k8s",
+						Provider: "providers.target.k8s",
+						Config:   map[string]string{},
+					},
+					{
+						Role:     "docker",
+						Provider: "providers.target.docker",
+						Config:   map[string]string{},
+					},
+					{
+						Role:     "ingress",
+						Provider: "providers.target.ingress",
+						Config: map[string]string{
+							"configType": "path",
+						},
+					},
+					{
+						Role:     "kubectl",
+						Provider: "providers.target.kubectl",
+						Config: map[string]string{
+							"configType": "path",
+						},
+					},
+					{
+						Role:     "staging",
+						Provider: "providers.target.staging",
+						Config: map[string]string{
+							"targetName": "target1",
+						},
+					},
+					{
+						Role:     "script",
+						Provider: "providers.target.script",
+						Config: map[string]string{
+							"applyScript":  "mock-apply.sh",
+							"removeScript": "mock-remove.sh",
+							"getScript":    "mock-get.sh",
+							"scriptFolder": "",
+						},
+					},
+					{
+						Role:     "http",
+						Provider: "providers.target.http",
+						Config:   map[string]string{},
+					},
+					{
+						Role:     "win10sideload",
+						Provider: "providers.target.win10.sideload",
+						Config:   map[string]string{},
+					},
+					{
+						Role:     "adb",
+						Provider: "providers.target.adb",
+						Config:   map[string]string{},
+					},
+					{
+						Role:     "proxy",
+						Provider: "providers.target.proxy",
+						Config: map[string]string{
+							"name":      "proxy",
+							"serverUrl": "",
+						},
+					},
+					{
+						Role:     "configmap",
+						Provider: "providers.target.configmap",
+						Config: map[string]string{
+							"configType": "path",
+						},
+					},
+					{
+						Role:     "mock",
+						Provider: "providers.target.mock",
+						Config:   map[string]string{},
+					},
+					{
+						Role:     "azureiotedge",
+						Provider: "providers.target.azure.iotedge",
+						Config: map[string]string{
+							"name":       "iot-edge",
+							"keyName":    "iothubowner",
+							"key":        "fakekey",
+							"iotHub":     "fakenet",
+							"apiVersion": "fakeversion",
+							"deviceName": "s8c-vm",
+						},
+					},
+					{
+						Role:     "azureadu",
+						Provider: "providers.target.azure.adu",
+						Config: map[string]string{
+							"name":               "adu",
+							"tenantId":           "faketenant",
+							"clientId":           "fakeclient",
+							"clientSecret":       "fakesecret",
+							"aduAccountEndpoint": "fakeendpoint",
+							"aduAccountInstance": "fakeinstance",
+							"aduGroup":           "fakegroup",
+						},
+					},
+					{
+						Role:     "mockconfig",
+						Provider: "providers.config.mock",
+						Config:   map[string]string{},
+					},
+					{
+						Role:     "catalogconfig",
+						Provider: "providers.config.catalog",
+						Config: map[string]string{
+							"baseUrl":  "fakeuri",
+							"user":     "fake",
+							"password": "",
+						},
+					},
+					{
+						Role:     "mocksecret",
+						Provider: "providers.secret.mock",
+						Config:   map[string]string{},
+					},
+					{
+						Role:     "memoryqueue",
+						Provider: "providers.queue.memory",
+						Config:   map[string]string{},
+					},
+					{
+						Role:     "memorygraph",
+						Provider: "providers.graph.memory",
+						Config:   map[string]string{},
+					},
+					{
+						Role:     "mockstage",
+						Provider: "providers.stage.mock",
+						Config:   map[string]string{},
+					},
+					{
+						Role:     "httpstage",
+						Provider: "providers.stage.http",
+						Config: map[string]string{
+							"url":    "fakeurl",
+							"method": "GET",
+						},
+					},
+					{
+						Role:     "createstage",
+						Provider: "providers.stage.create",
+						Config: map[string]string{
+							"baseUrl":       "fakeUrl",
+							"user":          "admin",
+							"password":      "",
+							"wait.count":    "1",
+							"wait.interval": "1",
+						},
+					},
+					{
+						Role:     "scriptstage",
+						Provider: "providers.stage.script",
+						Config: map[string]string{
+							"script": "",
+						},
+					},
+					{
+						Role:     "patchstage",
+						Provider: "providers.stage.patch",
+						Config: map[string]string{
+							"baseUrl":  "fakeUrl",
+							"user":     "admin",
+							"password": "",
+						},
+					},
+					{
+						Role:     "liststage",
+						Provider: "providers.stage.list",
+						Config: map[string]string{
+							"baseUrl":  "fakeUrl",
+							"user":     "admin",
+							"password": "",
+						},
+					},
+					{
+						Role:     "remotestage",
+						Provider: "providers.stage.remote",
+						Config: map[string]string{
+							"baseUrl":  "fakeUrl",
+							"user":     "admin",
+							"password": "",
+						},
+					},
+					{
+						Role:     "waitstage",
+						Provider: "providers.stage.wait",
+						Config: map[string]string{
+							"baseUrl":  "fakeUrl",
+							"user":     "admin",
+							"password": "",
+						},
+					},
+					{
+						Role:     "delaystage",
+						Provider: "providers.stage.delay",
+						Config: map[string]string{
+							"baseUrl":  "fakeUrl",
+							"user":     "admin",
+							"password": "",
+						},
+					},
+					{
+						Role:     "materializestage",
+						Provider: "providers.stage.materialize",
+						Config: map[string]string{
+							"baseUrl":  "fakeUrl",
+							"user":     "admin",
+							"password": "",
+						},
+					},
+					{
+						Role:     "mempubsub",
+						Provider: "providers.pubsub.memory",
+						Config:   map[string]string{},
+					},
+					{
+						Role:     "httpreporter",
+						Provider: "providers.reporter.http",
+						Config:   map[string]string{},
+					},
+					{
+						Role:     "k8sreporter",
+						Provider: "providers.reporter.k8s",
+						Config:   map[string]string{},
+					},
+				},
+			},
+		},
+	}
+
+	provider, err := CreateProviderForTargetRole(nil, "memorystate", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*memorystate.MemoryStateProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "k8sstate", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*k8sstate.K8sStateProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "k8scatalog", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*k8sstate.K8sStateProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "httpstate", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*httpstate.HttpStateProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "k8sref", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*k8sref.K8sReferenceProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "cvref", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*cvref.CustomVisionReferenceProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "httpref", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*httpref.HTTPReferenceProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "mockledger", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*mockledger.MockLedgerProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "counter", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*counter.CounterStageProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "k8s", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*k8s.K8sTargetProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "docker", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*docker.DockerTargetProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "ingress", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*ingress.IngressTargetProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "kubectl", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*kubectl.KubectlTargetProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "staging", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*staging.StagingTargetProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "script", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*script.ScriptProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "http", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*targethttp.HttpTargetProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "win10sideload", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*sideload.Win10SideLoadProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "adb", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*adb.AdbProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "proxy", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*proxy.ProxyUpdateProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "configmap", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*configmap.ConfigMapTargetProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "mock", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*tgtmock.MockTargetProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "azureiotedge", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*iotedge.IoTEdgeTargetProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "azureadu", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*adu.ADUTargetProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "mockconfig", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*mockconfig.MockConfigProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "catalogconfig", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*catalogconfig.CatalogConfigProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "mocksecret", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*mocksecret.MockSecretProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "memoryqueue", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*memoryqueue.MemoryQueueProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "memorygraph", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*memorygraph.MemoryGraphProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "mockstage", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*mockstage.MockStageProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "httpstage", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*httpstage.HttpStageProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "createstage", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*symphonystage.CreateStageProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "scriptstage", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*scriptstage.ScriptStageProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "patchstage", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*patchstage.PatchStageProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "liststage", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*liststage.ListStageProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "remotestage", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*remotestage.RemoteStageProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "waitstage", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*waitstage.WaitStageProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "delaystage", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*delaystage.DelayStageProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "materializestage", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*materialize.MaterializeStageProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "mempubsub", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*mempubsub.InMemoryPubSubProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "httpreporter", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*httpreporter.HTTPReporter))
+
+	provider, err = CreateProviderForTargetRole(nil, "k8sreporter", targetSpec, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*k8sreporter.K8sReporter))
+}

--- a/api/pkg/apis/v1alpha1/providers/stage/create/create.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/create/create.go
@@ -144,7 +144,7 @@ func (i *CreateStageProvider) Process(ctx context.Context, mgrContext contexts.M
 			if err != nil {
 				return nil, false, err
 			}
-		} else {
+		} else if action == "create" {
 			err = utils.CreateInstance(ctx, i.Config.BaseUrl, objectName, i.Config.User, i.Config.Password, oData, objectScope)
 			if err != nil {
 				return nil, false, err
@@ -157,13 +157,21 @@ func (i *CreateStageProvider) Process(ctx context.Context, mgrContext contexts.M
 					return nil, false, err
 				}
 				if summary.Summary.SuccessCount == summary.Summary.TargetCount {
-					break
+					outputs["objectType"] = objectType
+					outputs["objectName"] = objectName
+					return outputs, false, nil
 				}
 				time.Sleep(time.Duration(i.Config.WaitInterval) * time.Second)
 			}
 			err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Instance creation failed: %s", lastSummaryMessage), v1alpha2.InternalError)
 			return nil, false, err
+		} else {
+			err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Unsupported action: %s", action), v1alpha2.InternalError)
+			return nil, false, err
 		}
+	default:
+		err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Unsupported object type: %s", objectType), v1alpha2.InternalError)
+		return nil, false, err
 	}
 	outputs["objectType"] = objectType
 	outputs["objectName"] = objectName

--- a/api/pkg/apis/v1alpha1/providers/stage/create/create_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/create/create_test.go
@@ -8,9 +8,13 @@ package create
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	"github.com/stretchr/testify/assert"
 )
@@ -42,4 +46,248 @@ func TestDeployInstance(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, "OK", outputs["status"])
+}
+
+func TestCreateInitFromVendorMap(t *testing.T) {
+	provider := CreateStageProvider{}
+	input := map[string]string{
+		"baseUrl":       "http://symphony-service:8080/v1alpha2/",
+		"user":          "admin",
+		"password":      "",
+		"wait.interval": "1",
+		"wait.count":    "3",
+	}
+	config, err := SymphonyStageProviderConfigFromMap(input)
+	assert.Nil(t, err)
+	assert.Equal(t, "http://symphony-service:8080/v1alpha2/", config.BaseUrl)
+	assert.Equal(t, "admin", config.User)
+	assert.Equal(t, "", config.Password)
+	assert.Equal(t, 1, config.WaitInterval)
+	assert.Equal(t, 3, config.WaitCount)
+	err = provider.InitWithMap(input)
+	assert.Nil(t, err)
+
+	input = map[string]string{}
+	config, err = SymphonyStageProviderConfigFromMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"baseUrl": "",
+	}
+	config, err = SymphonyStageProviderConfigFromMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"baseUrl": "http://symphony-service:8080/v1alpha2/",
+	}
+	config, err = SymphonyStageProviderConfigFromMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"baseUrl": "http://symphony-service:8080/v1alpha2/",
+		"user":    "",
+	}
+	config, err = SymphonyStageProviderConfigFromMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"baseUrl": "http://symphony-service:8080/v1alpha2/",
+		"user":    "admin",
+	}
+	config, err = SymphonyStageProviderConfigFromMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"baseUrl":    "http://symphony-service:8080/v1alpha2/",
+		"user":       "admin",
+		"password":   "",
+		"wait.count": "abc",
+	}
+	config, err = SymphonyStageProviderConfigFromMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"baseUrl":       "http://symphony-service:8080/v1alpha2/",
+		"user":          "admin",
+		"password":      "",
+		"wait.count":    "15",
+		"wait.interval": "abc",
+	}
+	config, err = SymphonyStageProviderConfigFromMap(input)
+	assert.NotNil(t, err)
+}
+
+type AuthResponse struct {
+	AccessToken string   `json:"accessToken"`
+	TokenType   string   `json:"tokenType"`
+	Username    string   `json:"username"`
+	Roles       []string `json:"roles"`
+}
+
+func TestCreateProcessCreate(t *testing.T) {
+	ts := InitializeMockSymphonyAPI()
+	provider := CreateStageProvider{}
+	input := map[string]string{
+		"baseUrl":       ts.URL + "/",
+		"user":          "admin",
+		"password":      "",
+		"wait.interval": "1",
+		"wait.count":    "3",
+	}
+	provider.InitWithMap(input)
+	instance := model.InstanceSpec{
+		DisplayName: "instance1",
+	}
+	_, _, err := provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"objectType": "instance",
+		"objectName": "instance1",
+		"action":     "create",
+		"object":     instance,
+	})
+	assert.Nil(t, err)
+}
+
+func TestCreateProcessCreateFailedCase(t *testing.T) {
+	ts := InitializeMockSymphonyAPIFailedCase()
+	provider := CreateStageProvider{}
+	input := map[string]string{
+		"baseUrl":       ts.URL + "/",
+		"user":          "admin",
+		"password":      "",
+		"wait.interval": "1",
+		"wait.count":    "3",
+	}
+	provider.InitWithMap(input)
+	instance := model.InstanceSpec{
+		DisplayName: "instance1",
+	}
+	_, _, err := provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"objectType": "instance",
+		"objectName": "instance1",
+		"action":     "create",
+		"object":     instance,
+	})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Instance creation failed:")
+}
+
+func TestCreateProcessRemove(t *testing.T) {
+	ts := InitializeMockSymphonyAPI()
+	provider := CreateStageProvider{}
+	input := map[string]string{
+		"baseUrl":       ts.URL + "/",
+		"user":          "admin",
+		"password":      "",
+		"wait.interval": "1",
+		"wait.count":    "3",
+	}
+	provider.InitWithMap(input)
+	instance := model.InstanceSpec{
+		DisplayName: "instance1",
+	}
+	_, _, err := provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"objectType": "instance",
+		"objectName": "instance1",
+		"action":     "remove",
+		"object":     instance,
+	})
+	assert.Nil(t, err)
+}
+
+func TestCreateProcessUnsupported(t *testing.T) {
+	provider := CreateStageProvider{}
+	input := map[string]string{
+		"baseUrl":       "http://symphony-service:8080/v1alpha2/",
+		"user":          "admin",
+		"password":      "",
+		"wait.interval": "1",
+		"wait.count":    "3",
+	}
+	provider.InitWithMap(input)
+	_, _, err := provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"objectType": "instance",
+		"objectName": "instance1",
+		"action":     "upsert",
+		"object": model.InstanceSpec{
+			DisplayName: "instance1",
+		},
+	})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Unsupported action:")
+
+	_, _, err = provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"objectType": "solution",
+		"objectName": "solution1",
+		"action":     "delete",
+		"object":     model.SolutionSpec{},
+	})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Unsupported object type:")
+
+}
+
+func InitializeMockSymphonyAPI() *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var response interface{}
+		switch r.URL.Path {
+		case "/instances/instance1":
+			response = model.InstanceState{
+				Id: "instance1",
+				Spec: &model.InstanceSpec{
+					Name: "instance1",
+				},
+				Status: map[string]string{},
+			}
+		case "/solution/queue":
+			response = model.SummaryResult{
+				Summary: model.SummarySpec{
+					TargetCount:  1,
+					SuccessCount: 1,
+				},
+			}
+		default:
+			response = AuthResponse{
+				AccessToken: "test-token",
+				TokenType:   "Bearer",
+				Username:    "test-user",
+				Roles:       []string{"role1", "role2"},
+			}
+		}
+
+		json.NewEncoder(w).Encode(response)
+	}))
+	return ts
+}
+
+func InitializeMockSymphonyAPIFailedCase() *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var response interface{}
+		switch r.URL.Path {
+		case "/instances/instance1":
+			response = model.InstanceState{
+				Id: "instance1",
+				Spec: &model.InstanceSpec{
+					Name: "instance1",
+				},
+				Status: map[string]string{},
+			}
+		case "/solution/queue":
+			response = model.SummaryResult{
+				Summary: model.SummarySpec{
+					TargetCount:  2,
+					SuccessCount: 1,
+				},
+			}
+		default:
+			response = AuthResponse{
+				AccessToken: "test-token",
+				TokenType:   "Bearer",
+				Username:    "test-user",
+				Roles:       []string{"role1", "role2"},
+			}
+		}
+
+		json.NewEncoder(w).Encode(response)
+	}))
+	return ts
 }

--- a/api/pkg/apis/v1alpha1/providers/stage/delay/delay_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/delay/delay_test.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package delay
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDelayInitFromVendorMap(t *testing.T) {
+	provider := DelayStageProvider{}
+	input := map[string]string{
+		"id": "test",
+	}
+	err := provider.InitWithMap(input)
+	assert.Nil(t, err)
+	assert.Equal(t, "test", provider.Config.ID)
+}
+func TestDelayProcess(t *testing.T) {
+	provider := DelayStageProvider{}
+	err := provider.InitWithMap(map[string]string{})
+	assert.Nil(t, err)
+	dt1 := time.Now()
+	outputs, _, _ := provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"delay": 1,
+	})
+	dt2 := time.Now()
+	assert.Equal(t, v1alpha2.OK, outputs[v1alpha2.StatusOutput])
+	assert.GreaterOrEqual(t, dt2.Sub(dt1).Seconds(), 1.0)
+
+	dt1 = time.Now()
+	outputs, _, _ = provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"delay": int32(1),
+	})
+	dt2 = time.Now()
+	assert.Equal(t, v1alpha2.OK, outputs[v1alpha2.StatusOutput])
+	assert.GreaterOrEqual(t, dt2.Sub(dt1).Seconds(), 1.0)
+
+	dt1 = time.Now()
+	outputs, _, _ = provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"delay": int64(1),
+	})
+	dt2 = time.Now()
+	assert.Equal(t, v1alpha2.OK, outputs[v1alpha2.StatusOutput])
+	assert.GreaterOrEqual(t, dt2.Sub(dt1).Seconds(), 1.0)
+
+	dt1 = time.Now()
+	outputs, _, _ = provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"delay": "1s",
+	})
+	dt2 = time.Now()
+	assert.Equal(t, v1alpha2.OK, outputs[v1alpha2.StatusOutput])
+	assert.GreaterOrEqual(t, dt2.Sub(dt1).Seconds(), 1.0)
+
+	dt1 = time.Now()
+	outputs, _, _ = provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"delay": "1",
+	})
+	dt2 = time.Now()
+	assert.Equal(t, v1alpha2.OK, outputs[v1alpha2.StatusOutput])
+	assert.GreaterOrEqual(t, dt2.Sub(dt1).Seconds(), 1.0)
+}
+
+func TestDelayProcessFailedCase(t *testing.T) {
+	provider := DelayStageProvider{}
+	err := provider.InitWithMap(map[string]string{})
+	assert.Nil(t, err)
+
+	outputs, _, _ := provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"delay": "abc",
+	})
+	assert.Equal(t, v1alpha2.InternalError, outputs[v1alpha2.StatusOutput])
+}

--- a/api/pkg/apis/v1alpha1/providers/stage/http/http.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/http/http.go
@@ -106,21 +106,21 @@ func MockStageProviderConfigFromMap(properties map[string]string) (HttpStageProv
 		if err != nil {
 			return ret, err
 		}
-		ret.SuccessCodes = codes
+		ret.WaitSuccessCodes = codes
 	}
 	if v, ok := properties["wait.start"]; ok {
 		codes, err := readIntArray(v)
 		if err != nil {
 			return ret, err
 		}
-		ret.SuccessCodes = codes
+		ret.WaitStartCodes = codes
 	}
 	if v, ok := properties["wait.fail"]; ok {
 		codes, err := readIntArray(v)
 		if err != nil {
 			return ret, err
 		}
-		ret.SuccessCodes = codes
+		ret.WaitFailedCodes = codes
 	}
 	if v, ok := properties["wait.url"]; ok {
 		ret.WaitUrl = v

--- a/api/pkg/apis/v1alpha1/providers/stage/http/http_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/http/http_test.go
@@ -15,6 +15,51 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestHttpInitWithMap(t *testing.T) {
+	provider := HttpStageProvider{}
+	input := map[string]string{
+		"name":          "test",
+		"url":           "https://www.bing.com",
+		"method":        "GET",
+		"successCodes":  "200, 202",
+		"wait.start":    "200",
+		"wait.fail":     "404",
+		"wait.success":  "200",
+		"wait.url":      "https://www.bing.com",
+		"wait.interval": "1",
+		"wait.count":    "3",
+	}
+	err := provider.InitWithMap(input)
+	assert.Nil(t, err)
+	assert.Equal(t, []int{200, 202}, provider.Config.SuccessCodes)
+}
+
+func TestHttpProcessOverrideConfig(t *testing.T) {
+	provider := HttpStageProvider{}
+	input := map[string]string{
+		"name":          "test",
+		"url":           "https://www.bing.com",
+		"method":        "GET",
+		"successCodes":  "200, 202",
+		"wait.start":    "200",
+		"wait.fail":     "404",
+		"wait.success":  "200",
+		"wait.url":      "https://www.bing.com",
+		"wait.interval": "1",
+		"wait.count":    "3",
+	}
+	err := provider.InitWithMap(input)
+	assert.Nil(t, err)
+	outputs, _, err := provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"wait.fail": []int{500},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, outputs)
+	assert.Equal(t, 200, outputs["status"])
+	assert.NotNil(t, outputs["body"])
+	assert.Equal(t, []int{500}, provider.Config.WaitFailedCodes)
+	assert.Equal(t, []int{200}, provider.Config.WaitStartCodes)
+}
 func TestPingBing(t *testing.T) {
 	provider := HttpStageProvider{}
 	err := provider.Init(HttpStageProviderConfig{

--- a/api/pkg/apis/v1alpha1/providers/stage/list/list.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/list/list.go
@@ -9,6 +9,7 @@ package list
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
@@ -149,6 +150,10 @@ func (i *ListStageProvider) Process(ctx context.Context, mgrContext contexts.Man
 		} else {
 			outputs["items"] = filteredSites
 		}
+	default:
+		log.Errorf("  P (List Processor): unsupported object type: %s", objectType)
+		err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Unsupported object type: %s", objectType), v1alpha2.InternalError)
+		return nil, false, err
 	}
 	outputs["objectType"] = objectType
 	return outputs, false, nil

--- a/api/pkg/apis/v1alpha1/providers/stage/list/list_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/list/list_test.go
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package list
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListInitFromMap(t *testing.T) {
+	provider := ListStageProvider{}
+	input := map[string]string{
+		"baseUrl":  "http://symphony-service:8080/v1alpha2/",
+		"user":     "admin",
+		"password": "",
+	}
+	err := provider.InitWithMap(input)
+	assert.Nil(t, err)
+
+	input = map[string]string{}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"baseUrl": "",
+	}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"baseUrl": "http://symphony-service:8080/v1alpha2/",
+	}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"baseUrl": "http://symphony-service:8080/v1alpha2/",
+		"user":    "",
+	}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"baseUrl": "http://symphony-service:8080/v1alpha2/",
+		"user":    "admin",
+	}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+}
+func TestListProcessInstances(t *testing.T) {
+	ts := InitializeMockSymphonyAPI()
+	provider := ListStageProvider{}
+	input := map[string]string{
+		"baseUrl":  ts.URL + "/",
+		"user":     "admin",
+		"password": "",
+	}
+	err := provider.InitWithMap(input)
+	assert.Nil(t, err)
+
+	outputs, _, err := provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"objectType": "instance",
+	})
+	assert.Nil(t, err)
+	instances, ok := outputs["items"].([]model.InstanceState)
+	assert.True(t, ok)
+	assert.Equal(t, 2, len(instances))
+	assert.Equal(t, "instance1", instances[0].Id)
+	assert.Equal(t, "instance2", instances[1].Id)
+
+	outputs, _, err = provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"objectType": "instance",
+		"namesOnly":  true,
+	})
+	assert.Nil(t, err)
+	instanceNames, ok := outputs["items"].([]string)
+	assert.True(t, ok)
+	assert.Equal(t, 2, len(instances))
+	assert.Equal(t, "instance1", instanceNames[0])
+	assert.Equal(t, "instance2", instanceNames[1])
+}
+
+func TestListProcessSites(t *testing.T) {
+	ts := InitializeMockSymphonyAPI()
+	provider := ListStageProvider{}
+	input := map[string]string{
+		"baseUrl":  ts.URL + "/",
+		"user":     "admin",
+		"password": "",
+	}
+	err := provider.InitWithMap(input)
+	assert.Nil(t, err)
+
+	outputs, _, err := provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"objectType": "sites",
+	})
+	assert.Nil(t, err)
+	instances, ok := outputs["items"].([]model.SiteState)
+	assert.True(t, ok)
+	assert.Equal(t, 2, len(instances))
+	assert.Equal(t, "hq", instances[0].Id)
+	assert.Equal(t, "child", instances[1].Id)
+
+	outputs, _, err = provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"objectType": "sites",
+		"namesOnly":  true,
+	})
+	assert.Nil(t, err)
+	instanceNames, ok := outputs["items"].([]string)
+	assert.True(t, ok)
+	assert.Equal(t, 2, len(instances))
+	assert.Equal(t, "hq", instanceNames[0])
+	assert.Equal(t, "child", instanceNames[1])
+}
+
+func TestListProcessUnsupported(t *testing.T) {
+	provider := ListStageProvider{}
+	input := map[string]string{
+		"baseUrl":  "http://symphony-service:8080/v1alpha2/",
+		"user":     "admin",
+		"password": "",
+	}
+	err := provider.InitWithMap(input)
+	assert.Nil(t, err)
+
+	outputs, _, err := provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"objectType": "target",
+	})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Unsupported object type")
+	assert.Nil(t, outputs)
+}
+
+type AuthResponse struct {
+	AccessToken string   `json:"accessToken"`
+	TokenType   string   `json:"tokenType"`
+	Username    string   `json:"username"`
+	Roles       []string `json:"roles"`
+}
+
+func InitializeMockSymphonyAPI() *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var response interface{}
+		switch r.URL.Path {
+		case "/instances":
+			response = []model.InstanceState{
+				{
+					Id: "instance1",
+					Spec: &model.InstanceSpec{
+						Name: "instance1",
+					},
+					Status: map[string]string{},
+				},
+				{
+					Id: "instance2",
+					Spec: &model.InstanceSpec{
+						Name: "instance2",
+					},
+					Status: map[string]string{},
+				}}
+		case "/federation/registry":
+			response = []model.SiteState{
+				{
+					Id: "hq",
+					Spec: &model.SiteSpec{
+						Name: "hq",
+					},
+					Status: &model.SiteStatus{},
+				},
+				{
+					Id: "child",
+					Spec: &model.SiteSpec{
+						Name: "child",
+					},
+					Status: &model.SiteStatus{},
+				}}
+		default:
+			response = AuthResponse{
+				AccessToken: "test-token",
+				TokenType:   "Bearer",
+				Username:    "test-user",
+				Roles:       []string{"role1", "role2"},
+			}
+		}
+
+		json.NewEncoder(w).Encode(response)
+	}))
+	return ts
+}

--- a/api/pkg/apis/v1alpha1/providers/stage/materialize/materialize_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/materialize/materialize_test.go
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package materialize
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaterializeInit(t *testing.T) {
+	provider := MaterializeStageProvider{}
+	input := map[string]string{
+		"baseUrl":  "http://symphony-service:8080/v1alpha2/",
+		"user":     "admin",
+		"password": "",
+	}
+	err := provider.InitWithMap(input)
+	assert.Nil(t, err)
+	assert.Equal(t, "http://symphony-service:8080/v1alpha2/", provider.Config.BaseUrl)
+	assert.Equal(t, "admin", provider.Config.User)
+	assert.Equal(t, "", provider.Config.Password)
+
+	input = map[string]string{}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"baseUrl": "",
+	}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"baseUrl": "http://symphony-service:8080/v1alpha2/",
+	}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"baseUrl": "http://symphony-service:8080/v1alpha2/",
+		"user":    "",
+	}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"baseUrl": "http://symphony-service:8080/v1alpha2/",
+		"user":    "admin",
+	}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+}
+
+func TestMaterializeInitFromVendorMap(t *testing.T) {
+	input := map[string]string{
+		"wait.baseUrl":  "http://symphony-service:8080/v1alpha2/",
+		"wait.user":     "admin",
+		"wait.password": "",
+	}
+	config, err := MaterializeStageProviderConfigFromVendorMap(input)
+	assert.Nil(t, err)
+	provider := MaterializeStageProvider{}
+	provider.Init(config)
+	assert.Equal(t, "http://symphony-service:8080/v1alpha2/", provider.Config.BaseUrl)
+	assert.Equal(t, "admin", provider.Config.User)
+	assert.Equal(t, "", provider.Config.Password)
+}
+func TestMaterializeProcess(t *testing.T) {
+	ts := InitializeMockSymphonyAPI()
+	provider := MaterializeStageProvider{}
+	input := map[string]string{
+		"baseUrl":  ts.URL + "/",
+		"user":     "admin",
+		"password": "",
+	}
+	err := provider.InitWithMap(input)
+	assert.Nil(t, err)
+	provider.SetContext(&contexts.ManagerContext{
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+		},
+	})
+	_, _, err = provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"names":    []interface{}{"instance1", "target1", "solution1", "catalog1"},
+		"__origin": "hq",
+	})
+	assert.Nil(t, err)
+}
+
+func TestMaterializeProcessFailedCase(t *testing.T) {
+	ts := InitializeMockSymphonyAPI()
+	provider := MaterializeStageProvider{}
+	input := map[string]string{
+		"baseUrl":  ts.URL + "/",
+		"user":     "admin",
+		"password": "",
+	}
+	err := provider.InitWithMap(input)
+	assert.Nil(t, err)
+
+	_, _, err = provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"names":    []interface{}{"instance1", "target1", "solution1, target2"},
+		"__origin": "hq",
+	})
+	assert.NotNil(t, err)
+}
+
+type AuthResponse struct {
+	AccessToken string   `json:"accessToken"`
+	TokenType   string   `json:"tokenType"`
+	Username    string   `json:"username"`
+	Roles       []string `json:"roles"`
+}
+
+func InitializeMockSymphonyAPI() *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var response interface{}
+		switch r.URL.Path {
+		case "/instances/instance1":
+			response = model.InstanceState{
+				Id: "hq-instance1",
+				Spec: &model.InstanceSpec{
+					Name: "hq-instance1",
+				},
+				Status: map[string]string{},
+			}
+		case "/targets/registry/target1":
+			response = model.TargetState{
+				Id: "hq-target1",
+				Spec: &model.TargetSpec{
+					DisplayName: "hq-target1",
+				},
+			}
+		case "/solutions/solution1":
+			response = model.SolutionState{
+				Id: "hq-solution1",
+				Spec: &model.SolutionSpec{
+					DisplayName: "hq-solution1",
+				},
+			}
+		case "/catalogs/registry":
+			response = []model.CatalogState{
+				{
+					Id: "targetcatalog",
+					Spec: &model.CatalogSpec{
+						Type: "target",
+						Name: "hq-target1",
+						Properties: map[string]interface{}{
+							"spec": &model.TargetSpec{
+								DisplayName: "target1",
+							},
+						},
+					},
+				},
+				{
+					Id: "instancecatalog",
+					Spec: &model.CatalogSpec{
+						Type: "instance",
+						Name: "hq-instance1",
+						Properties: map[string]interface{}{
+							"spec": model.InstanceSpec{
+								Name: "instance1",
+							},
+						},
+					},
+				},
+				{
+					Id: "solutioncatalog",
+					Spec: &model.CatalogSpec{
+						Type: "solution",
+						Name: "hq-solution1",
+						Properties: map[string]interface{}{
+							"spec": model.SolutionSpec{
+								DisplayName: "solution1",
+							},
+						},
+					},
+				},
+				{
+					Id: "catalog1",
+					Spec: &model.CatalogSpec{
+						Type: "catalog",
+						Name: "hq-catalog1",
+						Properties: map[string]interface{}{
+							"spec": model.SolutionSpec{
+								DisplayName: "solution1",
+							},
+						},
+					},
+				},
+			}
+		case "catalogs/registry/catalog1":
+			response = model.CatalogState{
+				Id: "catalog1",
+				Spec: &model.CatalogSpec{
+					Name: "catalog1",
+				},
+			}
+		default:
+			response = AuthResponse{
+				AccessToken: "test-token",
+				TokenType:   "Bearer",
+				Username:    "test-user",
+				Roles:       []string{"role1", "role2"},
+			}
+		}
+
+		json.NewEncoder(w).Encode(response)
+	}))
+	return ts
+}

--- a/api/pkg/apis/v1alpha1/providers/stage/mock/mock_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/mock/mock_test.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package mock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockInitFromMap(t *testing.T) {
+	provider := MockStageProvider{}
+	input := map[string]string{
+		"id": "test",
+	}
+	err := provider.InitWithMap(input)
+	assert.Nil(t, err)
+}
+
+func TestMockProcess(t *testing.T) {
+	provider := MockStageProvider{}
+	input := map[string]string{
+		"id": "test",
+	}
+	err := provider.InitWithMap(input)
+	assert.Nil(t, err)
+	output, _, err := provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"foo": "2",
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(3), output["foo"])
+
+	output, _, err = provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"foo": "",
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, int(1), output["foo"])
+}

--- a/api/pkg/apis/v1alpha1/providers/stage/patch/patch_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/patch/patch_test.go
@@ -8,6 +8,10 @@ package patch
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -16,6 +20,10 @@ import (
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/utils"
 	"github.com/stretchr/testify/assert"
 )
+
+var testSolution = model.SolutionSpec{
+	Scope: "default",
+}
 
 func TestPatchSolution(t *testing.T) {
 	testPatchSolution := os.Getenv("TEST_PATCH_SOLUTION")
@@ -97,4 +105,224 @@ func TestPatchSolutionWholeComponent(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, outputs)
 	assert.Equal(t, "OK", outputs["status"])
+}
+
+func TestPatchInitFromMap(t *testing.T) {
+	provider := PatchStageProvider{}
+	input := map[string]string{
+		"baseUrl":  "http://symphony-service:8080/v1alpha2/",
+		"user":     "admin",
+		"password": "",
+	}
+	err := provider.InitWithMap(input)
+	assert.Nil(t, err)
+	assert.Equal(t, "http://symphony-service:8080/v1alpha2/", provider.Config.BaseUrl)
+	assert.Equal(t, "admin", provider.Config.User)
+	assert.Equal(t, "", provider.Config.Password)
+
+	input = map[string]string{}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"baseUrl": "",
+	}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"baseUrl": "http://symphony-service:8080/v1alpha2/",
+	}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"baseUrl": "http://symphony-service:8080/v1alpha2/",
+		"user":    "",
+	}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"baseUrl": "http://symphony-service:8080/v1alpha2/",
+		"user":    "admin",
+	}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+}
+
+func TestPatchProcessInline(t *testing.T) {
+	ts := InitializeMockSymphonyAPI()
+	provider := PatchStageProvider{}
+	input := map[string]string{
+		"baseUrl":  ts.URL + "/",
+		"user":     "admin",
+		"password": "",
+	}
+	err := provider.InitWithMap(input)
+	assert.Nil(t, err)
+	testSolution = model.SolutionSpec{
+		Scope: "default",
+	}
+	_, _, err = provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"objectType":  "solution",
+		"objectName":  "solution1",
+		"patchSource": "inline",
+		"patchContent": model.ComponentSpec{
+			Name: "ebpf-module",
+			Type: "ebpf",
+			Properties: map[string]interface{}{
+				"ebpf.url":   "https://github.com/Haishi2016/Vault818/releases/download/vtest/hello.bpf.o",
+				"ebpf.name":  "hello",
+				"ebpf.event": "xdp",
+			},
+		},
+		"patchAction": "add",
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "ebpf-module", testSolution.Components[0].Name)
+	assert.Equal(t, "ebpf", testSolution.Components[0].Type)
+	assert.Equal(t, map[string]interface{}{
+		"ebpf.url":   "https://github.com/Haishi2016/Vault818/releases/download/vtest/hello.bpf.o",
+		"ebpf.name":  "hello",
+		"ebpf.event": "xdp",
+	}, testSolution.Components[0].Properties)
+
+	_, _, err = provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"objectType":  "solution",
+		"objectName":  "solution1",
+		"patchSource": "inline",
+		"patchContent": model.ComponentSpec{
+			Name: "ebpf-module",
+			Type: "ebpf",
+			Properties: map[string]interface{}{
+				"ebpf.url":   "https://github.com/Haishi2016/Vault818/releases/download/vtest/hello.bpf.o",
+				"ebpf.name":  "hello",
+				"ebpf.event": "xdp",
+			},
+		},
+		"patchAction": "remove",
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(testSolution.Components))
+}
+
+func TestPatchProcessCatalog(t *testing.T) {
+	ts := InitializeMockSymphonyAPI()
+	provider := PatchStageProvider{}
+	input := map[string]string{
+		"baseUrl":  ts.URL + "/",
+		"user":     "admin",
+		"password": "",
+	}
+	err := provider.InitWithMap(input)
+	provider.SetContext(&contexts.ManagerContext{
+		VencorContext: &contexts.VendorContext{
+			EvaluationContext: &utils.EvaluationContext{},
+		},
+	})
+	assert.Nil(t, err)
+	testSolution = model.SolutionSpec{
+		Scope: "default",
+	}
+	// Step 1: first add component to solution spec
+	provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"objectType":  "solution",
+		"objectName":  "solution1",
+		"patchSource": "inline",
+		"patchContent": model.ComponentSpec{
+			Name: "ebpf-module",
+			Type: "ebpf",
+			Properties: map[string]interface{}{
+				"ebpf.url":   "https://github.com/Haishi2016/Vault818/releases/download/vtest/hello.bpf.o",
+				"ebpf.name":  "hello",
+				"ebpf.event": "xdp",
+				"input": map[string]interface{}{
+					"adapter": []string{},
+					"scope":   []string{},
+				},
+			},
+		},
+		"patchAction": "add",
+	})
+
+	// Step 2: update solution with config in catalog
+	_, _, err = provider.Process(context.Background(), contexts.ManagerContext{}, map[string]interface{}{
+		"objectType":   "solution",
+		"objectName":   "solution1",
+		"patchSource":  "catalog",
+		"patchContent": "catalog1",
+		"patchAction":  "add",
+		"component":    "ebpf-module",
+		"property":     "input",
+		"subKey":       "adapter",
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "ebpf-module", testSolution.Components[0].Name)
+	assert.Equal(t, "ebpf", testSolution.Components[0].Type)
+	assert.Equal(t, map[string]interface{}{
+		"ebpf.url":   "https://github.com/Haishi2016/Vault818/releases/download/vtest/hello.bpf.o",
+		"ebpf.name":  "hello",
+		"ebpf.event": "xdp",
+		"input": map[string]interface{}{
+			"adapter": []interface{}{map[string]interface{}{"testkey": "0", "testdict": []interface{}{"1"}, "testmap": map[string]interface{}{}}},
+			"scope":   []interface{}{},
+		},
+	}, testSolution.Components[0].Properties)
+
+}
+
+type AuthResponse struct {
+	AccessToken string   `json:"accessToken"`
+	TokenType   string   `json:"tokenType"`
+	Username    string   `json:"username"`
+	Roles       []string `json:"roles"`
+}
+
+func InitializeMockSymphonyAPI() *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var response interface{}
+		switch r.URL.Path {
+		case "/solutions/solution1":
+			if r.Method == "GET" {
+				response = model.SolutionState{
+					Id:   "solution1",
+					Spec: &testSolution,
+				}
+			} else {
+				body, _ := io.ReadAll(r.Body)
+				newSpec := model.SolutionSpec{}
+				json.Unmarshal(body, &newSpec)
+				testSolution = newSpec
+				response = model.SolutionState{
+					Id:   "solution1",
+					Spec: &testSolution,
+				}
+			}
+		case "/catalogs/registry/catalog1":
+			response = model.CatalogState{
+				Id: "catalog1",
+				Spec: &model.CatalogSpec{
+					Type: "config",
+					Name: "catalog1",
+					Properties: map[string]interface{}{
+						"testkey":  "0",
+						"testdict": []string{"1"},
+						"testmap":  map[string]interface{}{},
+					},
+				},
+			}
+
+		default:
+			response = AuthResponse{
+				AccessToken: "test-token",
+				TokenType:   "Bearer",
+				Username:    "test-user",
+				Roles:       []string{"role1", "role2"},
+			}
+		}
+
+		json.NewEncoder(w).Encode(response)
+	}))
+	return ts
 }

--- a/api/pkg/apis/v1alpha1/providers/stage/remote/remote_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/remote/remote_test.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package remote
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/pubsub/memory"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoteInitFromMap(t *testing.T) {
+	provider := RemoteStageProvider{}
+	input := map[string]string{}
+	err := provider.InitWithMap(input)
+	assert.Nil(t, err)
+}
+func TestRemoteProcess(t *testing.T) {
+	pubSubProvider := memory.InMemoryPubSubProvider{}
+	pubSubProvider.Init(memory.InMemoryPubSubConfig{Name: "test"})
+	ctx := contexts.ManagerContext{}
+	ctx.Init(nil, &pubSubProvider)
+	ctx.SiteInfo = v1alpha2.SiteInfo{
+		SiteId: "hq",
+	}
+	provider := RemoteStageProvider{}
+	input := map[string]string{}
+	err := provider.InitWithMap(input)
+	assert.Nil(t, err)
+	provider.SetContext(&ctx)
+	sig := make(chan bool)
+	succeededCount := 0
+	ctx.Subscribe("remote", func(topic string, event v1alpha2.Event) error {
+		var job v1alpha2.JobData
+		jData, _ := json.Marshal(event.Body)
+		err := json.Unmarshal(jData, &job)
+		assert.Nil(t, err)
+		assert.Equal(t, "child", event.Metadata["site"])
+		assert.Equal(t, "task", event.Metadata["objectType"])
+		assert.Equal(t, "RUN", job.Action)
+		succeededCount += 1
+		sig <- true
+		return nil
+	})
+	_, _, err = provider.Process(context.Background(), ctx, map[string]interface{}{
+		"__site": "child",
+	})
+	assert.Nil(t, err)
+	<-sig
+	assert.Equal(t, 1, succeededCount)
+
+	_, _, err = provider.Process(context.Background(), ctx, map[string]interface{}{})
+	assert.NotNil(t, err)
+	assert.Equal(t, "no site found in inputs", err.Error())
+}

--- a/api/pkg/apis/v1alpha1/providers/stage/script/script_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/script/script_test.go
@@ -8,12 +8,25 @@ package script
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	"github.com/stretchr/testify/assert"
 )
 
+func TestScriptInitWithMap(t *testing.T) {
+	provider := ScriptStageProvider{}
+	input := map[string]string{
+		"name":          "test",
+		"script":        "test.sh",
+		"scriptEngine":  "bash",
+		"scriptFolder":  "staging",
+		"stagingFolder": "staging",
+	}
+	err := provider.InitWithMap(input)
+	assert.Nil(t, err)
+}
 func TestShellScript(t *testing.T) {
 	provider := ScriptStageProvider{}
 	err := provider.Init(ScriptStageProviderConfig{
@@ -32,4 +45,19 @@ func TestShellScript(t *testing.T) {
 	assert.False(t, paused)
 	assert.Equal(t, "VALUE1", output["key1"])
 	assert.Equal(t, "VALUE2", output["key2"])
+}
+
+func TestShellScriptOnline(t *testing.T) {
+	provider := ScriptStageProvider{}
+	err := provider.Init(ScriptStageProviderConfig{
+		Name:          "test",
+		Script:        "go1.21.6.src.tar.gz",
+		ScriptEngine:  "gz",
+		ScriptFolder:  "https://golang.google.cn/dl/",
+		StagingFolder: "staging",
+	})
+	assert.Nil(t, err)
+	_, err = os.Stat("staging/go1.21.6.src.tar.gz")
+	assert.Nil(t, err)
+	os.Remove("staging/go1.21.6.src.tar.gz")
 }

--- a/api/pkg/apis/v1alpha1/providers/stage/wait/wait_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/wait/wait_test.go
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package wait
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWaitInitFromVendorMap(t *testing.T) {
+	input := map[string]string{
+		"wait.baseUrl":       "http://symphony-service:8080/v1alpha2/",
+		"wait.user":          "admin",
+		"wait.password":      "",
+		"wait.wait.interval": "15",
+		"wait.wait.count":    "10",
+	}
+	config, err := WaitStageProviderConfigFromVendorMap(input)
+	assert.Nil(t, err)
+	assert.Equal(t, "http://symphony-service:8080/v1alpha2/", config.BaseUrl)
+	assert.Equal(t, "admin", config.User)
+	assert.Equal(t, "", config.Password)
+	assert.Equal(t, 15, config.WaitInterval)
+	assert.Equal(t, 10, config.WaitCount)
+
+	input = map[string]string{}
+	config, err = WaitStageProviderConfigFromVendorMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"wait.baseUrl": "",
+	}
+	config, err = WaitStageProviderConfigFromVendorMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"wait.baseUrl": "http://symphony-service:8080/v1alpha2/",
+	}
+	config, err = WaitStageProviderConfigFromVendorMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"wait.baseUrl": "http://symphony-service:8080/v1alpha2/",
+		"wait.user":    "",
+	}
+	config, err = WaitStageProviderConfigFromVendorMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"wait.baseUrl": "http://symphony-service:8080/v1alpha2/",
+		"wait.user":    "admin",
+	}
+	config, err = WaitStageProviderConfigFromVendorMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"wait.baseUrl":       "http://symphony-service:8080/v1alpha2/",
+		"wait.user":          "admin",
+		"wait.password":      "",
+		"wait.wait.interval": "abc",
+	}
+	config, err = WaitStageProviderConfigFromVendorMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"wait.baseUrl":       "http://symphony-service:8080/v1alpha2/",
+		"wait.user":          "admin",
+		"wait.password":      "",
+		"wait.wait.interval": "15",
+		"wait.wait.count":    "abc",
+	}
+	config, err = WaitStageProviderConfigFromVendorMap(input)
+	assert.NotNil(t, err)
+}
+
+func TestWaitProcess(t *testing.T) {
+	ts := InitializeMockSymphonyAPI()
+	config := map[string]string{
+		"baseUrl":       ts.URL + "/",
+		"user":          "admin",
+		"password":      "",
+		"wait.interval": "1",
+		"wait.count":    "3",
+	}
+	provider := WaitStageProvider{}
+	err := provider.InitWithMap(config)
+	assert.Nil(t, err)
+
+	// instances exist
+	input := map[string]interface{}{
+		"objectType": "instance",
+		"names":      []interface{}{"instance1"},
+		"__origin":   "hq",
+	}
+	output, _, err := provider.Process(context.Background(), contexts.ManagerContext{}, input)
+	assert.Nil(t, err)
+	assert.Equal(t, "OK", output["status"])
+	assert.Equal(t, "instance", output["objectType"])
+
+	// instances not exist
+	input = map[string]interface{}{
+		"objectType": "instance",
+		"names":      []interface{}{"instance2"},
+		"__origin":   "hq",
+	}
+	_, _, err = provider.Process(context.Background(), contexts.ManagerContext{}, input)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "failed to wait for")
+
+	// sites exist
+	input = map[string]interface{}{
+		"objectType": "sites",
+		"names":      []interface{}{"site1"},
+		"__origin":   "hq",
+	}
+	output, _, err = provider.Process(context.Background(), contexts.ManagerContext{}, input)
+	assert.Nil(t, err)
+	assert.Equal(t, "OK", output["status"])
+	assert.Equal(t, "sites", output["objectType"])
+
+	// sites not exist
+	input = map[string]interface{}{
+		"objectType": "sites",
+		"names":      []interface{}{"site2"},
+		"__origin":   "hq",
+	}
+	_, _, err = provider.Process(context.Background(), contexts.ManagerContext{}, input)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "failed to wait for")
+
+	// catalogs exist
+	input = map[string]interface{}{
+		"objectType": "catalogs",
+		"names":      []interface{}{"catalog1"},
+		"__origin":   "hq",
+	}
+	output, _, err = provider.Process(context.Background(), contexts.ManagerContext{}, input)
+	assert.Nil(t, err)
+	assert.Equal(t, "OK", output["status"])
+	assert.Equal(t, "catalogs", output["objectType"])
+
+	// catalogs not exist
+	input = map[string]interface{}{
+		"objectType": "catalogs",
+		"names":      []interface{}{"catalog2"},
+		"__origin":   "hq",
+	}
+	_, _, err = provider.Process(context.Background(), contexts.ManagerContext{}, input)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "failed to wait for")
+}
+
+type AuthResponse struct {
+	AccessToken string   `json:"accessToken"`
+	TokenType   string   `json:"tokenType"`
+	Username    string   `json:"username"`
+	Roles       []string `json:"roles"`
+}
+
+func InitializeMockSymphonyAPI() *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var response interface{}
+		log.Info("Mock Symphony API called", "path", r.URL.Path)
+		switch r.URL.Path {
+		case "/instances":
+			response = []model.InstanceState{{
+				Id: "instance1",
+				Spec: &model.InstanceSpec{
+					Name: "hq-instance1",
+				},
+				Status: map[string]string{},
+			}}
+		case "/federation/registry":
+			response = []model.SiteState{{
+				Id: "site1",
+				Spec: &model.SiteSpec{
+					Name: "hq-site1",
+				},
+				Status: &model.SiteStatus{},
+			}}
+		case "/catalogs/registry":
+			response = []model.CatalogState{{
+				Id: "catalog1",
+				Spec: &model.CatalogSpec{
+					Name: "hq-catalog1",
+				},
+			}}
+		default:
+			response = AuthResponse{
+				AccessToken: "test-token",
+				TokenType:   "Bearer",
+				Username:    "test-user",
+				Roles:       []string{"role1", "role2"},
+			}
+		}
+
+		json.NewEncoder(w).Encode(response)
+	}))
+	return ts
+}


### PR DESCRIPTION
1. minor fix for a few issues:
      
      1). https://github.com/eclipse-symphony/symphony/issues/107
      2). https://github.com/eclipse-symphony/symphony/issues/103
      3). providerfactory doesn't return provider for "providers.stage.delay"


2. add unit tests for some providers

| components | previous(%) | now (%)|
|---------------|------------|-------|
|providerfactory.go | /| 82.3|
|stage/wait/wait.go|/| 91.3|
|stage/create/create.go|/ |89.6|
|stage/list/list.go| /| 90.0|
|stage/script/script.go| 49.5| 78.1|
|stage/delay/delay.go| /| 90.2|
|stage/remote/remote.go|/ | 83.3|
|stage/mock/mock.go|/ | 91.5|
|stage/http/http.go| 46.4|71.3 |
|stage/patch/patch.go| /| 65.3|
|stage/counter/counter.go | 69.5| 69.5|
|stage/materialize/materialize.go|/ | 86.2|