### PR TITLE
add support for maestro local build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,12 +90,13 @@ jobs:
           mage generatePackages /home/runner/maestro
           cd ..
 
-      - name: Replace version in packages/helm/values.yaml
+      - name: Replace version in packages/helm/values.yaml and packages/helm/Chart.yaml
         run: |
           version=$(cat .github/version/versions.txt)
           yq eval -i ".version = \"$version\"" packages/helm/symphony/Chart.yaml
           yq eval -i ".appVersion = \"$version\"" packages/helm/symphony/Chart.yaml
-          sed -i "s/{VERSION}/${{ steps.increment_version.outputs.version }}/g" packages/helm/symphony/values.yaml
+          yq eval -i ".symphonyImage.tag = \"$version\"" packages/helm/symphony/values.yaml
+          yq eval -i ".paiImage.tag = \"$version\"" packages/helm/symphony/values.yaml
           
       - name: Build Helm
         run: |

--- a/cli/cmd/up.go
+++ b/cli/cmd/up.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// The version is auto updated by the release pipeline, do not change it manually
+// The version is auto updated by the release pipeline, do not change it manually. If next line changes, please update the release pipeline, release.yaml as well.
 const SymphonyAPIVersion = "0.47.4"
 const KANPortalVersion = "0.39.0-main-603f4b9-amd64"
 

--- a/packages/helm/symphony/Chart.yaml
+++ b/packages/helm/symphony/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: symphony
 description: A Helm chart for Symphony control plane
 type: application
-# The version is auto updated by the release pipeline, do not change it manually
+# The version is auto updated by the release pipeline, do not change it manually. If Schema changes, please update the release pipeline file, release.yaml.
 version: "0.47.4"
-# The version is auto updated by the release pipeline, do not change it manually
+# The version is auto updated by the release pipeline, do not change it manually. If Schema changes, please update the release pipeline file, release.yaml.
 appVersion: "0.47.4"
 dependencies:
   - name: cert-manager

--- a/packages/helm/symphony/values.yaml
+++ b/packages/helm/symphony/values.yaml
@@ -2,11 +2,13 @@ fullnameOverride: symphony
 symphonyImage:
   repository: ghcr.io/eclipse-symphony/symphony-k8s
   pullPolicy: IfNotPresent
-  tag: "{VERSION}"
+  # The version is auto updated by the release pipeline, do not change it manually. If Schema changes, please update the release pipeline file, release.yaml.
+  tag: "0.47.4"
 paiImage:
   repository: ghcr.io/eclipse-symphony/symphony-api
   pullPolicy: IfNotPresent
-  tag: "{VERSION}"
+  # The version is auto updated by the release pipeline, do not change it manually. If Schema changes, please update the release pipeline file, release.yaml.
+  tag: "0.47.4"
 CUSTOM_VISION_KEY: "AAAA"
 installServiceExt: true
 global:
@@ -27,7 +29,7 @@ redis:
   image: redis/redis-stack-server:latest
   port: 6379
 parent:
-  url: 
+  url:
   username: admin
   password:
 siteId: hq


### PR DESCRIPTION
With {version} placeholder, maestro local build and local test would fail for the placeholder. 
Using current version would fix this. Release pipeline would update the two tags when triggered.