### PR TITLE
change test script pointing to new blobs

### DIFF
--- a/api/pkg/apis/v1alpha1/providers/target/script/script_test.go
+++ b/api/pkg/apis/v1alpha1/providers/target/script/script_test.go
@@ -62,7 +62,7 @@ func TestInitWithMap(t *testing.T) {
 		"needsUpdate":   "mock-needsupdate.sh",
 		"needsRemove":   "mock-needsremove.sh",
 		"stagingFolder": "./staging",
-		"scriptFolder":  "https://demopolicies.blob.core.windows.net/gatekeeper",
+		"scriptFolder":  "https://unittestscripts.blob.core.windows.net/script",
 		"applyScript":   "mock-apply.sh",
 		"removeScript":  "mock-remove.sh",
 		"getScript":     "mock-get.sh",


### PR DESCRIPTION
Original storage account and blob container holding test scripts was deleted. Created a new blob container and replaced the URI with new one.