### PR TITLE
Revert "Fix k8s state provider update status logic and add unit tests"

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,6 @@ jobs:
       TEST_MINIKUBE_ENABLED: yes
       TEST_MQTT_LOCAL_ENABLED: yes
       TEST_DOCKER_ENABLED: yes
-      TEST_K8S_STATE: yes
     steps:
     - uses: actions/checkout@v3
 
@@ -33,7 +32,7 @@ jobs:
         echo "export GOPATH=/home/runner/go" >> $HOME/.bashrc
         echo "export PATH=\$PATH:\$GOPATH/bin" >> $HOME/.bashrc
         source $HOME/.bashrc
-
+          
     - name: Install make
       run: sudo apt-get update && sudo apt-get install -y build-essential
 
@@ -71,9 +70,7 @@ jobs:
 
     - name: API Test
       run: |
-        echo "TEST_KUBECTL:$TEST_KUBECTL TEST_MINIKUBE_ENABLED:$TEST_MINIKUBE_ENABLED TEST_K8S_STATE: $TEST_K8S_STATE"
-        export REPOPATH="${{ github.workspace }}"
-        echo "REPOPATH=$REPOPATH"
+        echo "TEST_KUBECTL:$TEST_KUBECTL TEST_MINIKUBE_ENABLED:$TEST_MINIKUBE_ENABLED"
         cd api && go test -race -v ./... -run '^[^C]*$|^[^c][^o]*$|^[^c][^o]*o[^n][^f][^o][^r][^m][^a][^n][^c][^e][^C]*$'
 
     - name: target-api-testcoverage-app

--- a/api/pkg/apis/v1alpha1/providers/states/k8s/k8s_test.go
+++ b/api/pkg/apis/v1alpha1/providers/states/k8s/k8s_test.go
@@ -10,9 +10,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"testing"
-	"time"
 
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states"
@@ -79,10 +77,8 @@ func TestUpsert(t *testing.T) {
 	if testK8s == "" {
 		t.Skip("Skipping because TEST_K8S_STATE enviornment variable is not set")
 	}
-	err := checkTargetCRDApplied()
-	assert.Nil(t, err)
 	provider := K8sStateProvider{}
-	err = provider.Init(K8sStateProviderConfig{
+	err := provider.Init(K8sStateProviderConfig{
 		InCluster:  false,
 		ConfigType: "path",
 	})
@@ -114,15 +110,14 @@ func TestUpsert(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "s123", id)
 }
+
 func TestList(t *testing.T) {
 	testK8s := os.Getenv("TEST_K8S_STATE")
 	if testK8s == "" {
 		t.Skip("Skipping because TEST_K8S_STATE enviornment variable is not set")
 	}
-	err := checkTargetCRDApplied()
-	assert.Nil(t, err)
 	provider := K8sStateProvider{}
-	err = provider.Init(K8sStateProviderConfig{
+	err := provider.Init(K8sStateProviderConfig{
 		InCluster:  false,
 		ConfigType: "path",
 	})
@@ -137,7 +132,6 @@ func TestList(t *testing.T) {
 			},
 		},
 		Metadata: map[string]string{
-			"template": fmt.Sprintf(`{"apiVersion":"%s/v1", "kind": "Target", "metadata": {"name": "${{$target()}}"}}`, model.FabricGroup),
 			"scope":    "default",
 			"group":    model.FabricGroup,
 			"version":  "v1",
@@ -154,30 +148,17 @@ func TestList(t *testing.T) {
 		},
 	})
 	assert.Nil(t, err)
-	assert.Equal(t, 1, len(entries))
-	assert.Equal(t, "s123", entries[0].ID)
-
-	assert.Nil(t, err)
-	entries, _, err = provider.List(context.Background(), states.ListRequest{
-		Metadata: map[string]string{
-			"group":    model.FabricGroup,
-			"version":  "v1",
-			"resource": "targets",
-		},
-	})
-	assert.Nil(t, err)
-	assert.Equal(t, 1, len(entries))
+	assert.Equal(t, 2, len(entries))
 	assert.Equal(t, "s123", entries[0].ID)
 }
+
 func TestDelete(t *testing.T) {
 	testK8s := os.Getenv("TEST_K8S_STATE")
 	if testK8s == "" {
 		t.Skip("Skipping because TEST_K8S_STATE enviornment variable is not set")
 	}
-	err := checkTargetCRDApplied()
-	assert.Nil(t, err)
 	provider := K8sStateProvider{}
-	err = provider.Init(K8sStateProviderConfig{
+	err := provider.Init(K8sStateProviderConfig{
 		InCluster:  false,
 		ConfigType: "path",
 	})
@@ -211,10 +192,8 @@ func TestGet(t *testing.T) {
 	if testK8s == "" {
 		t.Skip("Skipping because TEST_K8S_STATE enviornment variable is not set")
 	}
-	err := checkTargetCRDApplied()
-	assert.Nil(t, err)
 	provider := K8sStateProvider{}
-	err = provider.Init(K8sStateProviderConfig{
+	err := provider.Init(K8sStateProviderConfig{
 		InCluster:  false,
 		ConfigType: "path",
 	})
@@ -250,39 +229,31 @@ func TestGet(t *testing.T) {
 			"scope":    "default",
 			"group":    model.FabricGroup,
 			"version":  "v1",
-			"resource": "targets",
+			"resource": "targetds",
 		},
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, "s123", item.ID)
 }
-func TestUpsertWithState(t *testing.T) {
-	// target already exists
-	testUpsertWithState(t, "s123")
-	// target doesn't exist
-	testUpsertWithState(t, "s234")
-}
-func testUpsertWithState(t *testing.T, targetName string) {
+func TestUpSertWithState(t *testing.T) {
 	testK8s := os.Getenv("TEST_K8S_STATE")
 	if testK8s == "" {
 		t.Skip("Skipping because TEST_K8S_STATE enviornment variable is not set")
 	}
-	err := checkTargetCRDApplied()
-	assert.Nil(t, err)
 	provider := K8sStateProvider{}
-	err = provider.Init(K8sStateProviderConfig{
+	err := provider.Init(K8sStateProviderConfig{
 		InCluster:  false,
 		ConfigType: "path",
 	})
 	assert.Nil(t, err)
 	id, err := provider.Upsert(context.Background(), states.UpsertRequest{
 		Value: states.StateEntry{
-			ID: targetName,
+			ID: "s234",
 			Body: map[string]interface{}{
 				"apiVersion": model.FabricGroup + "/v1",
 				"kind":       "Target",
 				"metadata": map[string]interface{}{
-					"name": targetName,
+					"name": "s234",
 				},
 				"spec": model.TargetSpec{
 					Properties: map[string]string{
@@ -291,8 +262,7 @@ func testUpsertWithState(t *testing.T, targetName string) {
 				},
 				"status": map[string]interface{}{
 					"properties": map[string]string{
-						"foo":             "bar",
-						"provisionStatus": "",
+						"foo": "bar",
 					},
 				},
 			},
@@ -306,28 +276,15 @@ func testUpsertWithState(t *testing.T, targetName string) {
 		},
 	})
 	assert.Nil(t, err)
-	assert.Equal(t, targetName, id)
-
-	err = provider.Delete(context.Background(), states.DeleteRequest{
-		ID: targetName,
-		Metadata: map[string]string{
-			"scope":    "default",
-			"group":    model.FabricGroup,
-			"version":  "v1",
-			"resource": "targets",
-		},
-	})
-	assert.Nil(t, err)
+	assert.Equal(t, "s234", id)
 }
-func TestUpsertWithStateOnly(t *testing.T) {
+func TestUpSertWithStateOnly(t *testing.T) {
 	testK8s := os.Getenv("TEST_K8S_STATE")
 	if testK8s == "" {
 		t.Skip("Skipping because TEST_K8S_STATE enviornment variable is not set")
 	}
-	err := checkTargetCRDApplied()
-	assert.Nil(t, err)
 	provider := K8sStateProvider{}
-	err = provider.Init(K8sStateProviderConfig{
+	err := provider.Init(K8sStateProviderConfig{
 		InCluster:  false,
 		ConfigType: "path",
 	})
@@ -358,40 +315,4 @@ func TestUpsertWithStateOnly(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, "s234", id)
-
-	err = provider.Delete(context.Background(), states.DeleteRequest{
-		ID: "s234",
-		Metadata: map[string]string{
-			"scope":    "default",
-			"group":    model.FabricGroup,
-			"version":  "v1",
-			"resource": "targets",
-		},
-	})
-	assert.Nil(t, err)
-}
-
-func runKubectl(args ...string) ([]byte, error) {
-	cmd := exec.Command("kubectl", args...)
-	return cmd.Output()
-}
-
-func checkTargetCRDApplied() error {
-	// Check that the CRD is applied
-	_, err := runKubectl("get", "crd", "targets.fabric.symphony")
-	if err != nil {
-		// apply the CRD api/pkg/apis/v1alpha1/providers/states/k8s/k8s_test.go
-		ProjectPath := os.Getenv("REPOPATH")
-		targetYamlPath := ProjectPath + "/k8s/config/oss/crd/bases/fabric.symphony_targets.yaml"
-		if _, err := os.Stat(targetYamlPath); err != nil {
-			return err
-		}
-		_, err = runKubectl("apply", "-f", targetYamlPath)
-		if err != nil {
-			return err
-		}
-		// Wait for the CRD to be applied
-		time.Sleep(10 * time.Second)
-	}
-	return nil
 }


### PR DESCRIPTION


This reverts commit 3bc65dd0bcfc39d7f90391f4d456190a09c5f9e2.

Symphony objects Target and Activation have structure for status object and the previous change will break activation logic.