### PR TITLE
Fix assert.Errorf/assert.Error, should use assert.EqualError

### DIFF
--- a/api/pkg/apis/v1alpha1/model/binding_test.go
+++ b/api/pkg/apis/v1alpha1/model/binding_test.go
@@ -37,7 +37,7 @@ func TestBindingMatchOneEmpty(t *testing.T) {
 		Role: "role",
 	}
 	res, err := binding1.DeepEquals(nil)
-	assert.Errorf(t, err, "parameter is not a BindingSpec type")
+	assert.EqualError(t, err, "parameter is not a BindingSpec type")
 	assert.False(t, res)
 }
 

--- a/api/pkg/apis/v1alpha1/model/campaign_test.go
+++ b/api/pkg/apis/v1alpha1/model/campaign_test.go
@@ -66,7 +66,7 @@ func TestCampaignMatchOneEmpty(t *testing.T) {
 		Name: "name",
 	}
 	res, err := campaign1.DeepEquals(nil)
-	assert.Errorf(t, err, "parameter is not a CampaignSpec type")
+	assert.EqualError(t, err, "parameter is not a CampaignSpec type")
 	assert.False(t, res)
 }
 
@@ -261,7 +261,7 @@ func TestStageMatchOneEmpty(t *testing.T) {
 		Name: "name",
 	}
 	res, err := stage1.DeepEquals(nil)
-	assert.Errorf(t, err, "parameter is not a StageSpec type")
+	assert.EqualError(t, err, "parameter is not a StageSpec type")
 	assert.False(t, res)
 }
 
@@ -270,7 +270,7 @@ func TestActivationMatchOneEmpty(t *testing.T) {
 		Name: "name",
 	}
 	res, err := activation1.DeepEquals(nil)
-	assert.Errorf(t, err, "parameter is not a ActivationSpec type")
+	assert.EqualError(t, err, "parameter is not a ActivationSpec type")
 	assert.False(t, res)
 }
 

--- a/api/pkg/apis/v1alpha1/model/catalog_test.go
+++ b/api/pkg/apis/v1alpha1/model/catalog_test.go
@@ -61,7 +61,7 @@ func TestCatalogMatchOneEmpty(t *testing.T) {
 		},
 	}
 	res, err := catalog1.DeepEquals(nil)
-	assert.Errorf(t, err, "parameter is not a CatalogSpec type")
+	assert.EqualError(t, err, "parameter is not a CatalogSpec type")
 	assert.False(t, res)
 }
 

--- a/api/pkg/apis/v1alpha1/model/component_test.go
+++ b/api/pkg/apis/v1alpha1/model/component_test.go
@@ -152,7 +152,7 @@ func TestComponentDeepEqualEmpty(t *testing.T) {
 		Name: "symphony-agent",
 	}
 	res, err := component1.DeepEquals(nil)
-	assert.Errorf(t, err, "parameter is not a ComponentSpec type")
+	assert.EqualError(t, err, "parameter is not a ComponentSpec type")
 	assert.False(t, res)
 }
 

--- a/api/pkg/apis/v1alpha1/model/deployment_test.go
+++ b/api/pkg/apis/v1alpha1/model/deployment_test.go
@@ -89,7 +89,7 @@ func TestDeploymentDeepEqualsOneEmpty(t *testing.T) {
 		ActiveTarget:        "ActiveTarget",
 	}
 	res, err := deployment1.DeepEquals(nil)
-	assert.Errorf(t, err, "parameter is not a DeploymentSpec type")
+	assert.EqualError(t, err, "parameter is not a DeploymentSpec type")
 	assert.False(t, res)
 }
 

--- a/api/pkg/apis/v1alpha1/model/device_test.go
+++ b/api/pkg/apis/v1alpha1/model/device_test.go
@@ -41,7 +41,7 @@ func TestDeviceMatchOneEmpty(t *testing.T) {
 		DisplayName: "displayName",
 	}
 	res, err := device1.DeepEquals(nil)
-	assert.Errorf(t, err, "parameter is not a DeviceSpec type")
+	assert.EqualError(t, err, "parameter is not a DeviceSpec type")
 	assert.False(t, res)
 }
 

--- a/api/pkg/apis/v1alpha1/model/filter_test.go
+++ b/api/pkg/apis/v1alpha1/model/filter_test.go
@@ -128,6 +128,6 @@ func TestFilterEqualOneEmpty(t *testing.T) {
 		},
 	}
 	res, err := filter1.DeepEquals(nil)
-	assert.Errorf(t, err, "parameter is not a FilterSpec type")
+	assert.EqualError(t, err, "parameter is not a FilterSpec type")
 	assert.False(t, res)
 }

--- a/api/pkg/apis/v1alpha1/model/instance_test.go
+++ b/api/pkg/apis/v1alpha1/model/instance_test.go
@@ -77,7 +77,7 @@ func TestInstanceDeepEqualsOneEmpty(t *testing.T) {
 		},
 	}
 	res, err := Instance.DeepEquals(nil)
-	assert.Errorf(t, err, "parameter is not a InstanceSpec type")
+	assert.EqualError(t, err, "parameter is not a InstanceSpec type")
 	assert.False(t, res)
 }
 
@@ -470,7 +470,7 @@ func TestTargetSelectorDeepEqualsOneEmpty(t *testing.T) {
 		Name: "TargetName",
 	}
 	res, err := Target.DeepEquals(nil)
-	assert.Errorf(t, err, "parameter is not a TargetSelector type")
+	assert.EqualError(t, err, "parameter is not a TargetSelector type")
 	assert.False(t, res)
 }
 
@@ -497,7 +497,7 @@ func TestPipelineSpecDeepEqualsOneEmpty(t *testing.T) {
 		Name: "PipelineName",
 	}
 	res, err := Pipeline.DeepEquals(nil)
-	assert.Errorf(t, err, "parameter is not a PipelineSpec type")
+	assert.EqualError(t, err, "parameter is not a PipelineSpec type")
 	assert.False(t, res)
 }
 
@@ -546,7 +546,7 @@ func TestTopologySpecDeepEqualsOneEmpty(t *testing.T) {
 		Device: "DeviceName",
 	}
 	res, err := Topology.DeepEquals(nil)
-	assert.Errorf(t, err, "parameter is not a TopologySpec type")
+	assert.EqualError(t, err, "parameter is not a TopologySpec type")
 	assert.False(t, res)
 }
 

--- a/api/pkg/apis/v1alpha1/model/route_test.go
+++ b/api/pkg/apis/v1alpha1/model/route_test.go
@@ -311,6 +311,6 @@ func TestRouteMatchOneEmpty(t *testing.T) {
 		},
 	}
 	res, err := route1.DeepEquals(nil)
-	assert.Errorf(t, err, "parameter is not a RouteSpec type")
+	assert.EqualError(t, err, "parameter is not a RouteSpec type")
 	assert.False(t, res)
 }

--- a/api/pkg/apis/v1alpha1/model/site_test.go
+++ b/api/pkg/apis/v1alpha1/model/site_test.go
@@ -72,6 +72,6 @@ func TestSiteEqualNil(t *testing.T) {
 		},
 	}
 	res, err := s1.DeepEquals(nil)
-	assert.Errorf(t, err, "parameter is not a SiteSpec type")
+	assert.EqualError(t, err, "parameter is not a SiteSpec type")
 	assert.False(t, res)
 }

--- a/api/pkg/apis/v1alpha1/model/solution_test.go
+++ b/api/pkg/apis/v1alpha1/model/solution_test.go
@@ -37,7 +37,7 @@ func TestSolutionDeepEqualsOneEmpty(t *testing.T) {
 		Components:  []ComponentSpec{{}},
 	}
 	res, err := solution.DeepEquals(nil)
-	assert.Errorf(t, err, "parameter is not a SolutionSpec type")
+	assert.EqualError(t, err, "parameter is not a SolutionSpec type")
 	assert.False(t, res)
 }
 

--- a/api/pkg/apis/v1alpha1/model/target_test.go
+++ b/api/pkg/apis/v1alpha1/model/target_test.go
@@ -62,7 +62,7 @@ func TestTargetDeepEqualsOneEmpty(t *testing.T) {
 		ForceRedeploy: false,
 	}
 	res, err := Target.DeepEquals(nil)
-	assert.Errorf(t, err, "parameter is not a TargetSpec type")
+	assert.EqualError(t, err, "parameter is not a TargetSpec type")
 	assert.False(t, res)
 }
 

--- a/api/pkg/apis/v1alpha1/model/validationrule_test.go
+++ b/api/pkg/apis/v1alpha1/model/validationrule_test.go
@@ -121,7 +121,7 @@ func TestValidateCOA(t *testing.T) {
 		},
 	}
 	equal := validationRule.Validate(components)
-	assert.Errorf(t, equal, "required property 'requiredProperties1' is missing")
+	assert.EqualError(t, equal, "required property 'requiredProperties1' is missing")
 }
 
 func TestValidateMetadata(t *testing.T) {
@@ -144,7 +144,7 @@ func TestValidateMetadata(t *testing.T) {
 		},
 	}
 	equal := validationRule.Validate(components)
-	assert.Errorf(t, equal, "required property 'RequiredMetadata1' is missing")
+	assert.EqualError(t, equal, "required metadata 'RequiredMetadata1' is missing")
 }
 
 func TestValidateComponentType(t *testing.T) {
@@ -159,7 +159,7 @@ func TestValidateComponentType(t *testing.T) {
 		},
 	}
 	equal := validationRule.Validate(components)
-	assert.Errorf(t, equal, "required property 'requiredComponentType' is missing")
+	assert.EqualError(t, equal, "provider requires component type 'requiredComponentType', but 'requiredComponentType1' is found instead")
 }
 
 func TestValidateInputs(t *testing.T) {
@@ -183,7 +183,7 @@ func TestValidateInputs(t *testing.T) {
 		"requiredProperties": "requiredProperties",
 	}
 	equal = validationRule.ValidateInputs(inputs2)
-	assert.Errorf(t, equal, "required property 'requiredProperties1' is missing")
+	assert.EqualError(t, equal, "required property 'requiredProperties1' is missing")
 }
 
 func TestIsComponentChangedNoWildcard(t *testing.T) {

--- a/api/pkg/apis/v1alpha1/utils/utils_test.go
+++ b/api/pkg/apis/v1alpha1/utils/utils_test.go
@@ -269,11 +269,11 @@ func TestGetString(t *testing.T) {
 
 	val, err = GetString(mapData, "c")
 	assert.NotNil(t, err)
-	assert.Errorf(t, err, "value of %s is not a string", "c")
+	assert.EqualError(t, err, "value of c is not a string")
 
 	val, err = GetString(mapData, "d")
 	assert.NotNil(t, err)
-	assert.Errorf(t, err, "key %s is not found", "d")
+	assert.EqualError(t, err, "key d is not found")
 }
 func TestReadStringFromMapCompat(t *testing.T) {
 	mapData := map[string]interface{}{


### PR DESCRIPTION
```assert.EqualError``` is the correct method to compare the error message. ```assert.Errorf``` or ```assert.Error``` only check if the err variable is nil or not. When err is not nil, it will print the message defined in ```assert.Errorf``` or ```assert.Error```.