### PR TITLE
Fix middleware.http.telemetry config parser issue and add tests

### DIFF
--- a/coa/pkg/apis/v1alpha2/bindings/http/http_pipeline.go
+++ b/coa/pkg/apis/v1alpha2/bindings/http/http_pipeline.go
@@ -38,6 +38,11 @@ func BuildPipeline(config HttpBindingConfig, pubsubProvider pubsub.IPubSubProvid
 		case "middleware.http.telemetry":
 			enableAppInsight := os.Getenv("ENABLE_APP_INSIGHT")
 			c.Properties["enabled"] = enableAppInsight == "true"
+			if c.Properties["enabled"] == true {
+				if os.Getenv("APP_INSIGHT_KEY") == "" {
+					return ret, v1alpha2.NewCOAError(nil, "APP_INSIGHT_KEY is not set", v1alpha2.BadConfig)
+				}
+			}
 			c.Properties["client"] = uuid.New().String()
 			telemetry := Telemetry{Properties: c.Properties}
 			ret.Handlers = append(ret.Handlers, telemetry.Telemetry)

--- a/coa/pkg/apis/v1alpha2/bindings/http/http_pipeline_test.go
+++ b/coa/pkg/apis/v1alpha2/bindings/http/http_pipeline_test.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package http
+
+import (
+	"testing"
+
+	v1alpha2 "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildPipeline_WithInvalidJWTConfig(t *testing.T) {
+	config := HttpBindingConfig{
+		Port: 8080,
+		Pipeline: []MiddlewareConfig{
+			{
+				Type: "middleware.http.jwt",
+				// JWT.MustHave is a string array
+				Properties: map[string]interface{}{
+					"MustHave": "test",
+				},
+			},
+		},
+	}
+	_, err := BuildPipeline(config, nil)
+	assert.NotNil(t, err)
+	coaError := err.(v1alpha2.COAError)
+	assert.Equal(t, v1alpha2.BadConfig, coaError.State)
+	assert.Equal(t, "incorrect jwt pipeline configuration format", coaError.Message)
+}
+
+func TestBuildPipeline_WithInvalidTracingConfig(t *testing.T) {
+	config := HttpBindingConfig{
+		Port: 8080,
+		Pipeline: []MiddlewareConfig{
+			{
+				Type: "middleware.http.tracing",
+				// Tracing.Pipeline is a string array
+				Properties: map[string]interface{}{
+					"pipeline": "test",
+				},
+			},
+		},
+	}
+	_, err := BuildPipeline(config, nil)
+	assert.NotNil(t, err)
+	coaError := err.(v1alpha2.COAError)
+	assert.Equal(t, v1alpha2.BadConfig, coaError.State)
+	assert.Equal(t, "incorrect tracing pipeline configuration format", coaError.Message)
+}
+
+func TestBuildPipeline_WithUnknownType(t *testing.T) {
+	config := HttpBindingConfig{
+		Port: 8080,
+		Pipeline: []MiddlewareConfig{
+			{
+				Type: "middleware.http.unknown",
+				Properties: map[string]interface{}{
+					"test": "test",
+				},
+			},
+		},
+	}
+	_, err := BuildPipeline(config, nil)
+	assert.NotNil(t, err)
+	coaError := err.(v1alpha2.COAError)
+	assert.Equal(t, v1alpha2.BadConfig, coaError.State)
+	assert.Equal(t, "middleware type 'middleware.http.unknown' is not recognized", coaError.Message)
+}

--- a/coa/pkg/apis/v1alpha2/bindings/http/http_test.go
+++ b/coa/pkg/apis/v1alpha2/bindings/http/http_test.go
@@ -1,0 +1,421 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package http
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	v1alpha2 "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	observability "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/observability"
+	observ_utils "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/observability/utils"
+	autogen "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/certs/autogen"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/pubsub/memory"
+	jwt "github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+)
+
+type TestCustomClaims struct {
+	User string `json:"user"`
+	jwt.RegisteredClaims
+}
+
+type TestAuthRequest struct {
+	UserName string `json:"username"`
+	Password string `json:"password"`
+}
+
+func testHttpRequestHelper(context context.Context, t *testing.T, method string, url string, body []byte, expectedStatusCode int, expectedBody string) {
+	client := &http.Client{}
+	req, err := http.NewRequestWithContext(context, method, url, bytes.NewBuffer(body))
+	observ_utils.PropagateSpanContextToHttpRequestHeader(req)
+	assert.Nil(t, err)
+	resp, err := client.Do(req)
+	assert.Nil(t, err)
+
+	defer resp.Body.Close()
+	assert.Equal(t, expectedStatusCode, resp.StatusCode)
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	assert.Nil(t, err)
+
+	if expectedBody != "" {
+		assert.Equal(t, expectedBody, string(bodyBytes))
+	}
+}
+
+func testHttpRequestHelperWithHeaders(context context.Context, t *testing.T, method string, url string, body []byte, headers map[string]string, expectedStatusCode int, expectedBody string, expectedResponseHeaders map[string]string) {
+	client := &http.Client{}
+	req, err := http.NewRequestWithContext(context, method, url, bytes.NewBuffer(body))
+	observ_utils.PropagateSpanContextToHttpRequestHeader(req)
+	assert.Nil(t, err)
+	for k, v := range headers {
+		req.Header.Add(k, v)
+	}
+	resp, err := client.Do(req)
+	assert.Nil(t, err)
+
+	defer resp.Body.Close()
+	assert.Equal(t, expectedStatusCode, resp.StatusCode)
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	assert.Nil(t, err)
+
+	if expectedBody != "" {
+		assert.Equal(t, expectedBody, string(bodyBytes))
+	}
+
+	for k, v := range expectedResponseHeaders {
+		assert.Equal(t, v, resp.Header.Get(k))
+	}
+}
+
+func TestHTTPEcho(t *testing.T) {
+	config := HttpBindingConfig{
+		Port: 8080,
+		TLS:  false,
+	}
+	binding := HttpBinding{}
+	endpoints := []v1alpha2.Endpoint{
+		{
+			Methods: []string{"GET"},
+			Route:   "greetings",
+			Version: "v1",
+			Handler: func(c v1alpha2.COARequest) v1alpha2.COAResponse {
+				return v1alpha2.COAResponse{
+					Body: []byte("Hi there!!"),
+				}
+			},
+		},
+		{
+			Methods: []string{"GET"},
+			Route:   "greetings2",
+			Version: "v1",
+			Handler: func(c v1alpha2.COARequest) v1alpha2.COAResponse {
+				return v1alpha2.COAResponse{
+					Body: []byte("Hi " + c.Parameters["name"] + "!!"),
+				}
+			},
+		},
+		{
+			Methods:    []string{"GET"},
+			Route:      "greetings3",
+			Version:    "v1",
+			Parameters: []string{"name"},
+			Handler: func(c v1alpha2.COARequest) v1alpha2.COAResponse {
+				return v1alpha2.COAResponse{
+					Body: []byte("Hi " + c.Parameters["__name"] + "!!!"),
+				}
+			},
+		},
+		{
+			Methods: []string{"POST"},
+			Route:   "greetingsWithMetadata",
+			Version: "v1",
+			Handler: func(c v1alpha2.COARequest) v1alpha2.COAResponse {
+				metadata := c.Metadata
+				value := metadata["key"]
+				return v1alpha2.COAResponse{
+					Metadata: map[string]string{
+						"key": value,
+					},
+					Body: []byte("Hi " + value + "!!!!"),
+				}
+			},
+		},
+	}
+	err := binding.Launch(config, endpoints, nil)
+	assert.Nil(t, err)
+
+	testHttpRequestHelper(context.Background(), t, fasthttp.MethodGet, "http://localhost:8080/v1/greetings", nil, 200, "Hi there!!")
+
+	// query args
+	testHttpRequestHelper(context.Background(), t, fasthttp.MethodGet, "http://localhost:8080/v1/greetings2?name=John", nil, 200, "Hi John!!")
+
+	// path parameters
+	testHttpRequestHelper(context.Background(), t, fasthttp.MethodGet, "http://localhost:8080/v1/greetings3/John", nil, 200, "Hi John!!!")
+
+	// req metadata and resp metadata
+	req4Metadata := map[string]string{
+		"key": "Alice",
+	}
+	b, _ := json.Marshal(req4Metadata)
+	testHttpRequestHelperWithHeaders(
+		context.Background(),
+		t,
+		fasthttp.MethodPost,
+		"http://localhost:8080/v1/greetingsWithMetadata",
+		nil,
+		map[string]string{
+			v1alpha2.COAMetaHeader: string(b),
+		},
+		200,
+		"Hi Alice!!!!",
+		map[string]string{
+			v1alpha2.COAMetaHeader: string(b),
+		})
+}
+
+func TestHTTPEchoWithTLS(t *testing.T) {
+	config := HttpBindingConfig{
+		Port: 8888,
+		TLS:  true,
+		CertProvider: CertProviderConfig{
+			Type: "certs.autogen",
+			Config: autogen.AutoGenCertProviderConfig{
+				Name: "test",
+			},
+		},
+	}
+	binding := HttpBinding{}
+	endpoints := []v1alpha2.Endpoint{
+		{
+			Methods: []string{"GET"},
+			Route:   "greetings",
+			Version: "v1",
+			Handler: func(c v1alpha2.COARequest) v1alpha2.COAResponse {
+				return v1alpha2.COAResponse{
+					Body: []byte("Hi there!!"),
+				}
+			},
+		},
+	}
+	err := binding.Launch(config, endpoints, nil)
+	assert.Nil(t, err)
+
+	// need to wait for tls cert creation (it is in another go routine)
+	time.Sleep(5 * time.Second)
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+	req, err := http.NewRequest(fasthttp.MethodGet, "https://localhost:8888/v1/greetings", nil)
+	assert.Nil(t, err)
+	resp, err := client.Do(req)
+	assert.Nil(t, err)
+
+	defer resp.Body.Close()
+	assert.Equal(t, resp.StatusCode, 200)
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	assert.Nil(t, err)
+
+	assert.Equal(t, string(bodyBytes), "Hi there!!")
+}
+
+func TestHTTPEchoWithPipeline(t *testing.T) {
+	pubsub := &memory.InMemoryPubSubProvider{}
+	err := pubsub.Init(memory.InMemoryPubSubConfig{})
+	assert.Nil(t, err)
+
+	signingKey := "TestKey"
+	config := HttpBindingConfig{
+		Port: 8081,
+		TLS:  false,
+		Pipeline: []MiddlewareConfig{
+			{
+				Type: "middleware.http.tracing",
+				Properties: map[string]interface{}{
+					"pipeline": []map[string]interface{}{
+						{
+							"exporter": map[string]interface{}{
+								"type":       "tracing.exporters.console",
+								"backendUrl": "",
+								"sampler": map[string]string{
+									"sampleRate": "always",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Type:       "middleware.http.trail",
+				Properties: map[string]interface{}{},
+			},
+			{
+				Type: "middleware.http.telemetry",
+				Properties: map[string]interface{}{
+					"enabled":                 true,
+					"maxBatchSize":            8192,
+					"maxBatchIntervalSeconds": 2,
+					"client":                  "coabinding-test", // will be override as uuid
+				},
+			},
+			{
+				Type: "middleware.http.cors",
+				Properties: map[string]interface{}{
+					"Any": "value",
+				},
+			},
+			{
+				Type: "middleware.http.jwt",
+				Properties: map[string]interface{}{
+					"ignorePaths": []string{"/v1/auth"},
+					"verifyKey":   signingKey,
+					"enableRBAC":  true,
+					"roles": []map[string]string{
+						{
+							"role":  "administrator",
+							"claim": "user",
+							"value": "adminuser",
+						},
+					},
+					"policy": map[string]interface{}{
+						"administrator": map[string]map[string]string{
+							"items": {
+								"/v1/greetings": fasthttp.MethodGet,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	binding := HttpBinding{}
+	userRoleMap := map[string][]string{
+		"adminuser":      {"administrator"},
+		"reader":         {"reader"},
+		"developer":      {"developer"},
+		"device-manager": {"device-manager"},
+		"operator":       {"operator"},
+	}
+	endpoints := []v1alpha2.Endpoint{
+		{
+			Methods: []string{"POST"},
+			Route:   "auth",
+			Version: "v1",
+			Handler: func(c v1alpha2.COARequest) v1alpha2.COAResponse {
+				var authRequest TestAuthRequest
+				_ = json.Unmarshal(c.Body, &authRequest)
+
+				mySigningKey := []byte(signingKey)
+				claims := TestCustomClaims{
+					authRequest.UserName,
+					jwt.RegisteredClaims{
+						// A usual scenario is to set the expiration time relative to the current time
+						ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)),
+						IssuedAt:  jwt.NewNumericDate(time.Now()),
+						NotBefore: jwt.NewNumericDate(time.Now()),
+						Issuer:    "test",
+						Subject:   "test",
+						ID:        "1",
+						Audience:  []string{"*"},
+					},
+				}
+
+				token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+				ss, _ := token.SignedString(mySigningKey)
+
+				roles := userRoleMap[authRequest.UserName]
+				if roles == nil {
+					roles = nil
+				}
+				rolesJSON, _ := json.Marshal(roles)
+				resp := v1alpha2.COAResponse{
+					State:       v1alpha2.OK,
+					Body:        []byte(fmt.Sprintf(`{"accessToken":"%s", "tokenType": "Bearer", "username": "%s", "roles": %s}`, ss, authRequest.UserName, rolesJSON)),
+					ContentType: "application/json",
+				}
+				return resp
+			},
+		},
+		{
+			Methods: []string{"GET", "POST"},
+			Route:   "greetings",
+			Version: "v1",
+			Handler: func(c v1alpha2.COARequest) v1alpha2.COAResponse {
+				switch c.Method {
+				case fasthttp.MethodGet:
+					return v1alpha2.COAResponse{
+						Body: []byte("Hi there!!"),
+					}
+				case fasthttp.MethodPost:
+					reqBody := string(c.Body)
+					return v1alpha2.COAResponse{
+						Body: []byte(fmt.Sprintf("Hi %s!!", reqBody)),
+					}
+				}
+				return v1alpha2.COAResponse{}
+			},
+		},
+	}
+	err = binding.Launch(config, endpoints, pubsub)
+	assert.Nil(t, err)
+
+	time.Sleep(5 * time.Second)
+
+	client := &http.Client{}
+
+	user := TestAuthRequest{
+		UserName: "adminuser",
+		Password: "",
+	}
+	userJSON, _ := json.Marshal(user)
+	authReq, err := http.NewRequest(fasthttp.MethodPost, "http://localhost:8081/v1/auth", bytes.NewBuffer(userJSON))
+	assert.Nil(t, err)
+	authResp, err := client.Do(authReq)
+	assert.Nil(t, err)
+
+	defer authResp.Body.Close()
+	assert.Equal(t, authResp.StatusCode, 200)
+	bodyBytes2, err := ioutil.ReadAll(authResp.Body)
+	var parsedAuthResp map[string]interface{}
+	json.Unmarshal(bodyBytes2, &parsedAuthResp)
+	authHeader, ok := parsedAuthResp["accessToken"].(string)
+	assert.True(t, ok)
+
+	// test valid token and rbac
+	testHttpRequestHelperWithHeaders(context.Background(), t, fasthttp.MethodGet, "http://localhost:8081/v1/greetings", nil,
+		map[string]string{
+			"Authorization": "Bearer " + authHeader,
+		}, 200, "Hi there!!", map[string]string{
+			"Access-Control-Allow-Origin":      corsAllowOrigin,
+			"Access-Control-Allow-Methods":     corsAllowMethods,
+			"Access-Control-Allow-Credentials": corsAllowCredentials,
+			"Access-Control-Allow-Headers":     corsAllowHeaders,
+			"Any":                              "value",
+		})
+
+	// invalid token
+	testHttpRequestHelperWithHeaders(context.Background(), t, fasthttp.MethodGet, "http://localhost:8081/v1/greetings", nil, map[string]string{
+		"Authorization": "Bearer fake-token",
+	}, 403, "", nil)
+
+	// empty token
+	testHttpRequestHelperWithHeaders(context.Background(), t, fasthttp.MethodGet, "http://localhost:8081/v1/greetings", nil, nil, 403, "", nil)
+
+	// test valid token and wrong rbac (method not match)
+	testHttpRequestHelperWithHeaders(context.Background(), t, fasthttp.MethodPost, "http://localhost:8081/v1/greetings", []byte("John"), map[string]string{
+		"Authorization": "Bearer " + authHeader,
+	}, 403, "", nil)
+
+	// test valid token and rbac with context
+	ctx, span := observability.StartSpan("HTTP-Test-Client", context.Background(), &map[string]string{
+		"method":      "TestHTTPEchoWithPipeline",
+		"http.method": fasthttp.MethodGet,
+		"http.url":    "http://localhost:8081/v1/greetings",
+	})
+	defer observ_utils.CloseSpanWithError(span, &err)
+	testHttpRequestHelperWithHeaders(ctx, t, fasthttp.MethodGet, "http://localhost:8081/v1/greetings", nil,
+		map[string]string{
+			"Authorization": "Bearer " + authHeader,
+		}, 200, "Hi there!!", map[string]string{
+			"Access-Control-Allow-Origin":      corsAllowOrigin,
+			"Access-Control-Allow-Methods":     corsAllowMethods,
+			"Access-Control-Allow-Credentials": corsAllowCredentials,
+			"Access-Control-Allow-Headers":     corsAllowHeaders,
+			"Any":                              "value",
+		})
+
+	time.Sleep(5 * time.Second) // wait for telemetry to send data
+}

--- a/coa/pkg/apis/v1alpha2/bindings/http/http_test.go
+++ b/coa/pkg/apis/v1alpha2/bindings/http/http_test.go
@@ -137,6 +137,9 @@ func TestHTTPEcho(t *testing.T) {
 	err := binding.Launch(config, endpoints, nil)
 	assert.Nil(t, err)
 
+	// wait for http server startup
+	time.Sleep(5 * time.Second)
+
 	testHttpRequestHelper(context.Background(), t, fasthttp.MethodGet, "http://localhost:8080/v1/greetings", nil, 200, "Hi there!!")
 
 	// query args
@@ -352,6 +355,7 @@ func TestHTTPEchoWithPipeline(t *testing.T) {
 	err = binding.Launch(config, endpoints, pubsub)
 	assert.Nil(t, err)
 
+	// wait for http server startup
 	time.Sleep(5 * time.Second)
 
 	client := &http.Client{}

--- a/coa/pkg/apis/v1alpha2/bindings/http/jwt_test.go
+++ b/coa/pkg/apis/v1alpha2/bindings/http/jwt_test.go
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package http
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func generateJWTToken(signingKey interface{}, method jwt.SigningMethod, userName string, expiresAt time.Time, issuedAt time.Time, notAfter time.Time, issuer string, subject string, audiences []string) (string, error) {
+	claims := TestCustomClaims{
+		User: userName,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(expiresAt),
+			IssuedAt:  jwt.NewNumericDate(issuedAt),
+			NotBefore: jwt.NewNumericDate(notAfter),
+			Issuer:    issuer,
+			Subject:   subject,
+			Audience:  jwt.ClaimStrings(audiences),
+		},
+	}
+	token := jwt.NewWithClaims(method, claims)
+	return token.SignedString(signingKey)
+}
+
+func TestValidateWithValidTokenAuthN(t *testing.T) {
+	j := JWT{
+		AuthHeader: "Authorization",
+		VerifyKey:  "test",
+		EnableRBAC: false,
+	}
+
+	token, err := generateJWTToken([]byte("test"), jwt.SigningMethodHS256, "test", time.Now().Add(time.Hour), time.Now(), time.Now(), "test", "test", []string{"test"})
+	assert.Nil(t, err)
+	_, _, err = j.validateToken(token)
+	assert.Nil(t, err)
+}
+
+func TestValidateWithInvalidTokenAuthN(t *testing.T) {
+	j := JWT{
+		AuthHeader: "Authorization",
+		VerifyKey:  "test",
+		EnableRBAC: false,
+	}
+
+	// expiresAt is in the past, notAfter is in the past
+	// token is expired
+	token, err := generateJWTToken([]byte("test"), jwt.SigningMethodHS256, "test", time.Now().Add(-1*time.Hour), time.Now(), time.Now().Add(-1*time.Hour), "test", "test", []string{"test"})
+	assert.Nil(t, err)
+
+	_, _, err = j.validateToken(token)
+	assert.NotNil(t, err)
+}
+
+func TestValidateWithTokenMustHaveNotExists(t *testing.T) {
+	j := JWT{
+		AuthHeader: "Authorization",
+		VerifyKey:  "test",
+		EnableRBAC: false,
+		MustHave:   []string{"username"},
+	}
+
+	// TestClaims has user claim, but MustHave is username
+	token, err := generateJWTToken([]byte("test"), jwt.SigningMethodHS256, "test", time.Now().Add(time.Hour), time.Now(), time.Now(), "test", "test", []string{"test"})
+	assert.Nil(t, err)
+
+	_, _, err = j.validateToken(token)
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "required claim 'username' is not found")
+}
+
+func TestValidateWithTokenMustMatchNotExists(t *testing.T) {
+	j := JWT{
+		AuthHeader: "Authorization",
+		VerifyKey:  "test",
+		EnableRBAC: false,
+		MustMatch:  map[string]interface{}{"username": "test"},
+	}
+
+	// TestClaims has user claim, but MustMatch is username
+	token, err := generateJWTToken([]byte("test"), jwt.SigningMethodHS256, "test", time.Now().Add(time.Hour), time.Now(), time.Now(), "test", "test", []string{"test"})
+	assert.Nil(t, err)
+
+	_, _, err = j.validateToken(token)
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "required claim 'username' is not found")
+}
+
+func TestValidateWithTokenMustMatchNotMatch(t *testing.T) {
+	j := JWT{
+		AuthHeader: "Authorization",
+		VerifyKey:  "test",
+		EnableRBAC: false,
+		MustMatch:  map[string]interface{}{"user": "test1"},
+	}
+
+	// TestClaims has user claim, but MustMatch is user with different value
+	token, err := generateJWTToken([]byte("test"), jwt.SigningMethodHS256, "test", time.Now().Add(time.Hour), time.Now(), time.Now(), "test", "test", []string{"test"})
+	assert.Nil(t, err)
+
+	_, _, err = j.validateToken(token)
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "claim 'user' doesn't have required value")
+}
+
+func TestValidateWithTokenWithCert(t *testing.T) {
+	// generate a new private key
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(t, err)
+
+	// Marshal the public key into PKIX, ASN.1 DER form.
+	pubASN1, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
+	if err != nil {
+		panic(err)
+	}
+
+	// PEM encode the public key.
+	pubBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: pubASN1,
+	})
+
+	j := JWT{
+		AuthHeader: "Authorization",
+		VerifyKey:  string(pubBytes),
+		EnableRBAC: false,
+	}
+
+	token, err := generateJWTToken(privateKey, jwt.SigningMethodRS256, "test", time.Now().Add(time.Hour), time.Now(), time.Now(), "test", "test", []string{"test"})
+	assert.Nil(t, err)
+	_, _, err = j.validateToken(token)
+	assert.Nil(t, err)
+}

--- a/coa/pkg/apis/v1alpha2/bindings/http/telemetry.go
+++ b/coa/pkg/apis/v1alpha2/bindings/http/telemetry.go
@@ -28,15 +28,23 @@ func initClient(properties map[string]interface{}) {
 		instrumentationKey = "0be0a36e-6e0a-4544-a453-a237fd25cf64"
 	}
 	telemetryConfig := appinsights.NewTelemetryConfiguration(instrumentationKey)
+	telemetryConfig.MaxBatchSize = 8192
 	if batchSize, ok := properties["maxBatchSize"]; ok {
-		telemetryConfig.MaxBatchSize = int(batchSize.(float64))
-	} else {
-		telemetryConfig.MaxBatchSize = 8192
+		if batchSizeFloat, fok := batchSize.(float64); fok {
+			telemetryConfig.MaxBatchSize = int(batchSizeFloat)
+		}
+		if batchSizeInt, iok := batchSize.(int); iok {
+			telemetryConfig.MaxBatchSize = batchSizeInt
+		}
 	}
-	if batchInterval, ok := properties["maxBatchInterval"]; ok {
-		telemetryConfig.MaxBatchInterval = time.Duration(int(batchInterval.(float64))) * time.Second
-	} else {
-		telemetryConfig.MaxBatchInterval = 2 * time.Second
+	telemetryConfig.MaxBatchInterval = 2 * time.Second
+	if batchInterval, ok := properties["maxBatchIntervalSeconds"]; ok {
+		if batchIntervalFloat, fok := batchInterval.(float64); fok {
+			telemetryConfig.MaxBatchInterval = time.Duration(int(batchIntervalFloat)) * time.Second
+		}
+		if batchIntervalInt, iok := batchInterval.(int); iok {
+			telemetryConfig.MaxBatchInterval = time.Duration(batchIntervalInt) * time.Second
+		}
 	}
 	client = appinsights.NewTelemetryClientFromConfig(telemetryConfig)
 	initialized = true

--- a/coa/pkg/apis/v1alpha2/bindings/http/telemetry.go
+++ b/coa/pkg/apis/v1alpha2/bindings/http/telemetry.go
@@ -24,9 +24,6 @@ var initialized bool
 
 func initClient(properties map[string]interface{}) {
 	instrumentationKey := os.Getenv("APP_INSIGHT_KEY")
-	if instrumentationKey == "" {
-		instrumentationKey = "0be0a36e-6e0a-4544-a453-a237fd25cf64"
-	}
 	telemetryConfig := appinsights.NewTelemetryConfiguration(instrumentationKey)
 	telemetryConfig.MaxBatchSize = 8192
 	if batchSize, ok := properties["maxBatchSize"]; ok {

--- a/coa/pkg/apis/v1alpha2/bindings/http/telemetry.go
+++ b/coa/pkg/apis/v1alpha2/bindings/http/telemetry.go
@@ -24,27 +24,31 @@ var initialized bool
 
 func initClient(properties map[string]interface{}) {
 	instrumentationKey := os.Getenv("APP_INSIGHT_KEY")
-	telemetryConfig := appinsights.NewTelemetryConfiguration(instrumentationKey)
-	telemetryConfig.MaxBatchSize = 8192
-	if batchSize, ok := properties["maxBatchSize"]; ok {
-		if batchSizeFloat, fok := batchSize.(float64); fok {
-			telemetryConfig.MaxBatchSize = int(batchSizeFloat)
+	if instrumentationKey == "" {
+		initialized = false
+	} else {
+		telemetryConfig := appinsights.NewTelemetryConfiguration(instrumentationKey)
+		telemetryConfig.MaxBatchSize = 8192
+		if batchSize, ok := properties["maxBatchSize"]; ok {
+			if batchSizeFloat, fok := batchSize.(float64); fok {
+				telemetryConfig.MaxBatchSize = int(batchSizeFloat)
+			}
+			if batchSizeInt, iok := batchSize.(int); iok {
+				telemetryConfig.MaxBatchSize = batchSizeInt
+			}
 		}
-		if batchSizeInt, iok := batchSize.(int); iok {
-			telemetryConfig.MaxBatchSize = batchSizeInt
+		telemetryConfig.MaxBatchInterval = 2 * time.Second
+		if batchInterval, ok := properties["maxBatchIntervalSeconds"]; ok {
+			if batchIntervalFloat, fok := batchInterval.(float64); fok {
+				telemetryConfig.MaxBatchInterval = time.Duration(int(batchIntervalFloat)) * time.Second
+			}
+			if batchIntervalInt, iok := batchInterval.(int); iok {
+				telemetryConfig.MaxBatchInterval = time.Duration(batchIntervalInt) * time.Second
+			}
 		}
+		client = appinsights.NewTelemetryClientFromConfig(telemetryConfig)
+		initialized = true
 	}
-	telemetryConfig.MaxBatchInterval = 2 * time.Second
-	if batchInterval, ok := properties["maxBatchIntervalSeconds"]; ok {
-		if batchIntervalFloat, fok := batchInterval.(float64); fok {
-			telemetryConfig.MaxBatchInterval = time.Duration(int(batchIntervalFloat)) * time.Second
-		}
-		if batchIntervalInt, iok := batchInterval.(int); iok {
-			telemetryConfig.MaxBatchInterval = time.Duration(batchIntervalInt) * time.Second
-		}
-	}
-	client = appinsights.NewTelemetryClientFromConfig(telemetryConfig)
-	initialized = true
 }
 
 // CORS middleware to allow CORS. The middleware doesn't override existing headers in incoming requests

--- a/coa/pkg/apis/v1alpha2/bindings/http/tracing.go
+++ b/coa/pkg/apis/v1alpha2/bindings/http/tracing.go
@@ -7,13 +7,13 @@
 package http
 
 import (
-	"bytes"
 	"encoding/hex"
 	"fmt"
 	"net/http"
 	"net/textproto"
 	"strings"
 
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	observability "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/observability"
 	observ_utils "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/observability/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/logger"
@@ -35,7 +35,7 @@ const (
 
 type Tracing struct {
 	Observability observability.Observability
-	Buffer        *bytes.Buffer
+	Buffer        *v1alpha2.SafeBuffer // this is not used but should be a thread safe buffer
 }
 
 func (t Tracing) Tracing(next fasthttp.RequestHandler) fasthttp.RequestHandler {

--- a/coa/pkg/apis/v1alpha2/bindings/http/tracing_test.go
+++ b/coa/pkg/apis/v1alpha2/bindings/http/tracing_test.go
@@ -7,8 +7,17 @@
 package http
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
 	"testing"
+	"time"
 
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	observability "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/observability"
+	observ_utils "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/observability/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/valyala/fasthttp"
 	"go.opentelemetry.io/otel/trace"
@@ -106,4 +115,104 @@ func TestSpanContextFromW3CStringInvalidParentId(t *testing.T) {
 func TestSpanContextFromW3CStringEmpty(t *testing.T) {
 	_, ok := SpanContextFromW3CString("")
 	assert.False(t, ok)
+}
+
+type SpanAttrValue struct {
+	Type  string
+	Value string
+}
+
+type SpanAttr struct {
+	Key   string
+	Value SpanAttrValue
+}
+
+func TestTracing(t *testing.T) {
+	tracing := Tracing{
+		Observability: observability.Observability{},
+	}
+	config := observability.ObservabilityConfig{}
+	config.Pipelines = []observability.PipelineConfig{
+		{
+			Exporter: observability.ExporterConfig{
+				Type:       "tracing.exporters.console",
+				BackendUrl: "",
+				Sampler: observability.SamplerConfig{
+					SampleRate: "always",
+				},
+			},
+		},
+	}
+	var buf v1alpha2.SafeBuffer
+	tracing.Observability.Buffer = &buf
+	err := tracing.Observability.Init(config)
+	assert.Nil(t, err)
+
+	successPath := "/success"
+	successUrl := "http://localhost:7777" + successPath
+	// lauch a HTTP server and validate console tracing in buffer
+	go func() {
+		requestHandler := func(ctx *fasthttp.RequestCtx) {
+			switch string(ctx.Path()) {
+			case successPath:
+				if string(ctx.Method()) == fasthttp.MethodGet {
+					fmt.Fprintf(ctx, "Hello, World!")
+				}
+			default:
+				ctx.Error("Unsupported path", fasthttp.StatusNotFound)
+			}
+		}
+
+		_ = fasthttp.ListenAndServe(":7777", tracing.Tracing(requestHandler))
+	}()
+
+	// wait for server to start
+	time.Sleep(3 * time.Second)
+
+	ctx, span := observability.StartSpan("HTTP-Test-Client", context.Background(), &map[string]string{
+		"method":      "TestTracing",
+		"http.method": fasthttp.MethodGet,
+		"http.url":    successUrl,
+	})
+
+	// GET request with parent span
+	client := &http.Client{}
+	req, err := http.NewRequestWithContext(ctx, fasthttp.MethodGet, successUrl, nil)
+	observ_utils.PropagateSpanContextToHttpRequestHeader(req)
+	assert.Nil(t, err)
+	resp, err := client.Do(req)
+	assert.Nil(t, err)
+
+	defer resp.Body.Close()
+	assert.Equal(t, 200, resp.StatusCode)
+	respBody, err := ioutil.ReadAll(resp.Body)
+	assert.Nil(t, err)
+	assert.Equal(t, "Hello, World!", string(respBody))
+
+	// validate the buffer
+	time.Sleep(3 * time.Second) // wait for the span to be written to the buffer
+	spanContent := buf.String()
+	var mapSpan map[string]interface{}
+	json.Unmarshal([]byte(spanContent), &mapSpan)
+	fmt.Println(spanContent)
+
+	assert.Equal(t, span.SpanContext().TraceID().String(), mapSpan["SpanContext"].(map[string]interface{})["TraceID"])
+	assert.Equal(t, span.SpanContext().TraceID().String(), mapSpan["Parent"].(map[string]interface{})["TraceID"])
+	assert.Equal(t, span.SpanContext().SpanID().String(), mapSpan["Parent"].(map[string]interface{})["SpanID"])
+	assert.Equal(t, successPath, mapSpan["Name"])
+
+	attrs, err := json.Marshal(mapSpan["Attributes"])
+	assert.Nil(t, err)
+	spanAttrs := make([]SpanAttr, 0)
+	json.Unmarshal(attrs, &spanAttrs)
+	attrsMap := make(map[string]SpanAttrValue)
+	for _, attr := range spanAttrs {
+		attrsMap[attr.Key] = attr.Value
+	}
+
+	_, expectedVendor := observ_utils.GetVendor(successPath)
+	assert.Equal(t, successPath, attrsMap["path"].Value)
+	assert.Equal(t, expectedVendor, attrsMap["vendor"].Value)
+	assert.Equal(t, fasthttp.MethodGet, attrsMap["method"].Value)
+	assert.Equal(t, "200", attrsMap["status"].Value)
 }

--- a/coa/pkg/apis/v1alpha2/bindings/mqtt/mqtt_test.go
+++ b/coa/pkg/apis/v1alpha2/bindings/mqtt/mqtt_test.go
@@ -20,14 +20,14 @@ import (
 func TestMQTTEcho(t *testing.T) {
 	testMQTT := os.Getenv("TEST_MQTT_LOCAL_ENABLED")
 	if testMQTT == "" {
-		t.Skip("Skipping because TES_MQTT enviornment variable is not set")
+		t.Skip("Skipping because TEST_MQTT_LOCAL_ENABLED enviornment variable is not set")
 	}
 	sig := make(chan int)
 	config := MQTTBindingConfig{
 		BrokerAddress: "tcp://127.0.0.1:1883",
-		ClientID:      "coa-test2",
-		RequestTopic:  "coa-request",
-		ResponseTopic: "coa-response",
+		ClientID:      "coabinding-test2",
+		RequestTopic:  "coabinding-request2",
+		ResponseTopic: "coabinding-response2",
 	}
 	binding := MQTTBinding{}
 	endpoints := []v1alpha2.Endpoint{
@@ -44,7 +44,7 @@ func TestMQTTEcho(t *testing.T) {
 	err := binding.Launch(config, endpoints)
 	assert.Nil(t, err)
 
-	opts := gmqtt.NewClientOptions().AddBroker(config.BrokerAddress).SetClientID("test-sender")
+	opts := gmqtt.NewClientOptions().AddBroker(config.BrokerAddress).SetClientID("test-sender2")
 	opts.SetKeepAlive(2 * time.Second)
 	opts.SetPingTimeout(1 * time.Second)
 
@@ -66,6 +66,144 @@ func TestMQTTEcho(t *testing.T) {
 	request := v1alpha2.COARequest{
 		Route:  "greetings",
 		Method: "GET",
+	}
+	data, _ := json.Marshal(request)
+	token := c.Publish(config.RequestTopic, 0, false, data) //sending COARequest directly doesn't seem to work
+	token.Wait()
+	<-sig
+}
+
+func TestMQTTConnectFail(t *testing.T) {
+	testMQTT := os.Getenv("TEST_MQTT_LOCAL_ENABLED")
+	if testMQTT == "" {
+		t.Skip("Skipping because TEST_MQTT_LOCAL_ENABLED enviornment variable is not set")
+	}
+	config := MQTTBindingConfig{
+		BrokerAddress: "tcp://169.254.1.1:1883",
+		ClientID:      "coabinding-test",
+		RequestTopic:  "coabinding-request",
+		ResponseTopic: "coabinding-response",
+	}
+	binding := MQTTBinding{}
+	err := binding.Launch(config, nil)
+	assert.NotNil(t, err)
+	coaError := err.(v1alpha2.COAError)
+	assert.Equal(t, v1alpha2.InternalError, coaError.State)
+	assert.Contains(t, coaError.Error(), "failed to connect to MQTT broker")
+}
+
+func TestMQTT_CannotParseCOARequest(t *testing.T) {
+	testMQTT := os.Getenv("TEST_MQTT_LOCAL_ENABLED")
+	if testMQTT == "" {
+		t.Skip("Skipping because TEST_MQTT_LOCAL_ENABLED enviornment variable is not set")
+	}
+	sig := make(chan int)
+	config := MQTTBindingConfig{
+		BrokerAddress: "tcp://127.0.0.1:1883",
+		ClientID:      "coabinding-test3",
+		RequestTopic:  "coabinding-request3",
+		ResponseTopic: "coabinding-response3",
+	}
+	binding := MQTTBinding{}
+	endpoints := []v1alpha2.Endpoint{
+		{
+			Methods: []string{"GET"},
+			Route:   "greetings",
+			Handler: func(c v1alpha2.COARequest) v1alpha2.COAResponse {
+				return v1alpha2.COAResponse{
+					Body: []byte("Hi there!!"),
+				}
+			},
+		},
+	}
+	err := binding.Launch(config, endpoints)
+	assert.Nil(t, err)
+
+	opts := gmqtt.NewClientOptions().AddBroker(config.BrokerAddress).SetClientID("test-sender3")
+	opts.SetKeepAlive(2 * time.Second)
+	opts.SetPingTimeout(1 * time.Second)
+
+	c := gmqtt.NewClient(opts)
+	if token := c.Connect(); token.Wait() && token.Error() != nil {
+		panic(token.Error())
+	}
+	if token := c.Subscribe(config.ResponseTopic, 0, func(client gmqtt.Client, msg gmqtt.Message) {
+		var response v1alpha2.COAResponse
+		err := json.Unmarshal(msg.Payload(), &response)
+		assert.Nil(t, err)
+		assert.Equal(t, v1alpha2.BadRequest, response.State)
+		sig <- 1
+	}); token.Wait() && token.Error() != nil {
+		if token.Error().Error() != "subscription exists" {
+			panic(token.Error())
+		}
+	}
+	// error Request
+	data := []byte("This is not a COARequest")
+	token := c.Publish(config.RequestTopic, 0, false, data) //sending COARequest directly doesn't seem to work
+	token.Wait()
+	<-sig
+}
+
+func TestMQTTEchoWithCallContext(t *testing.T) {
+	testMQTT := os.Getenv("TEST_MQTT_LOCAL_ENABLED")
+	if testMQTT == "" {
+		t.Skip("Skipping because TEST_MQTT_LOCAL_ENABLED enviornment variable is not set")
+	}
+	sig := make(chan int)
+	config := MQTTBindingConfig{
+		BrokerAddress: "tcp://127.0.0.1:1883",
+		ClientID:      "coabinding-test4",
+		RequestTopic:  "coabinding-request4",
+		ResponseTopic: "coabinding-response4",
+	}
+	binding := MQTTBinding{}
+	endpoints := []v1alpha2.Endpoint{
+		{
+			Methods: []string{"GET"},
+			Route:   "greetings",
+			Handler: func(c v1alpha2.COARequest) v1alpha2.COAResponse {
+				if c.Metadata != nil {
+					if v, ok := c.Metadata["call-context"]; ok {
+						return v1alpha2.COAResponse{
+							Body: []byte(v),
+						}
+					}
+				}
+				return v1alpha2.COAResponse{
+					Body: []byte("Hi there!!"),
+				}
+			},
+		},
+	}
+	err := binding.Launch(config, endpoints)
+	assert.Nil(t, err)
+
+	opts := gmqtt.NewClientOptions().AddBroker(config.BrokerAddress).SetClientID("test-sender4")
+	opts.SetKeepAlive(2 * time.Second)
+	opts.SetPingTimeout(1 * time.Second)
+
+	c := gmqtt.NewClient(opts)
+	if token := c.Connect(); token.Wait() && token.Error() != nil {
+		panic(token.Error())
+	}
+	if token := c.Subscribe(config.ResponseTopic, 0, func(client gmqtt.Client, msg gmqtt.Message) {
+		var response v1alpha2.COAResponse
+		err := json.Unmarshal(msg.Payload(), &response)
+		assert.Nil(t, err)
+		assert.Equal(t, string(response.Body), "test-context")
+		sig <- 1
+	}); token.Wait() && token.Error() != nil {
+		if token.Error().Error() != "subscription exists" {
+			panic(token.Error())
+		}
+	}
+	request := v1alpha2.COARequest{
+		Route:  "greetings",
+		Method: "GET",
+		Metadata: map[string]string{
+			"call-context": "test-context",
+		},
 	}
 	data, _ := json.Marshal(request)
 	token := c.Publish(config.RequestTopic, 0, false, data) //sending COARequest directly doesn't seem to work

--- a/coa/pkg/apis/v1alpha2/observability/observability.go
+++ b/coa/pkg/apis/v1alpha2/observability/observability.go
@@ -9,7 +9,6 @@ package observability
 import (
 	"fmt"
 
-	"bytes"
 	"context"
 
 	v1alpha2 "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
@@ -48,7 +47,7 @@ type SamplerConfig struct {
 type Observability struct {
 	Tracer         trace.Tracer
 	TracerProvider trace.TracerProvider
-	Buffer         *bytes.Buffer
+	Buffer         *v1alpha2.SafeBuffer // should be a thread safe buffer
 }
 
 func StartSpan(name string, ctx context.Context, attributes *map[string]string) (context.Context, trace.Span) {

--- a/coa/pkg/apis/v1alpha2/safebuffer.go
+++ b/coa/pkg/apis/v1alpha2/safebuffer.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package v1alpha2
+
+import (
+	"bytes"
+	"sync"
+)
+
+type SafeBuffer struct {
+	buffer bytes.Buffer
+	mu     sync.Mutex
+}
+
+func (sb *SafeBuffer) Write(p []byte) (n int, err error) {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+
+	return sb.buffer.Write(p)
+}
+
+func (sb *SafeBuffer) String() string {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+
+	return sb.buffer.String()
+}
+
+func (sb *SafeBuffer) Reset() {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+
+	sb.buffer.Reset()
+}

--- a/coa/pkg/apis/v1alpha2/safebuffer_test.go
+++ b/coa/pkg/apis/v1alpha2/safebuffer_test.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package v1alpha2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafeBuffer(t *testing.T) {
+	sb := &SafeBuffer{}
+	sb.Write([]byte("test"))
+	assert.Equal(t, "test", sb.String())
+}
+
+func TestSafeBufferConcurrent(t *testing.T) {
+	sb := &SafeBuffer{}
+	sig1 := make(chan bool)
+	sig2 := make(chan bool)
+	go func() {
+		sb.Write([]byte("test1"))
+		sig1 <- true
+	}()
+	go func() {
+		sb.Write([]byte("test2"))
+		sig2 <- true
+	}()
+
+	<-sig1
+	<-sig2
+	assert.True(t, sb.String() == "test1test2" || sb.String() == "test2test1")
+}
+
+func TestSafeBufferReset(t *testing.T) {
+	sb := &SafeBuffer{}
+	sb.Write([]byte("test"))
+	sb.Reset()
+	assert.Equal(t, "", sb.String())
+}


### PR DESCRIPTION
**Changes**

- Fix #128 
- Add more tests

Files | Previous (%) | Now (%) | Notes
-- | -- | -- | --
./pkg/apis/v1alpha2/bindings/http/jwt.go | 0 | 90.3 |  
./pkg/apis/v1alpha2/bindings/http/trail.go | 0 | 100 |  
./pkg/apis/v1alpha2/bindings/http/telemetry.go | 0 | 82.4 | ENABLE_APP_INSIGHT and APP_INSIGHT_KEY configured
./pkg/apis/v1alpha2/bindings/http/cors.go | 0 | 100 |  
./pkg/apis/v1alpha2/bindings/http/http_pipeline.go | 0 | 97.4 |  
./pkg/apis/v1alpha2/bindings/http/tracing.go | 65.8 | 75 |  
./pkg/apis/v1alpha2/bindings/http/http.go | 0 | 87.5 |  
./pkg/apis/v1alpha2/bindings/mqtt/mqtt.go | 67.6 | 85.3 |  






































