### PR TITLE
catalog prefix using parent site name

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/sync/sync-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/sync/sync-manager.go
@@ -58,6 +58,7 @@ func (s *SyncManager) Poll() []error {
 			s.Context.Publish("catalog-sync", v1alpha2.Event{
 				Metadata: map[string]string{
 					"objectType": catalog.Spec.Type,
+					"origin":     batch.Origin,
 				},
 				Body: v1alpha2.JobData{
 					Id:     catalog.Spec.Name,

--- a/api/pkg/apis/v1alpha1/vendors/catalogs-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/catalogs-vendor.go
@@ -60,12 +60,13 @@ func (e *CatalogsVendor) Init(config vendors.VendorConfig, factories []managers.
 			var catalog model.CatalogState
 			jData, _ = json.Marshal(job.Body)
 			err = json.Unmarshal(jData, &catalog)
+			origin := event.Metadata["origin"]
 			if err == nil {
-				name := fmt.Sprintf("%s-%s", catalog.Spec.SiteId, catalog.Spec.Name)
+				name := fmt.Sprintf("%s-%s", origin, catalog.Spec.Name)
 				catalog.ObjectMeta.Name = name
 				catalog.Spec.Name = name
 				if catalog.Spec.ParentName != "" {
-					catalog.Spec.ParentName = fmt.Sprintf("%s-%s", catalog.Spec.SiteId, catalog.Spec.ParentName)
+					catalog.Spec.ParentName = fmt.Sprintf("%s-%s", origin, catalog.Spec.ParentName)
 				}
 				err := e.CatalogsManager.UpsertState(context.TODO(), name, catalog)
 				if err != nil {

--- a/api/pkg/apis/v1alpha1/vendors/catalogs-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/catalogs-vendor_test.go
@@ -494,10 +494,11 @@ func TestCatalogOnCatalogsGraphMethodNotAllowed(t *testing.T) {
 
 func TestCatalogSubscribe(t *testing.T) {
 	vendor := CatalogVendorInit()
-
+	origin := "parent"
 	vendor.Context.Publish("catalog-sync", v1alpha2.Event{
 		Metadata: map[string]string{
 			"objectType": catalogState.Spec.Type,
+			"origin":     origin,
 		},
 		Body: v1alpha2.JobData{
 			Id:     catalogState.ObjectMeta.Name,
@@ -510,7 +511,7 @@ func TestCatalogSubscribe(t *testing.T) {
 		Method:  fasthttp.MethodGet,
 		Context: context.Background(),
 		Parameters: map[string]string{
-			"__name": fmt.Sprintf("%s-%s", catalogState.Spec.SiteId, catalogState.Spec.Name),
+			"__name": fmt.Sprintf("%s-%s", origin, catalogState.Spec.Name),
 		},
 	}
 	response := vendor.onCatalogs(*requestGet)


### PR DESCRIPTION
Fix https://github.com/eclipse-symphony/symphony/issues/141
The fix affects catalog synchronization from parent sites to child sites.
Previously catalogs on child site are named as catalog.Spec.SiteId-catalog.Spec.Name.
Now change it to parentSiteId-catalog.Spec.Name.

The change is tested on catalog synchronization between two sites.