### PR TITLE
Return err when rtsp server is disconnected

### DIFF
--- a/coa/pkg/apis/v1alpha2/providers/probe/rtsp/rtsp.go
+++ b/coa/pkg/apis/v1alpha2/providers/probe/rtsp/rtsp.go
@@ -103,6 +103,8 @@ func (m *RTSPProbeProvider) Probe(user string, password string, ip string, name 
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		return nil, err
 	}
 	if path != "" {
 		return map[string]string{

--- a/docs/symphony-book/agent/symphony-agent.md
+++ b/docs/symphony-book/agent/symphony-agent.md
@@ -32,6 +32,9 @@ In this example, the Symphony agent needs a service principal to access an Azure
    ```bash
    az storage account create --name <storage account name> --resource-group <resource group name> --location <location> --sku Standard_LRS
    az storage container create -n snapshots --account-name <storage account name>
+
+   # grant permission to access storage account
+   az role assignment create --assignee <service principal app id> --role "Storage Blob Data Owner" --scope /subscriptions/<subscription id>/resourceGroups/<resource group name>/providers/Microsoft.Storage/storageAccounts/<storage account name>
    ```
 
 3. If you plan to run Symphony agent as a process or a service, install [FFmpeg](https://ffmpeg.org/) on your target machine. You can skip this step if you plan to run Symphony agent as a container, which has FFmpeg pre-installed.


### PR DESCRIPTION
Fix #159 

Also found symphony-agent doc lacks a step to guide users to grant rbac to access storage account.

Tested symphony-agent sample - https://github.com/eclipse-symphony/symphony/blob/main/docs/symphony-book/agent/symphony-agent.md.

![image](https://github.com/eclipse-symphony/symphony/assets/59427055/22bc6199-f867-4192-80c1-4195e3f3ef60)
