### PR TITLE
Update MQTT Target Provider's Status and Message

### DIFF
--- a/api/pkg/apis/v1alpha1/providers/target/mqtt/mqtt.go
+++ b/api/pkg/apis/v1alpha1/providers/target/mqtt/mqtt.go
@@ -169,8 +169,9 @@ func (i *MQTTTargetProvider) Init(config providers.IProviderConfig) error {
 		var response v1alpha2.COAResponse
 		json.Unmarshal(msg.Payload(), &response)
 		proxyResponse := ProxyResponse{
-			IsOK:  response.State == v1alpha2.OK || response.State == v1alpha2.Accepted,
-			State: response.State,
+			IsOK:    response.State == v1alpha2.OK || response.State == v1alpha2.Accepted,
+			State:   response.State,
+			Payload: response.String(),
 		}
 
 		if !proxyResponse.IsOK {
@@ -194,6 +195,13 @@ func (i *MQTTTargetProvider) Init(config providers.IProviderConfig) error {
 		case "TargetProvider-NeedsRemove":
 			i.NeedsRemoveChan <- proxyResponse
 		case "TargetProvider-Apply":
+			if proxyResponse.IsOK {
+				var ret model.SummarySpec
+				err = json.Unmarshal(response.Body, &ret)
+				if err == nil {
+					proxyResponse.Payload = ret
+				}
+			}
 			i.ApplyChan <- proxyResponse
 		}
 	}); token.Wait() && token.Error() != nil {
@@ -364,6 +372,15 @@ func (i *MQTTTargetProvider) Apply(ctx context.Context, deployment model.Deploym
 		case resp := <-i.ApplyChan:
 			if resp.IsOK {
 				err = nil
+				payload, isOk := resp.Payload.(model.SummarySpec)
+				if isOk {
+					// Update ret
+					for target, targetResult := range payload.TargetResults {
+						for _, componentResults := range targetResult.ComponentResults {
+							ret[target] = componentResults
+						}
+					}
+				}
 				return ret, err
 			} else {
 				err = v1alpha2.NewCOAError(nil, fmt.Sprint(resp.Payload), resp.State)

--- a/api/pkg/apis/v1alpha1/providers/target/mqtt/mqtt_test.go
+++ b/api/pkg/apis/v1alpha1/providers/target/mqtt/mqtt_test.go
@@ -369,7 +369,7 @@ func TestApply(t *testing.T) {
 		}},
 	}
 
-	ret, err := provider.Apply(context.Background(), deploymentSpec, stepSpec, false) //TODO: this is probably broken: the step should contain at least a component
+	ret, err := provider.Apply(context.Background(), deploymentSpec, stepSpec, false)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, ret)


### PR DESCRIPTION
Previously, an MQTT Target Provider component's summary spec would always return `9998` for its status and an empty message. 

![image](https://github.com/eclipse-symphony/symphony/assets/122116059/c2321e13-c3f2-4f50-80e3-8ad0a9180562)

`ret` is assigned but never updated in the MQTT Target Provider: https://github.com/eclipse-symphony/symphony/blob/main/api/pkg/apis/v1alpha1/providers/target/mqtt/mqtt.go#L340

This PR updates `ret` in the MQTT Target Provider according to what the target returns:
![image](https://github.com/eclipse-symphony/symphony/assets/122116059/c6c79292-a16b-434b-8d13-326586ef9288)
