### PR TITLE
Fixes Some Links in the Symphony Book Documentation

### DIFF
--- a/docs/symphony-book/concepts/unified-object-model/campaign.md
+++ b/docs/symphony-book/concepts/unified-object-model/campaign.md
@@ -2,7 +2,7 @@
 
 A campaign describes a workflow of multiple stages. When a stage finishes execution, the stage runs a `StageSelector` to select the next stage. The campaign stops execution if no next stage is selected.
 
-For more information about how Symphony approaches workflows, see [Workflows](../concepts/workflows.md).
+For more information about how Symphony approaches workflows, see [Workflows](../workflows.md).
 
 ## Stages
 

--- a/docs/symphony-book/concepts/unified-object-model/solution.md
+++ b/docs/symphony-book/concepts/unified-object-model/solution.md
@@ -37,4 +37,4 @@ Circular references are not allowed.
 ## Related topics
 
 * [Solution schema](../concepts/unified-object-model/solution.md)
-* [Configuration management](./configuration-management.md)
+* [Configuration management](../../configuration-management/_overview.md)

--- a/docs/symphony-book/concepts/unified-object-model/solution.md
+++ b/docs/symphony-book/concepts/unified-object-model/solution.md
@@ -36,5 +36,4 @@ Circular references are not allowed.
 
 ## Related topics
 
-* [Solution schema](../concepts/unified-object-model/solution.md)
 * [Configuration management](../../configuration-management/_overview.md)


### PR DESCRIPTION
Some of the links in the Symphony Book documentation were broken.  I attempted to link to the correct locations.