### PR TITLE
Pin setup-envtest version to fit golang 1.20.2

### DIFF
--- a/k8s/magefile.go
+++ b/k8s/magefile.go
@@ -31,7 +31,7 @@ var (
 
 	envTest = bintool.Must(bintool.NewGo(
 		"sigs.k8s.io/controller-runtime/tools/setup-envtest",
-		"latest",
+		"v0.0.0-20240320141353-395cfc7486e6",
 	))
 
 	kustomize = bintool.Must(bintool.New(


### PR DESCRIPTION
### **Issue description:**

setup-envtest module bumped its golang version to 1.22.0 recently. 

By checking the go.mod, we can found the last available version to golang 1.20.2 is **v0.0.0-20240320141353-395cfc7486e6**, we need to pin to this version since symphony-k8s image uses golang:1.20.2-alpine (golang 1.20.2)
https://pkg.go.dev/sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240320141353-395cfc7486e6?tab=versions

Otherwise building k8s image will fail at running mage operatorTest. 

### **References:** 

**v0.0.0-20240320141353-395cfc7486e6**: https://github.com/kubernetes-sigs/controller-runtime/blob/395cfc7486e652d19fe1b544a436f9852ba26e4f/tools/setup-envtest/go.mod
<img width="466" alt="image" src="https://github.com/eclipse-symphony/symphony/assets/59427055/5da9ba61-bde8-41de-82c8-68d7f4d7e63b">

**latest**: https://github.com/kubernetes-sigs/controller-runtime/blob/main/tools/setup-envtest/go.mod
<img width="468" alt="image" src="https://github.com/eclipse-symphony/symphony/assets/59427055/2b126aa5-ce9a-4efa-acd5-31eab2bce5e6">
