### PR TITLE
Support different namespace for memory state provider

### DIFF
--- a/api/pkg/apis/v1alpha1/vendors/activations-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/activations-vendor_test.go
@@ -60,7 +60,7 @@ func TestActivationsOnStatus(t *testing.T) {
 		Context: context.Background(),
 	})
 	assert.Equal(t, v1alpha2.InternalError, resp.State)
-	assert.Equal(t, "entry 'activation1' is not found", string(resp.Body))
+	assert.Equal(t, "entry 'activation1' is not found in namespace default", string(resp.Body))
 
 	resp = vendor.onStatus(v1alpha2.COARequest{
 		Method: fasthttp.MethodPost,

--- a/api/pkg/apis/v1alpha1/vendors/campaigns-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/campaigns-vendor_test.go
@@ -131,7 +131,7 @@ func TestCampaignsOnCampaignsFailure(t *testing.T) {
 		Context: context.Background(),
 	})
 	assert.Equal(t, v1alpha2.InternalError, resp.State)
-	assert.Equal(t, "entry 'campaign1' is not found", string(resp.Body))
+	assert.Equal(t, "entry 'campaign1' is not found in namespace default", string(resp.Body))
 
 	resp = vendor.onCampaigns(v1alpha2.COARequest{
 		Method: fasthttp.MethodPost,
@@ -153,7 +153,7 @@ func TestCampaignsOnCampaignsFailure(t *testing.T) {
 		Context: context.Background(),
 	})
 	assert.Equal(t, v1alpha2.InternalError, resp.State)
-	assert.Equal(t, "entry 'campaign1' is not found", string(resp.Body))
+	assert.Equal(t, "entry 'campaign1' is not found in namespace default", string(resp.Body))
 }
 
 func TestCampaignsWrongMethod(t *testing.T) {

--- a/api/pkg/apis/v1alpha1/vendors/solutions-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/solutions-vendor_test.go
@@ -80,8 +80,10 @@ func TestSolutionsOnSolutions(t *testing.T) {
 	pubSubProvider.Init(memory.InMemoryPubSubConfig{Name: "test"})
 	vendor.Context.Init(&pubSubProvider)
 	solution := model.SolutionState{
-		Spec: &model.SolutionSpec{
-			DisplayName: "solution1",
+		Spec: &model.SolutionSpec{},
+		ObjectMeta: model.ObjectMeta{
+			Name:      "solutions1",
+			Namespace: "scope1",
 		},
 	}
 	data, _ := json.Marshal(solution)
@@ -109,7 +111,7 @@ func TestSolutionsOnSolutions(t *testing.T) {
 	err := json.Unmarshal(resp.Body, &solutions)
 	assert.Nil(t, err)
 	assert.Equal(t, "solutions1", solutions.ObjectMeta.Name)
-	assert.Equal(t, "default", solutions.ObjectMeta.Namespace)
+	assert.Equal(t, "scope1", solutions.ObjectMeta.Namespace)
 
 	resp = vendor.onSolutions(v1alpha2.COARequest{
 		Method: fasthttp.MethodGet,
@@ -124,7 +126,7 @@ func TestSolutionsOnSolutions(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(solutionsList))
 	assert.Equal(t, "solutions1", solutionsList[0].ObjectMeta.Name)
-	assert.Equal(t, "default", solutionsList[0].ObjectMeta.Namespace)
+	assert.Equal(t, "scope1", solutionsList[0].ObjectMeta.Namespace)
 
 	resp = vendor.onSolutions(v1alpha2.COARequest{
 		Method: fasthttp.MethodDelete,

--- a/coa/pkg/apis/v1alpha2/providers/states/memorystate/memorystate_test.go
+++ b/coa/pkg/apis/v1alpha2/providers/states/memorystate/memorystate_test.go
@@ -164,6 +164,56 @@ func TestListWithNamespace(t *testing.T) {
 	assert.Equal(t, "234", entries[1].ID)
 }
 
+func TestListWithNamespaceTwoObjectWithSameName(t *testing.T) {
+	provider := MemoryStateProvider{}
+	err := provider.Init(MemoryStateProvider{})
+	assert.Nil(t, err)
+	_, err = provider.Upsert(context.Background(), states.UpsertRequest{
+		Value: states.StateEntry{
+			ID: "123",
+			Body: TestPayload{
+				Name:  "Random name",
+				Value: 12345,
+			},
+		},
+	})
+	assert.Nil(t, err)
+	_, err = provider.Upsert(context.Background(), states.UpsertRequest{
+		Value: states.StateEntry{
+			ID: "123",
+			Body: TestPayload{
+				Name:  "Random name",
+				Value: 12345,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"namespace": "nondefault",
+		},
+	})
+	assert.Nil(t, err)
+	entries, _, err := provider.List(context.Background(), states.ListRequest{
+		Metadata: map[string]interface{}{
+			"namespace": "default",
+		},
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(entries))
+	assert.Equal(t, "123", entries[0].ID)
+	entries, _, err = provider.List(context.Background(), states.ListRequest{
+		Metadata: map[string]interface{}{
+			"namespace": "nondefault",
+		},
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(entries))
+	assert.Equal(t, "123", entries[0].ID)
+	entries, _, err = provider.List(context.Background(), states.ListRequest{})
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(entries))
+	assert.Equal(t, "123", entries[0].ID)
+	assert.Equal(t, "123", entries[1].ID)
+}
+
 func TestDelete(t *testing.T) {
 	provider := MemoryStateProvider{}
 	err := provider.Init(MemoryStateProvider{})

--- a/coa/pkg/apis/v1alpha2/providers/states/memorystate/memorystate_test.go
+++ b/coa/pkg/apis/v1alpha2/providers/states/memorystate/memorystate_test.go
@@ -160,8 +160,7 @@ func TestListWithNamespace(t *testing.T) {
 	entries, _, err = provider.List(context.Background(), states.ListRequest{})
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(entries))
-	assert.Equal(t, "123", entries[0].ID)
-	assert.Equal(t, "234", entries[1].ID)
+	assert.True(t, (entries[0].ID == "123" && entries[1].ID == "234") || (entries[1].ID == "123" && entries[0].ID == "234"))
 }
 
 func TestListWithNamespaceTwoObjectWithSameName(t *testing.T) {

--- a/coa/pkg/apis/v1alpha2/providers/states/memorystate/memorystate_test.go
+++ b/coa/pkg/apis/v1alpha2/providers/states/memorystate/memorystate_test.go
@@ -74,6 +74,26 @@ func TestUpSert(t *testing.T) {
 	assert.Equal(t, "123", id)
 }
 
+func TestUpSertWithNamespace(t *testing.T) {
+	provider := MemoryStateProvider{}
+	err := provider.Init(MemoryStateProvider{})
+	assert.Nil(t, err)
+	id, err := provider.Upsert(context.Background(), states.UpsertRequest{
+		Value: states.StateEntry{
+			ID: "123",
+			Body: TestPayload{
+				Name:  "Random name",
+				Value: 12345,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"namespace": "nondefault",
+		},
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "123", id)
+}
+
 func TestList(t *testing.T) {
 	provider := MemoryStateProvider{}
 	err := provider.Init(MemoryStateProvider{})
@@ -92,6 +112,56 @@ func TestList(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(entries))
 	assert.Equal(t, "123", entries[0].ID)
+}
+
+func TestListWithNamespace(t *testing.T) {
+	provider := MemoryStateProvider{}
+	err := provider.Init(MemoryStateProvider{})
+	assert.Nil(t, err)
+	_, err = provider.Upsert(context.Background(), states.UpsertRequest{
+		Value: states.StateEntry{
+			ID: "123",
+			Body: TestPayload{
+				Name:  "Random name",
+				Value: 12345,
+			},
+		},
+	})
+	assert.Nil(t, err)
+	_, err = provider.Upsert(context.Background(), states.UpsertRequest{
+		Value: states.StateEntry{
+			ID: "234",
+			Body: TestPayload{
+				Name:  "Random name",
+				Value: 12345,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"namespace": "nondefault",
+		},
+	})
+	assert.Nil(t, err)
+	entries, _, err := provider.List(context.Background(), states.ListRequest{
+		Metadata: map[string]interface{}{
+			"namespace": "default",
+		},
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(entries))
+	assert.Equal(t, "123", entries[0].ID)
+	entries, _, err = provider.List(context.Background(), states.ListRequest{
+		Metadata: map[string]interface{}{
+			"namespace": "nondefault",
+		},
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(entries))
+	assert.Equal(t, "234", entries[0].ID)
+	entries, _, err = provider.List(context.Background(), states.ListRequest{})
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(entries))
+	assert.Equal(t, "123", entries[0].ID)
+	assert.Equal(t, "234", entries[1].ID)
 }
 
 func TestDelete(t *testing.T) {
@@ -113,6 +183,39 @@ func TestDelete(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	entries, _, err := provider.List(context.Background(), states.ListRequest{})
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(entries))
+}
+
+func TestDeleteWithNamespace(t *testing.T) {
+	provider := MemoryStateProvider{}
+	err := provider.Init(MemoryStateProvider{})
+	assert.Nil(t, err)
+	_, err = provider.Upsert(context.Background(), states.UpsertRequest{
+		Value: states.StateEntry{
+			ID: "123",
+			Body: TestPayload{
+				Name:  "Random name",
+				Value: 12345,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"namespace": "nondefault",
+		},
+	})
+	assert.Nil(t, err)
+	err = provider.Delete(context.Background(), states.DeleteRequest{
+		ID: "123",
+		Metadata: map[string]interface{}{
+			"namespace": "nondefault",
+		},
+	})
+	assert.Nil(t, err)
+	entries, _, err := provider.List(context.Background(), states.ListRequest{
+		Metadata: map[string]interface{}{
+			"namespace": "nondefault",
+		},
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(entries))
 }
@@ -157,6 +260,48 @@ func TestGet(t *testing.T) {
 	assert.Nil(t, err)
 	entity, err := provider.Get(context.Background(), states.GetRequest{
 		ID: "123",
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, entity)
+	assert.Equal(t, "123", entity.ID)
+
+	payload := TestPayload{}
+	data, err := json.Marshal(entity.Body)
+	assert.Nil(t, err)
+	err = json.Unmarshal(data, &payload)
+	assert.Nil(t, err)
+	assert.Equal(t, "Random name", payload.Name)
+	assert.Equal(t, 12345, payload.Value)
+	entity, err = provider.Get(context.Background(), states.GetRequest{
+		ID: "890",
+	})
+	sczErr, ok := err.(v1alpha2.COAError)
+	assert.True(t, ok)
+	assert.Equal(t, v1alpha2.NotFound, sczErr.State)
+}
+
+func TestGetWithNamespace(t *testing.T) {
+	provider := MemoryStateProvider{}
+	err := provider.Init(MemoryStateProvider{})
+	assert.Nil(t, err)
+	_, err = provider.Upsert(context.Background(), states.UpsertRequest{
+		Value: states.StateEntry{
+			ID: "123",
+			Body: TestPayload{
+				Name:  "Random name",
+				Value: 12345,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"namespace": "nondefault",
+		},
+	})
+	assert.Nil(t, err)
+	entity, err := provider.Get(context.Background(), states.GetRequest{
+		ID: "123",
+		Metadata: map[string]interface{}{
+			"namespace": "nondefault",
+		},
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, entity)
@@ -312,6 +457,39 @@ func TestLabelFilter(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(entity))
 }
+
+func TestLabelFilterWithNamespace(t *testing.T) {
+	provider := MemoryStateProvider{}
+	err := provider.Init(MemoryStateProvider{})
+	assert.Nil(t, err)
+	_, err = provider.Upsert(context.Background(), states.UpsertRequest{
+		Value: states.StateEntry{
+			ID: "",
+			Body: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"app": "test",
+					},
+				},
+				"spec": map[string]interface{}{},
+			},
+		},
+		Metadata: map[string]interface{}{
+			"namespace": "nondefault",
+		},
+	})
+	assert.Nil(t, err)
+	entity, _, err := provider.List(context.Background(), states.ListRequest{
+		FilterType:  "label",
+		FilterValue: "app=test",
+		Metadata: map[string]interface{}{
+			"namespace": "nondefault",
+		},
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(entity))
+}
+
 func TestLabelFilterNotEqual(t *testing.T) {
 	provider := MemoryStateProvider{}
 	err := provider.Init(MemoryStateProvider{})
@@ -333,6 +511,37 @@ func TestLabelFilterNotEqual(t *testing.T) {
 	entity, _, err := provider.List(context.Background(), states.ListRequest{
 		FilterType:  "label",
 		FilterValue: "app!=test2",
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(entity))
+}
+func TestLabelFilterNotEqualWithNamespace(t *testing.T) {
+	provider := MemoryStateProvider{}
+	err := provider.Init(MemoryStateProvider{})
+	assert.Nil(t, err)
+	_, err = provider.Upsert(context.Background(), states.UpsertRequest{
+		Value: states.StateEntry{
+			ID: "",
+			Body: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"app": "test",
+					},
+				},
+				"spec": map[string]interface{}{},
+			},
+		},
+		Metadata: map[string]interface{}{
+			"namespace": "nondefault",
+		},
+	})
+	assert.Nil(t, err)
+	entity, _, err := provider.List(context.Background(), states.ListRequest{
+		FilterType:  "label",
+		FilterValue: "app!=test2",
+		Metadata: map[string]interface{}{
+			"namespace": "nondefault",
+		},
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(entity))


### PR DESCRIPTION
Previously, memory state provider maintained a map of objects. The key is the object name, and the value is the object. 

Memory state provider is also used when running on k8s cluster, for example, storing heartbeat of a job or sync cache of catalogs.
In these scenarios, objects need to be stored under namespace scope. 

Test:

- Add new unit tests for upsert, get, delete, list (single namespace or all namespaces)
- Pass integration tests.