### PR TITLE
Add response status and message in the target's http proxy apply()

### DIFF
--- a/api/pkg/apis/v1alpha1/providers/target/proxy/proxy.go
+++ b/api/pkg/apis/v1alpha1/providers/target/proxy/proxy.go
@@ -164,11 +164,26 @@ func (i *ProxyUpdateProvider) Apply(ctx context.Context, deployment model.Deploy
 	components = step.GetUpdatedComponents()
 	if len(components) > 0 {
 		data, _ := json.Marshal(deployment)
+		payload, err := i.callRestAPI("instances", "POST", data)
 
-		_, err = i.callRestAPI("instances", "POST", data)
 		if err != nil {
 			sLog.Errorf("  P (Proxy Target): failed to post instances: %+v, traceId: %s", err, span.SpanContext().TraceID().String())
 			return ret, err
+		}
+
+		var summarySpec model.SummarySpec
+		err = json.Unmarshal(payload, &summarySpec)
+
+		if err != nil {
+			sLog.Errorf("  P (Proxy Target): failed to unmarshall apply response: %+v, traceId: %s", err, span.SpanContext().TraceID().String())
+			return ret, err
+		}
+
+		// Update ret
+		for target, targetResult := range summarySpec.TargetResults {
+			for _, componentResults := range targetResult.ComponentResults {
+				ret[target] = componentResults
+			}
 		}
 	}
 	components = step.GetDeletedComponents()

--- a/api/pkg/apis/v1alpha1/providers/target/proxy/proxy.go
+++ b/api/pkg/apis/v1alpha1/providers/target/proxy/proxy.go
@@ -174,18 +174,16 @@ func (i *ProxyUpdateProvider) Apply(ctx context.Context, deployment model.Deploy
 		var summarySpec model.SummarySpec
 		err = json.Unmarshal(payload, &summarySpec)
 
-		if err != nil {
-			sLog.Errorf("  P (Proxy Target): failed to unmarshall apply response: %+v, traceId: %s", err, span.SpanContext().TraceID().String())
-			return ret, err
-		}
-
-		// Update ret
-		for target, targetResult := range summarySpec.TargetResults {
-			for _, componentResults := range targetResult.ComponentResults {
-				ret[target] = componentResults
+		if err == nil {
+			// Update ret
+			for target, targetResult := range summarySpec.TargetResults {
+				for _, componentResults := range targetResult.ComponentResults {
+					ret[target] = componentResults
+				}
 			}
 		}
 	}
+
 	components = step.GetDeletedComponents()
 	if len(components) > 0 {
 		data, _ := json.Marshal(deployment)


### PR DESCRIPTION
Previously, an HTTP Proxy Target Provider component's summary spec would always return 9998 for its status and an empty message: 
![image](https://github.com/eclipse-symphony/symphony/assets/122116059/a204ef37-e732-4ca2-8b8a-5aa1bf69ea53)

The `ret` variable is assigned but never updated in the HTTP Proxy Target Provider: https://github.com/eclipse-symphony/symphony/blob/main/api/pkg/apis/v1alpha1/providers/target/proxy/proxy.go#L163

This PR updates `ret` variable in the HTTP Proxy Target Provider according to what the target returns:
![image](https://github.com/eclipse-symphony/symphony/assets/122116059/fcd1b2da-edbf-4e6b-983a-1ea28f297503)

