### PR TITLE
remove Docker check; remove 'v' prefix of version parameter

### DIFF
--- a/cli/cmd/up.go
+++ b/cli/cmd/up.go
@@ -70,9 +70,10 @@ var UpCmd = &cobra.Command{
 				return
 			}
 		} else {
-			if !handleDocker() {
-				return
-			}
+			// we don't need to check for Docker, as we are not using it
+			// if !handleDocker() {
+			//	return
+			// }
 			if !handleKubectl() {
 				return
 			}

--- a/cli/install/install.ps1
+++ b/cli/install/install.ps1
@@ -84,7 +84,7 @@ function GetVersionInfo {
         $release = $Releases | Where-Object { $_.tag_name -notlike "*rc*" } | Select-Object -First 1
     }
     else {
-        $release = $Releases | Where-Object { $_.tag_name -eq "v$Version" } | Select-Object -First 1
+        $release = $Releases | Where-Object { $_.tag_name -eq "$Version" } | Select-Object -First 1
     }
 
     return $release

--- a/cli/install/install.sh
+++ b/cli/install/install.sh
@@ -196,7 +196,7 @@ if [ -z "$1" ]; then
     echo "Getting the latest Maestro CLI..."
     getLatestRelease
 else
-    retVal=v$1
+    retVal=$1
 fi
 
 verifySupported $retVal


### PR DESCRIPTION
Removed Docker check as we are currently not using it for either no-k8s or k8s version. We may need it again when we add run-in-docker option.

Also remove the auto-added 'v' prefix if user specifies a version number, as our releases don't have the 'v' prefix in the repo.