### PR TITLE
Use BOT_USER (eclipse-symphoy-bot) to checkout, commit, push changes in release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,13 +2,14 @@ name: Release
 
 on:
   workflow_dispatch:
-permissions: write-all
+permissions:
+  contents: write
+  packages: write
 env:
   ContainerRegistry: "ghcr.io"
   ContainerRegistryRepo: "ghcr.io/eclipse-symphony"
   BOT_USER_NAME: eclipse-symphoy-bot
   BOT_EMAIL_ID: symphony-bot@eclipse.org
-  REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 # Two users are used in this pipeline
@@ -22,7 +23,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
       - name: Git config

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,14 @@ permissions: write-all
 env:
   ContainerRegistry: "ghcr.io"
   ContainerRegistryRepo: "ghcr.io/eclipse-symphony"
+  BOT_USER_NAME: eclipse-symphoy-bot
+  BOT_EMAIL_ID: symphony-bot@eclipse.org
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
+# Two users are used in this pipeline
+# BOT_USER_NAME (eclipse-symphoy-bot) / secrets.BOT_GITHUB_TOKEN is used to checkout/commit/push the changes to the repository
+# github.repository_owner / secrets.GITHUB_TOKEN is used to login to the docker registry and helm registry and to create the release
 jobs:
   build:
     if: github.repository == 'eclipse-symphony/symphony' && (github.actor == 'chgennar' || github.actor == 'juancooldude' || github.actor == 'Haishi2016' || github.actor == 'nonsocode' || github.actor == 'msftcoderdjw' || github.actor == 'TonyXiaofeng' || github.actor == 'iwangjintian') 
@@ -14,6 +21,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+
+      - name: Git config
+        run: |
+            git config user.name ${{ env.BOT_USER_NAME }}
+            git config user.email ${{ env.BOT_EMAIL_ID }}
 
       - name: Install dependencies
         run: |
@@ -150,7 +165,7 @@ jobs:
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.BOT_GITHUB_TOKEN }}
           branch: main
 
       - name: Create Release


### PR DESCRIPTION
**Context:**

https://github.com/eclipse-symphony/.eclipsefdn/pull/4

Suggestions by eclipse forks:
> so I see that you request these changes in order to support your release workflow that fails now.
> 
> This is a common problem with github actions and can not be easily solved by a bypass rule for github actions, as there is no user like that.
> 
> However, what we have done for other projects and is also good practice is the following:
> 
> * inject a token as secret that allows to bypass the branch protection rule
> * add the eclipse-symphoy-bot user to the bypass list (as already done in this PR)
> * disable status checks as this is not compatible with direct pushes
> * adapt your release workflow like that:
>   
>   * https://github.com/eclipse-xpanse/xpanse-ui/blob/main/.github/workflows/ui-release.yml#L18-L41
>   * that uses the injected token for checkout that will also be used when you commit and push something
>   * setup the commit information to the bot user which is then also visible in the commit history
> 
> so if I look at your existing release workflow, only a few things have to change:
> 
> * use then the injected token instead of secrets.GITHUB_TOKEN
> * update our git config to use
>   
>   * BOT_USER_NAME: eclipse-symphony-bot
>   * BOT_EMAIL_ID: [symphony-bot@eclipse.org](mailto:symphony-bot@eclipse.org)

**Changes:**
1. Use BOT_USER_NAME (eclipse-symphony-bot) to checkout, commit and push changes in release pipeline. 
2. https://github.com/eclipse-symphony/.eclipsefdn/pull/4/files (eclipse-symphony-bot is added in bypass_pull_request_allowances list.)











