### PR TITLE
Correctly setup commit user and email in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,11 +25,6 @@ jobs:
         with:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
-      - name: Git config
-        run: |
-            git config user.name ${{ env.BOT_USER_NAME }}
-            git config user.email ${{ env.BOT_EMAIL_ID }}
-
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y make gcc
@@ -155,8 +150,8 @@ jobs:
 
       - name: Commit changes
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.name ${{ env.BOT_USER_NAME }}
+          git config --local user.email ${{ env.BOT_EMAIL_ID }}
           git add .github/version/versions.txt
           git add packages/helm/symphony/Chart.yaml
           git add cli/cmd/up.go


### PR DESCRIPTION
This is a follow up of #247 .

I have seen that the latest release still committed using actions@github.com user information and inspected the workflow. In fact the user and email was set twice in the workflow, this PR fixes that to use the correct username.

@msftcoderdjw 