### PR TITLE
remove all username pwd calls. (only keep for child and parent communication)

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/jobs/jobs-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/jobs/jobs-manager_test.go
@@ -15,8 +15,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/eclipse-symphony/symphony/api/constants"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
-	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
@@ -62,7 +62,7 @@ func TestHandleJobEvent(t *testing.T) {
 
 	ts := InitializeMockSymphonyAPI()
 	defer ts.Close()
-	utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	jobManager := JobsManager{}
 	err := jobManager.Init(nil, managers.ManagerConfig{
 		Properties: map[string]string{
@@ -163,7 +163,7 @@ func TestPoll(t *testing.T) {
 	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
 	ts := InitializeMockSymphonyAPI()
 	defer ts.Close()
-	utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	jobManager := JobsManager{}
 	err := jobManager.Init(nil, managers.ManagerConfig{
 		Properties: map[string]string{
@@ -193,7 +193,7 @@ func TestDelayOrSkipJobPoll(t *testing.T) {
 	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
 	ts := InitializeMockSymphonyAPI()
 	defer ts.Close()
-	utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	jobManager := JobsManager{}
 	err := jobManager.Init(nil, managers.ManagerConfig{
 		Properties: map[string]string{

--- a/api/pkg/apis/v1alpha1/managers/jobs/jobs-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/jobs/jobs-manager_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
@@ -61,7 +62,7 @@ func TestHandleJobEvent(t *testing.T) {
 
 	ts := InitializeMockSymphonyAPI()
 	defer ts.Close()
-
+	utils.UpdateApiClientUrl(ts.URL + "/")
 	jobManager := JobsManager{}
 	err := jobManager.Init(nil, managers.ManagerConfig{
 		Properties: map[string]string{
@@ -162,6 +163,7 @@ func TestPoll(t *testing.T) {
 	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
 	ts := InitializeMockSymphonyAPI()
 	defer ts.Close()
+	utils.UpdateApiClientUrl(ts.URL + "/")
 	jobManager := JobsManager{}
 	err := jobManager.Init(nil, managers.ManagerConfig{
 		Properties: map[string]string{
@@ -191,6 +193,7 @@ func TestDelayOrSkipJobPoll(t *testing.T) {
 	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
 	ts := InitializeMockSymphonyAPI()
 	defer ts.Close()
+	utils.UpdateApiClientUrl(ts.URL + "/")
 	jobManager := JobsManager{}
 	err := jobManager.Init(nil, managers.ManagerConfig{
 		Properties: map[string]string{

--- a/api/pkg/apis/v1alpha1/managers/sites/sites-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/sites/sites-manager.go
@@ -26,6 +26,7 @@ import (
 type SitesManager struct {
 	managers.Manager
 	StateProvider states.IStateProvider
+	apiClient     *utils.APIClient
 }
 
 func (s *SitesManager) Init(context *contexts.VendorContext, config managers.ManagerConfig, providers map[string]providers.IProvider) error {
@@ -39,6 +40,7 @@ func (s *SitesManager) Init(context *contexts.VendorContext, config managers.Man
 	} else {
 		return err
 	}
+	s.apiClient, err = utils.GetUPApiClient(s.VendorContext.SiteInfo.ParentSite.BaseUrl)
 	return nil
 }
 
@@ -258,12 +260,9 @@ func (s *SitesManager) Poll() []error {
 	}
 	thisSite.Spec.IsSelf = false
 	jData, _ := json.Marshal(thisSite)
-	utils.UpdateSite(
+	s.apiClient.UpdateSite(
 		ctx,
-		s.VendorContext.SiteInfo.ParentSite.BaseUrl,
 		s.VendorContext.SiteInfo.SiteId,
-		s.VendorContext.SiteInfo.ParentSite.Username,
-		s.VendorContext.SiteInfo.ParentSite.Password,
 		jData,
 	)
 	return nil

--- a/api/pkg/apis/v1alpha1/managers/sites/sites-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/sites/sites-manager.go
@@ -40,7 +40,10 @@ func (s *SitesManager) Init(context *contexts.VendorContext, config managers.Man
 	} else {
 		return err
 	}
-	s.apiClient, err = utils.GetUPApiClient(s.VendorContext.SiteInfo.ParentSite.BaseUrl)
+	s.apiClient, err = utils.GetParentApiClient(s.VendorContext.SiteInfo.ParentSite.BaseUrl)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/api/pkg/apis/v1alpha1/managers/sites/sites-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/sites/sites-manager.go
@@ -26,7 +26,7 @@ import (
 type SitesManager struct {
 	managers.Manager
 	StateProvider states.IStateProvider
-	apiClient     *utils.APIClient
+	apiClient     utils.ApiClient
 }
 
 func (s *SitesManager) Init(context *contexts.VendorContext, config managers.ManagerConfig, providers map[string]providers.IProvider) error {
@@ -264,7 +264,8 @@ func (s *SitesManager) Poll() []error {
 		ctx,
 		s.VendorContext.SiteInfo.SiteId,
 		jData,
-	)
+		s.VendorContext.SiteInfo.ParentSite.Username,
+		s.VendorContext.SiteInfo.ParentSite.Password)
 	return nil
 }
 func (s *SitesManager) Reconcil() []error {

--- a/api/pkg/apis/v1alpha1/managers/solution/solution-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/solution/solution-manager.go
@@ -60,7 +60,7 @@ type SolutionManager struct {
 	SecretProvider  secret.ISecretProvider
 	IsTarget        bool
 	TargetNames     []string
-	ApiClientHttp   *api_utils.APIClient
+	ApiClientHttp   api_utils.ApiClient
 }
 
 type SolutionManagerDeploymentState struct {
@@ -649,7 +649,9 @@ func (s *SolutionManager) Enabled() bool {
 func (s *SolutionManager) Poll() []error {
 	if s.Config.Properties["poll.enabled"] == "true" && s.Context.SiteInfo.ParentSite.BaseUrl != "" && s.IsTarget {
 		for _, target := range s.TargetNames {
-			catalogs, err := s.ApiClientHttp.GetCatalogsWithFilter(context.Background(), "", "label", "staged_target="+target)
+			catalogs, err := s.ApiClientHttp.GetCatalogsWithFilter(context.Background(), "", "label", "staged_target="+target,
+				s.Context.SiteInfo.ParentSite.Username,
+				s.Context.SiteInfo.ParentSite.Password)
 			if err != nil {
 				return []error{err}
 			}
@@ -679,7 +681,11 @@ func (s *SolutionManager) Poll() []error {
 					if err != nil {
 						return []error{err}
 					}
-					err = s.ApiClientHttp.ReportCatalogs(context.Background(), deployment.Instance.ObjectMeta.Name+"-"+target, components)
+					err = s.ApiClientHttp.ReportCatalogs(context.Background(),
+						deployment.Instance.ObjectMeta.Name+"-"+target,
+						components,
+						s.Context.SiteInfo.ParentSite.Username,
+						s.Context.SiteInfo.ParentSite.Password)
 					if err != nil {
 						return []error{err}
 					}

--- a/api/pkg/apis/v1alpha1/managers/solution/solution-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/solution/solution-manager.go
@@ -60,6 +60,7 @@ type SolutionManager struct {
 	SecretProvider  secret.ISecretProvider
 	IsTarget        bool
 	TargetNames     []string
+	ApiClientHttp   *api_utils.APIClient
 }
 
 type SolutionManagerDeploymentState struct {
@@ -131,7 +132,7 @@ func (s *SolutionManager) Init(context *contexts.VendorContext, config managers.
 			return err
 		}
 	}
-
+	s.ApiClientHttp, err = api_utils.GetUPApiClient(s.Context.SiteInfo.ParentSite.BaseUrl)
 	return nil
 }
 
@@ -647,9 +648,8 @@ func (s *SolutionManager) Enabled() bool {
 }
 func (s *SolutionManager) Poll() []error {
 	if s.Config.Properties["poll.enabled"] == "true" && s.Context.SiteInfo.ParentSite.BaseUrl != "" && s.IsTarget {
-		symphonyUrl := s.Context.SiteInfo.ParentSite.BaseUrl
 		for _, target := range s.TargetNames {
-			catalogs, err := api_utils.GetCatalogsWithFilter(context.Background(), symphonyUrl, s.Context.SiteInfo.ParentSite.Username, s.Context.SiteInfo.ParentSite.Password, "", "label", "staged_target="+target)
+			catalogs, err := s.ApiClientHttp.GetCatalogsWithFilter(context.Background(), "", "label", "staged_target="+target)
 			if err != nil {
 				return []error{err}
 			}
@@ -679,7 +679,7 @@ func (s *SolutionManager) Poll() []error {
 					if err != nil {
 						return []error{err}
 					}
-					err = api_utils.ReportCatalogs(context.Background(), symphonyUrl, s.Context.SiteInfo.ParentSite.Username, s.Context.SiteInfo.ParentSite.Password, deployment.Instance.ObjectMeta.Name+"-"+target, components)
+					err = s.ApiClientHttp.ReportCatalogs(context.Background(), deployment.Instance.ObjectMeta.Name+"-"+target, components)
 					if err != nil {
 						return []error{err}
 					}

--- a/api/pkg/apis/v1alpha1/managers/solution/solution-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/solution/solution-manager.go
@@ -132,7 +132,10 @@ func (s *SolutionManager) Init(context *contexts.VendorContext, config managers.
 			return err
 		}
 	}
-	s.ApiClientHttp, err = api_utils.GetUPApiClient(s.Context.SiteInfo.ParentSite.BaseUrl)
+	s.ApiClientHttp, err = api_utils.GetParentApiClient(s.Context.SiteInfo.ParentSite.BaseUrl)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/api/pkg/apis/v1alpha1/managers/staging/staging-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/staging/staging-manager.go
@@ -30,6 +30,7 @@ type StagingManager struct {
 	managers.Manager
 	QueueProvider queue.IQueueProvider
 	StateProvider states.IStateProvider
+	apiClient     *utils.APIClient
 }
 
 const Site_Job_Queue = "site-job-queue"
@@ -51,6 +52,7 @@ func (s *StagingManager) Init(context *contexts.VendorContext, config managers.M
 	} else {
 		return err
 	}
+	s.apiClient, err = utils.GetApiClient()
 	return nil
 }
 func (s *StagingManager) Enabled() bool {
@@ -75,12 +77,7 @@ func (s *StagingManager) Poll() []error {
 	}
 	siteId := site.(string)
 	var catalogs []model.CatalogState
-	catalogs, err = utils.GetCatalogs(
-		ctx,
-		s.VendorContext.SiteInfo.CurrentSite.BaseUrl,
-		s.VendorContext.SiteInfo.CurrentSite.Username,
-		s.VendorContext.SiteInfo.CurrentSite.Password,
-		"")
+	catalogs, err = s.apiClient.GetCatalogs(ctx, "")
 	if err != nil {
 		log.Errorf(" M (Staging): Failed to get catalogs: %s", err.Error())
 		observ_utils.CloseSpanWithError(span, &err)

--- a/api/pkg/apis/v1alpha1/managers/staging/staging-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/staging/staging-manager.go
@@ -30,7 +30,7 @@ type StagingManager struct {
 	managers.Manager
 	QueueProvider queue.IQueueProvider
 	StateProvider states.IStateProvider
-	apiClient     *utils.APIClient
+	apiClient     utils.ApiClient
 }
 
 const Site_Job_Queue = "site-job-queue"
@@ -53,6 +53,9 @@ func (s *StagingManager) Init(context *contexts.VendorContext, config managers.M
 		return err
 	}
 	s.apiClient, err = utils.GetApiClient()
+	if err != nil {
+		return err
+	}
 	return nil
 }
 func (s *StagingManager) Enabled() bool {
@@ -77,7 +80,9 @@ func (s *StagingManager) Poll() []error {
 	}
 	siteId := site.(string)
 	var catalogs []model.CatalogState
-	catalogs, err = s.apiClient.GetCatalogs(ctx, "")
+	catalogs, err = s.apiClient.GetCatalogs(ctx, "",
+		s.VendorContext.SiteInfo.CurrentSite.Username,
+		s.VendorContext.SiteInfo.CurrentSite.Password)
 	if err != nil {
 		log.Errorf(" M (Staging): Failed to get catalogs: %s", err.Error())
 		observ_utils.CloseSpanWithError(span, &err)

--- a/api/pkg/apis/v1alpha1/managers/staging/staging-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/staging/staging-manager_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	memoryqueue "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/queue/memory"
@@ -24,6 +25,7 @@ import (
 
 func TestPoll(t *testing.T) {
 	ts := InitializeMockSymphonyAPI()
+	utils.UpdateApiClientUrl(ts.URL + "/")
 	queueProvider := &memoryqueue.MemoryQueueProvider{}
 	queueProvider.Init(memoryqueue.MemoryQueueProviderConfig{})
 
@@ -44,6 +46,9 @@ func TestPoll(t *testing.T) {
 			},
 		},
 	}
+	var err error
+	manager.apiClient, err = utils.GetApiClient()
+	assert.Nil(t, err)
 	queueProvider.Enqueue("site-job-queue", "fake")
 	errList := manager.Poll()
 	assert.Nil(t, errList)
@@ -63,6 +68,7 @@ func TestPoll(t *testing.T) {
 
 func TestHandleJobEvent(t *testing.T) {
 	ts := InitializeMockSymphonyAPI()
+	utils.UpdateApiClientUrl(ts.URL + "/")
 	queueProvider := &memoryqueue.MemoryQueueProvider{}
 	queueProvider.Init(memoryqueue.MemoryQueueProviderConfig{})
 
@@ -83,7 +89,10 @@ func TestHandleJobEvent(t *testing.T) {
 			},
 		},
 	}
-	err := manager.HandleJobEvent(context.Background(), v1alpha2.Event{
+	var err error
+	manager.apiClient, err = utils.GetApiClient()
+	assert.Nil(t, err)
+	err = manager.HandleJobEvent(context.Background(), v1alpha2.Event{
 		Metadata: map[string]string{
 			"site": "fake",
 		},

--- a/api/pkg/apis/v1alpha1/managers/staging/staging-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/staging/staging-manager_test.go
@@ -11,8 +11,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
+	"github.com/eclipse-symphony/symphony/api/constants"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
@@ -25,7 +27,7 @@ import (
 
 func TestPoll(t *testing.T) {
 	ts := InitializeMockSymphonyAPI()
-	utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	queueProvider := &memoryqueue.MemoryQueueProvider{}
 	queueProvider.Init(memoryqueue.MemoryQueueProviderConfig{})
 
@@ -68,7 +70,7 @@ func TestPoll(t *testing.T) {
 
 func TestHandleJobEvent(t *testing.T) {
 	ts := InitializeMockSymphonyAPI()
-	utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	queueProvider := &memoryqueue.MemoryQueueProvider{}
 	queueProvider.Init(memoryqueue.MemoryQueueProviderConfig{})
 

--- a/api/pkg/apis/v1alpha1/managers/sync/sync-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/sync/sync-manager.go
@@ -20,7 +20,7 @@ import (
 
 type SyncManager struct {
 	managers.Manager
-	apiClient *utils.APIClient
+	apiClient utils.ApiClient
 }
 
 func (s *SyncManager) Init(context *contexts.VendorContext, config managers.ManagerConfig, providers map[string]providers.IProvider) error {
@@ -46,7 +46,9 @@ func (s *SyncManager) Poll() []error {
 	if s.VendorContext.SiteInfo.ParentSite.BaseUrl == "" {
 		return nil
 	}
-	batch, err := s.apiClient.GetABatchForSite(ctx, s.VendorContext.SiteInfo.SiteId)
+	batch, err := s.apiClient.GetABatchForSite(ctx, s.VendorContext.SiteInfo.SiteId,
+		s.VendorContext.SiteInfo.ParentSite.Username,
+		s.VendorContext.SiteInfo.ParentSite.Password)
 	if err != nil {
 		return []error{err}
 	}

--- a/api/pkg/apis/v1alpha1/managers/sync/sync-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/sync/sync-manager.go
@@ -31,7 +31,10 @@ func (s *SyncManager) Init(context *contexts.VendorContext, config managers.Mana
 	if s.Context.SiteInfo.SiteId == "" {
 		return v1alpha2.NewCOAError(nil, "siteId is required", v1alpha2.BadConfig)
 	}
-	s.apiClient, err = utils.GetUPApiClient(s.VendorContext.SiteInfo.ParentSite.BaseUrl)
+	s.apiClient, err = utils.GetParentApiClient(s.VendorContext.SiteInfo.ParentSite.BaseUrl)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 func (s *SyncManager) Enabled() bool {

--- a/api/pkg/apis/v1alpha1/managers/sync/sync-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/sync/sync-manager.go
@@ -20,6 +20,7 @@ import (
 
 type SyncManager struct {
 	managers.Manager
+	apiClient *utils.APIClient
 }
 
 func (s *SyncManager) Init(context *contexts.VendorContext, config managers.ManagerConfig, providers map[string]providers.IProvider) error {
@@ -30,6 +31,7 @@ func (s *SyncManager) Init(context *contexts.VendorContext, config managers.Mana
 	if s.Context.SiteInfo.SiteId == "" {
 		return v1alpha2.NewCOAError(nil, "siteId is required", v1alpha2.BadConfig)
 	}
+	s.apiClient, err = utils.GetUPApiClient(s.VendorContext.SiteInfo.ParentSite.BaseUrl)
 	return nil
 }
 func (s *SyncManager) Enabled() bool {
@@ -44,12 +46,7 @@ func (s *SyncManager) Poll() []error {
 	if s.VendorContext.SiteInfo.ParentSite.BaseUrl == "" {
 		return nil
 	}
-	batch, err := utils.GetABatchForSite(
-		ctx,
-		s.VendorContext.SiteInfo.ParentSite.BaseUrl,
-		s.VendorContext.SiteInfo.SiteId,
-		s.VendorContext.SiteInfo.ParentSite.Username,
-		s.VendorContext.SiteInfo.ParentSite.Password)
+	batch, err := s.apiClient.GetABatchForSite(ctx, s.VendorContext.SiteInfo.SiteId)
 	if err != nil {
 		return []error{err}
 	}

--- a/api/pkg/apis/v1alpha1/providers/config/catalog/catalogprovider.go
+++ b/api/pkg/apis/v1alpha1/providers/config/catalog/catalogprovider.go
@@ -23,14 +23,12 @@ import (
 var msLock sync.Mutex
 
 type CatalogConfigProviderConfig struct {
-	BaseUrl  string `json:"baseUrl"`
-	User     string `json:"user"`
-	Password string `json:"password"`
 }
 
 type CatalogConfigProvider struct {
-	Config  CatalogConfigProviderConfig
-	Context *contexts.ManagerContext
+	Config    CatalogConfigProviderConfig
+	Context   *contexts.ManagerContext
+	ApiClient *utils.APIClient
 }
 
 func (s *CatalogConfigProvider) Init(config providers.IProviderConfig) error {
@@ -41,6 +39,7 @@ func (s *CatalogConfigProvider) Init(config providers.IProviderConfig) error {
 		return err
 	}
 	s.Config = mockConfig
+	s.ApiClient, err = utils.GetApiClient()
 	return nil
 }
 func (s *CatalogConfigProvider) SetContext(ctx *contexts.ManagerContext) {
@@ -65,31 +64,10 @@ func (i *CatalogConfigProvider) InitWithMap(properties map[string]string) error 
 }
 func CatalogConfigProviderConfigFromMap(properties map[string]string) (CatalogConfigProviderConfig, error) {
 	ret := CatalogConfigProviderConfig{}
-	baseUrl, err := utils.GetString(properties, "baseUrl")
-	if err != nil {
-		return ret, err
-	}
-	ret.BaseUrl = baseUrl
-	if ret.BaseUrl == "" {
-		return ret, v1alpha2.NewCOAError(nil, "baseUrl is required", v1alpha2.BadConfig)
-	}
-	user, err := utils.GetString(properties, "user")
-	if err != nil {
-		return ret, err
-	}
-	ret.User = user
-	if ret.User == "" {
-		return ret, v1alpha2.NewCOAError(nil, "user is required", v1alpha2.BadConfig)
-	}
-	password, err := utils.GetString(properties, "password")
-	if err != nil {
-		return ret, err
-	}
-	ret.Password = password
 	return ret, nil
 }
 func (m *CatalogConfigProvider) unwindOverrides(override string, field string, namespace string) (string, error) {
-	catalog, err := utils.GetCatalog(context.TODO(), m.Config.BaseUrl, override, m.Config.User, m.Config.Password, namespace)
+	catalog, err := m.ApiClient.GetCatalog(context.TODO(), override, namespace)
 	if err != nil {
 		return "", err
 	}
@@ -104,7 +82,7 @@ func (m *CatalogConfigProvider) unwindOverrides(override string, field string, n
 func (m *CatalogConfigProvider) Read(object string, field string, localcontext interface{}) (interface{}, error) {
 	namespace := m.getNamespaceFromContext(localcontext)
 
-	catalog, err := utils.GetCatalog(context.TODO(), m.Config.BaseUrl, object, m.Config.User, m.Config.Password, namespace)
+	catalog, err := m.ApiClient.GetCatalog(context.TODO(), object, namespace)
 	if err != nil {
 		return "", err
 	}
@@ -128,7 +106,7 @@ func (m *CatalogConfigProvider) Read(object string, field string, localcontext i
 func (m *CatalogConfigProvider) ReadObject(object string, localcontext interface{}) (map[string]interface{}, error) {
 	namespace := m.getNamespaceFromContext(localcontext)
 
-	catalog, err := utils.GetCatalog(context.TODO(), m.Config.BaseUrl, object, m.Config.User, m.Config.Password, namespace)
+	catalog, err := m.ApiClient.GetCatalog(context.TODO(), object, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -219,16 +197,16 @@ func (m *CatalogConfigProvider) traceValue(v interface{}, localcontext interface
 // TODO: IConfigProvider interface methods should be enhanced to accept namespace as a parameter
 // so we can get rid of getCatalogInDefaultNamespace.
 func (m *CatalogConfigProvider) Set(object string, field string, value interface{}) error {
-	catalog, err := m.getCatalogInDefaultNamespace(context.TODO(), m.Config.BaseUrl, object, m.Config.User, m.Config.Password)
+	catalog, err := m.getCatalogInDefaultNamespace(context.TODO(), object)
 	if err != nil {
 		return err
 	}
 	catalog.Spec.Properties[field] = value
 	data, _ := json.Marshal(catalog)
-	return utils.UpsertCatalog(context.TODO(), m.Config.BaseUrl, object, m.Config.User, m.Config.Password, data)
+	return m.ApiClient.UpsertCatalog(context.TODO(), object, data)
 }
 func (m *CatalogConfigProvider) SetObject(object string, value map[string]interface{}) error {
-	catalog, err := m.getCatalogInDefaultNamespace(context.TODO(), m.Config.BaseUrl, object, m.Config.User, m.Config.Password)
+	catalog, err := m.getCatalogInDefaultNamespace(context.TODO(), object)
 	if err != nil {
 		return err
 	}
@@ -237,10 +215,10 @@ func (m *CatalogConfigProvider) SetObject(object string, value map[string]interf
 		catalog.Spec.Properties[k] = v
 	}
 	data, _ := json.Marshal(catalog)
-	return utils.UpsertCatalog(context.TODO(), m.Config.BaseUrl, object, m.Config.User, m.Config.Password, data)
+	return m.ApiClient.UpsertCatalog(context.TODO(), object, data)
 }
 func (m *CatalogConfigProvider) Remove(object string, field string) error {
-	catlog, err := m.getCatalogInDefaultNamespace(context.TODO(), m.Config.BaseUrl, object, m.Config.User, m.Config.Password)
+	catlog, err := m.getCatalogInDefaultNamespace(context.TODO(), object)
 	if err != nil {
 		return err
 	}
@@ -249,12 +227,12 @@ func (m *CatalogConfigProvider) Remove(object string, field string) error {
 	}
 	delete(catlog.Spec.Properties, field)
 	data, _ := json.Marshal(catlog)
-	return utils.UpsertCatalog(context.TODO(), m.Config.BaseUrl, object, m.Config.User, m.Config.Password, data)
+	return m.ApiClient.UpsertCatalog(context.TODO(), object, data)
 }
 func (m *CatalogConfigProvider) RemoveObject(object string) error {
-	return utils.DeleteCatalog(context.TODO(), m.Config.BaseUrl, object, m.Config.User, m.Config.Password)
+	return m.ApiClient.DeleteCatalog(context.TODO(), object)
 }
 
-func (m *CatalogConfigProvider) getCatalogInDefaultNamespace(context context.Context, baseUrl string, catalog string, user string, password string) (model.CatalogState, error) {
-	return utils.GetCatalog(context, baseUrl, catalog, user, password, "")
+func (m *CatalogConfigProvider) getCatalogInDefaultNamespace(context context.Context, catalog string) (model.CatalogState, error) {
+	return m.ApiClient.GetCatalog(context, catalog, "")
 }

--- a/api/pkg/apis/v1alpha1/providers/config/catalog/catalogprovider_test.go
+++ b/api/pkg/apis/v1alpha1/providers/config/catalog/catalogprovider_test.go
@@ -10,10 +10,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
+	"github.com/eclipse-symphony/symphony/api/constants"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
-	api_utils "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/utils"
@@ -83,7 +84,7 @@ func TestRead(t *testing.T) {
 		json.NewEncoder(w).Encode(response)
 	}))
 	defer ts.Close()
-	api_utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	provider := CatalogConfigProvider{}
 	err := provider.Init(CatalogConfigProviderConfig{})
 	provider.Context = &contexts.ManagerContext{
@@ -156,7 +157,7 @@ func TestReadObject(t *testing.T) {
 		json.NewEncoder(w).Encode(response)
 	}))
 	defer ts.Close()
-	api_utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	provider := CatalogConfigProvider{}
 	err := provider.Init(CatalogConfigProviderConfig{})
 	provider.Context = &contexts.ManagerContext{
@@ -208,7 +209,7 @@ func TestSetandRemove(t *testing.T) {
 		json.NewEncoder(w).Encode(response)
 	}))
 	defer ts.Close()
-	api_utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	provider := CatalogConfigProvider{}
 	err := provider.Init(CatalogConfigProviderConfig{})
 	provider.Context = &contexts.ManagerContext{
@@ -266,7 +267,7 @@ func TestSetandRemoveObject(t *testing.T) {
 		json.NewEncoder(w).Encode(response)
 	}))
 	defer ts.Close()
-	api_utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	provider := CatalogConfigProvider{}
 	err := provider.Init(CatalogConfigProviderConfig{})
 	provider.Context = &contexts.ManagerContext{

--- a/api/pkg/apis/v1alpha1/providers/config/catalog/catalogprovider_test.go
+++ b/api/pkg/apis/v1alpha1/providers/config/catalog/catalogprovider_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	api_utils "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/utils"
@@ -82,9 +83,9 @@ func TestRead(t *testing.T) {
 		json.NewEncoder(w).Encode(response)
 	}))
 	defer ts.Close()
-
+	api_utils.UpdateApiClientUrl(ts.URL + "/")
 	provider := CatalogConfigProvider{}
-	err := provider.Init(CatalogConfigProviderConfig{BaseUrl: ts.URL + "/", User: "admin", Password: ""})
+	err := provider.Init(CatalogConfigProviderConfig{})
 	provider.Context = &contexts.ManagerContext{
 		VencorContext: &contexts.VendorContext{
 			EvaluationContext: &utils.EvaluationContext{},
@@ -155,9 +156,9 @@ func TestReadObject(t *testing.T) {
 		json.NewEncoder(w).Encode(response)
 	}))
 	defer ts.Close()
-
+	api_utils.UpdateApiClientUrl(ts.URL + "/")
 	provider := CatalogConfigProvider{}
-	err := provider.Init(CatalogConfigProviderConfig{BaseUrl: ts.URL + "/", User: "admin", Password: ""})
+	err := provider.Init(CatalogConfigProviderConfig{})
 	provider.Context = &contexts.ManagerContext{
 		VencorContext: &contexts.VendorContext{
 			EvaluationContext: &utils.EvaluationContext{},
@@ -207,9 +208,9 @@ func TestSetandRemove(t *testing.T) {
 		json.NewEncoder(w).Encode(response)
 	}))
 	defer ts.Close()
-
+	api_utils.UpdateApiClientUrl(ts.URL + "/")
 	provider := CatalogConfigProvider{}
-	err := provider.Init(CatalogConfigProviderConfig{BaseUrl: ts.URL + "/", User: "admin", Password: ""})
+	err := provider.Init(CatalogConfigProviderConfig{})
 	provider.Context = &contexts.ManagerContext{
 		VencorContext: &contexts.VendorContext{
 			EvaluationContext: &utils.EvaluationContext{},
@@ -265,9 +266,9 @@ func TestSetandRemoveObject(t *testing.T) {
 		json.NewEncoder(w).Encode(response)
 	}))
 	defer ts.Close()
-
+	api_utils.UpdateApiClientUrl(ts.URL + "/")
 	provider := CatalogConfigProvider{}
-	err := provider.Init(CatalogConfigProviderConfig{BaseUrl: ts.URL + "/", User: "admin", Password: ""})
+	err := provider.Init(CatalogConfigProviderConfig{})
 	provider.Context = &contexts.ManagerContext{
 		VencorContext: &contexts.VendorContext{
 			EvaluationContext: &utils.EvaluationContext{},

--- a/api/pkg/apis/v1alpha1/providers/stage/create/create.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/create/create.go
@@ -28,16 +28,14 @@ import (
 var msLock sync.Mutex
 
 type CreateStageProviderConfig struct {
-	BaseUrl      string `json:"baseUrl"`
-	User         string `json:"user"`
-	Password     string `json:"password"`
-	WaitCount    int    `json:"wait.count,omitempty"`
-	WaitInterval int    `json:"wait.interval,omitempty"`
+	WaitCount    int `json:"wait.count,omitempty"`
+	WaitInterval int `json:"wait.interval,omitempty"`
 }
 
 type CreateStageProvider struct {
-	Config  CreateStageProviderConfig
-	Context *contexts.ManagerContext
+	Config    CreateStageProviderConfig
+	Context   *contexts.ManagerContext
+	ApiClient *utils.APIClient
 }
 
 const (
@@ -53,6 +51,7 @@ func (s *CreateStageProvider) Init(config providers.IProviderConfig) error {
 		return err
 	}
 	s.Config = mockConfig
+	s.ApiClient, err = utils.GetApiClient()
 	return nil
 }
 func (s *CreateStageProvider) SetContext(ctx *contexts.ManagerContext) {
@@ -76,26 +75,6 @@ func (i *CreateStageProvider) InitWithMap(properties map[string]string) error {
 }
 func SymphonyStageProviderConfigFromMap(properties map[string]string) (CreateStageProviderConfig, error) {
 	ret := CreateStageProviderConfig{}
-	baseUrl, err := utils.GetString(properties, "baseUrl")
-	if err != nil {
-		return ret, err
-	}
-	ret.BaseUrl = baseUrl
-	if ret.BaseUrl == "" {
-		return ret, v1alpha2.NewCOAError(nil, "baseUrl is required", v1alpha2.BadConfig)
-	}
-	user, err := utils.GetString(properties, "user")
-	if err != nil {
-		return ret, err
-	}
-	ret.User = user
-	if ret.User == "" {
-		return ret, v1alpha2.NewCOAError(nil, "user is required", v1alpha2.BadConfig)
-	}
-	password, err := utils.GetString(properties, "password")
-	if err != nil {
-		return ret, err
-	}
 	waitStr, err := utils.GetString(properties, "wait.count")
 	if err != nil {
 		return ret, err
@@ -114,7 +93,6 @@ func SymphonyStageProviderConfigFromMap(properties map[string]string) (CreateSta
 		return ret, v1alpha2.NewCOAError(err, "wait.interval must be an integer", v1alpha2.BadConfig)
 	}
 	ret.WaitInterval = waitInterval
-	ret.Password = password
 	if waitCount <= 0 {
 		waitCount = 1
 	}
@@ -146,18 +124,18 @@ func (i *CreateStageProvider) Process(ctx context.Context, mgrContext contexts.M
 		}
 
 		if strings.EqualFold(action, RemoveAction) {
-			err = utils.DeleteInstance(ctx, i.Config.BaseUrl, objectName, i.Config.User, i.Config.Password, objectNamespace)
+			err = i.ApiClient.DeleteInstance(ctx, objectName, objectNamespace)
 			if err != nil {
 				return nil, false, err
 			}
 		} else if strings.EqualFold(action, CreateAction) {
-			err = utils.CreateInstance(ctx, i.Config.BaseUrl, objectName, i.Config.User, i.Config.Password, oData, objectNamespace)
+			err = i.ApiClient.CreateInstance(ctx, objectName, oData, objectNamespace)
 			if err != nil {
 				return nil, false, err
 			}
 			for ic := 0; ic < i.Config.WaitCount; ic++ {
-				var summary model.SummaryResult
-				summary, err = utils.GetSummary(ctx, i.Config.BaseUrl, i.Config.User, i.Config.Password, objectName, objectNamespace)
+				var summary *model.SummaryResult
+				summary, err = i.ApiClient.GetSummary(ctx, objectName, objectNamespace)
 				lastSummaryMessage = summary.Summary.SummaryMessage
 				if err != nil {
 					return nil, false, err

--- a/api/pkg/apis/v1alpha1/providers/stage/create/create_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/create/create_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/eclipse-symphony/symphony/api/constants"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
@@ -49,9 +50,6 @@ func TestDeployInstance(t *testing.T) {
 func TestCreateInitFromVendorMap(t *testing.T) {
 	provider := CreateStageProvider{}
 	input := map[string]string{
-		"baseUrl":       "http://symphony-service:8080/v1alpha2/",
-		"user":          "admin",
-		"password":      "",
 		"wait.interval": "1",
 		"wait.count":    "3",
 	}
@@ -67,16 +65,38 @@ func TestCreateInitFromVendorMap(t *testing.T) {
 	assert.NotNil(t, err)
 
 	input = map[string]string{
-		"baseUrl": "",
+		"wait.count": "abc",
 	}
 	config, err = SymphonyStageProviderConfigFromMap(input)
 	assert.NotNil(t, err)
 
 	input = map[string]string{
-		"baseUrl": "http://symphony-service:8080/v1alpha2/",
+		"wait.count":    "15",
+		"wait.interval": "abc",
 	}
 	config, err = SymphonyStageProviderConfigFromMap(input)
 	assert.NotNil(t, err)
+}
+
+func TestCreateInitFromVendorMapForNonServiceAccount(t *testing.T) {
+	UseServiceAccountTokenEnvName := os.Getenv(constants.UseServiceAccountTokenEnvName)
+	if UseServiceAccountTokenEnvName != "false" {
+		t.Skip("Skipping becasue UseServiceAccountTokenEnvName is not false")
+	}
+	provider := CreateStageProvider{}
+	input := map[string]string{
+		"user":          "admin",
+		"password":      "",
+		"wait.interval": "1",
+		"wait.count":    "3",
+	}
+	config, err := SymphonyStageProviderConfigFromMap(input)
+	assert.Nil(t, err)
+	assert.Equal(t, "admin", config.User)
+	assert.Equal(t, 1, config.WaitInterval)
+	assert.Equal(t, 3, config.WaitCount)
+	err = provider.InitWithMap(input)
+	assert.Nil(t, err)
 
 	input = map[string]string{
 		"baseUrl": "http://symphony-service:8080/v1alpha2/",
@@ -84,29 +104,9 @@ func TestCreateInitFromVendorMap(t *testing.T) {
 	}
 	config, err = SymphonyStageProviderConfigFromMap(input)
 	assert.NotNil(t, err)
-
 	input = map[string]string{
 		"baseUrl": "http://symphony-service:8080/v1alpha2/",
 		"user":    "admin",
-	}
-	config, err = SymphonyStageProviderConfigFromMap(input)
-	assert.NotNil(t, err)
-
-	input = map[string]string{
-		"baseUrl":    "http://symphony-service:8080/v1alpha2/",
-		"user":       "admin",
-		"password":   "",
-		"wait.count": "abc",
-	}
-	config, err = SymphonyStageProviderConfigFromMap(input)
-	assert.NotNil(t, err)
-
-	input = map[string]string{
-		"baseUrl":       "http://symphony-service:8080/v1alpha2/",
-		"user":          "admin",
-		"password":      "",
-		"wait.count":    "15",
-		"wait.interval": "abc",
 	}
 	config, err = SymphonyStageProviderConfigFromMap(input)
 	assert.NotNil(t, err)

--- a/api/pkg/apis/v1alpha1/providers/stage/create/create_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/create/create_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	"github.com/stretchr/testify/assert"
 )
@@ -26,9 +27,6 @@ func TestDeployInstance(t *testing.T) {
 	}
 	provider := CreateStageProvider{}
 	err := provider.Init(CreateStageProviderConfig{
-		BaseUrl:      "http://localhost:8082/v1alpha2/",
-		User:         "admin",
-		Password:     "",
 		WaitCount:    3,
 		WaitInterval: 5,
 	})
@@ -59,9 +57,6 @@ func TestCreateInitFromVendorMap(t *testing.T) {
 	}
 	config, err := SymphonyStageProviderConfigFromMap(input)
 	assert.Nil(t, err)
-	assert.Equal(t, "http://symphony-service:8080/v1alpha2/", config.BaseUrl)
-	assert.Equal(t, "admin", config.User)
-	assert.Equal(t, "", config.Password)
 	assert.Equal(t, 1, config.WaitInterval)
 	assert.Equal(t, 3, config.WaitCount)
 	err = provider.InitWithMap(input)
@@ -126,6 +121,7 @@ type AuthResponse struct {
 
 func TestCreateProcessCreate(t *testing.T) {
 	ts := InitializeMockSymphonyAPI()
+	utils.UpdateApiClientUrl(ts.URL + "/")
 	provider := CreateStageProvider{}
 	input := map[string]string{
 		"baseUrl":       ts.URL + "/",
@@ -149,6 +145,7 @@ func TestCreateProcessCreate(t *testing.T) {
 
 func TestCreateProcessCreateFailedCase(t *testing.T) {
 	ts := InitializeMockSymphonyAPIFailedCase()
+	utils.UpdateApiClientUrl(ts.URL + "/")
 	provider := CreateStageProvider{}
 	input := map[string]string{
 		"baseUrl":       ts.URL + "/",
@@ -173,6 +170,7 @@ func TestCreateProcessCreateFailedCase(t *testing.T) {
 
 func TestCreateProcessRemove(t *testing.T) {
 	ts := InitializeMockSymphonyAPI()
+	utils.UpdateApiClientUrl(ts.URL + "/")
 	provider := CreateStageProvider{}
 	input := map[string]string{
 		"baseUrl":       ts.URL + "/",

--- a/api/pkg/apis/v1alpha1/providers/stage/create/create_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/create/create_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/eclipse-symphony/symphony/api/constants"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
-	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	"github.com/stretchr/testify/assert"
 )
@@ -121,7 +120,7 @@ type AuthResponse struct {
 
 func TestCreateProcessCreate(t *testing.T) {
 	ts := InitializeMockSymphonyAPI()
-	utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	provider := CreateStageProvider{}
 	input := map[string]string{
 		"baseUrl":       ts.URL + "/",
@@ -145,7 +144,7 @@ func TestCreateProcessCreate(t *testing.T) {
 
 func TestCreateProcessCreateFailedCase(t *testing.T) {
 	ts := InitializeMockSymphonyAPIFailedCase()
-	utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	provider := CreateStageProvider{}
 	input := map[string]string{
 		"baseUrl":       ts.URL + "/",
@@ -170,7 +169,7 @@ func TestCreateProcessCreateFailedCase(t *testing.T) {
 
 func TestCreateProcessRemove(t *testing.T) {
 	ts := InitializeMockSymphonyAPI()
-	utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	provider := CreateStageProvider{}
 	input := map[string]string{
 		"baseUrl":       ts.URL + "/",

--- a/api/pkg/apis/v1alpha1/providers/stage/list/list.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/list/list.go
@@ -27,14 +27,12 @@ var msLock sync.Mutex
 var log = logger.NewLogger("coa.runtime")
 
 type ListStageProviderConfig struct {
-	BaseUrl  string `json:"baseUrl"`
-	User     string `json:"user"`
-	Password string `json:"password"`
 }
 
 type ListStageProvider struct {
-	Config  ListStageProviderConfig
-	Context *contexts.ManagerContext
+	Config    ListStageProviderConfig
+	Context   *contexts.ManagerContext
+	ApiClient *utils.APIClient
 }
 
 func (s *ListStageProvider) Init(config providers.IProviderConfig) error {
@@ -45,6 +43,7 @@ func (s *ListStageProvider) Init(config providers.IProviderConfig) error {
 		return err
 	}
 	s.Config = mockConfig
+	s.ApiClient, err = utils.GetApiClient()
 	return nil
 }
 func (s *ListStageProvider) SetContext(ctx *contexts.ManagerContext) {
@@ -68,27 +67,6 @@ func (i *ListStageProvider) InitWithMap(properties map[string]string) error {
 }
 func ListStageProviderConfigFromMap(properties map[string]string) (ListStageProviderConfig, error) {
 	ret := ListStageProviderConfig{}
-	baseUrl, err := utils.GetString(properties, "baseUrl")
-	if err != nil {
-		return ret, err
-	}
-	ret.BaseUrl = baseUrl
-	if ret.BaseUrl == "" {
-		return ret, v1alpha2.NewCOAError(nil, "baseUrl is required", v1alpha2.BadConfig)
-	}
-	user, err := utils.GetString(properties, "user")
-	if err != nil {
-		return ret, err
-	}
-	ret.User = user
-	if ret.User == "" {
-		return ret, v1alpha2.NewCOAError(nil, "user is required", v1alpha2.BadConfig)
-	}
-	password, err := utils.GetString(properties, "password")
-	if err != nil {
-		return ret, err
-	}
-	ret.Password = password
 	return ret, nil
 }
 func (i *ListStageProvider) Process(ctx context.Context, mgrContext contexts.ManagerContext, inputs map[string]interface{}) (map[string]interface{}, bool, error) {
@@ -117,7 +95,7 @@ func (i *ListStageProvider) Process(ctx context.Context, mgrContext contexts.Man
 	switch objectType {
 	case "instance":
 		var instances []model.InstanceState
-		instances, err = utils.GetInstances(ctx, i.Config.BaseUrl, i.Config.User, i.Config.Password, objectNamespace)
+		instances, err = i.ApiClient.GetInstances(ctx, objectNamespace)
 		if err != nil {
 			log.Errorf("  P (List Processor): failed to get instances: %v", err)
 			return nil, false, err
@@ -133,7 +111,7 @@ func (i *ListStageProvider) Process(ctx context.Context, mgrContext contexts.Man
 		}
 	case "sites":
 		var sites []model.SiteState
-		sites, err = utils.GetSites(ctx, i.Config.BaseUrl, i.Config.User, i.Config.Password)
+		sites, err = i.ApiClient.GetSites(ctx)
 		if err != nil {
 			log.Errorf("  P (List Processor): failed to get sites: %v", err)
 			return nil, false, err
@@ -155,7 +133,7 @@ func (i *ListStageProvider) Process(ctx context.Context, mgrContext contexts.Man
 		}
 	case "catalogs":
 		var catalogs []model.CatalogState
-		catalogs, err = utils.GetCatalogs(ctx, i.Config.BaseUrl, i.Config.User, i.Config.Password, objectNamespace)
+		catalogs, err = i.ApiClient.GetCatalogs(ctx, objectNamespace)
 		if err != nil {
 			log.Errorf("  P (List Processor): failed to get catalogs: %v", err)
 			return nil, false, err

--- a/api/pkg/apis/v1alpha1/providers/stage/list/list_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/list/list_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/eclipse-symphony/symphony/api/constants"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
-	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	"github.com/stretchr/testify/assert"
 )
@@ -53,7 +52,7 @@ func TestListInitFromMap(t *testing.T) {
 
 func TestListProcessInstances(t *testing.T) {
 	ts := InitializeMockSymphonyAPI()
-	utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	provider := ListStageProvider{}
 	input := map[string]string{
 		"baseUrl":  ts.URL + "/",
@@ -87,7 +86,7 @@ func TestListProcessInstances(t *testing.T) {
 
 func TestListProcessSites(t *testing.T) {
 	ts := InitializeMockSymphonyAPI()
-	utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	provider := ListStageProvider{}
 	input := map[string]string{
 		"baseUrl":  ts.URL + "/",
@@ -121,7 +120,7 @@ func TestListProcessSites(t *testing.T) {
 
 func TestListProcessCatalogs(t *testing.T) {
 	ts := InitializeMockSymphonyAPI()
-	utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	provider := ListStageProvider{}
 	input := map[string]string{
 		"baseUrl":  ts.URL + "/",

--- a/api/pkg/apis/v1alpha1/providers/stage/list/list_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/list/list_test.go
@@ -14,52 +14,14 @@ import (
 	"testing"
 
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestListInitFromMap(t *testing.T) {
-	provider := ListStageProvider{}
-	input := map[string]string{
-		"baseUrl":  "http://symphony-service:8080/v1alpha2/",
-		"user":     "admin",
-		"password": "",
-	}
-	err := provider.InitWithMap(input)
-	assert.Nil(t, err)
-
-	input = map[string]string{}
-	err = provider.InitWithMap(input)
-	assert.NotNil(t, err)
-
-	input = map[string]string{
-		"baseUrl": "",
-	}
-	err = provider.InitWithMap(input)
-	assert.NotNil(t, err)
-
-	input = map[string]string{
-		"baseUrl": "http://symphony-service:8080/v1alpha2/",
-	}
-	err = provider.InitWithMap(input)
-	assert.NotNil(t, err)
-
-	input = map[string]string{
-		"baseUrl": "http://symphony-service:8080/v1alpha2/",
-		"user":    "",
-	}
-	err = provider.InitWithMap(input)
-	assert.NotNil(t, err)
-
-	input = map[string]string{
-		"baseUrl": "http://symphony-service:8080/v1alpha2/",
-		"user":    "admin",
-	}
-	err = provider.InitWithMap(input)
-	assert.NotNil(t, err)
-}
 func TestListProcessInstances(t *testing.T) {
 	ts := InitializeMockSymphonyAPI()
+	utils.UpdateApiClientUrl(ts.URL + "/")
 	provider := ListStageProvider{}
 	input := map[string]string{
 		"baseUrl":  ts.URL + "/",
@@ -93,6 +55,7 @@ func TestListProcessInstances(t *testing.T) {
 
 func TestListProcessSites(t *testing.T) {
 	ts := InitializeMockSymphonyAPI()
+	utils.UpdateApiClientUrl(ts.URL + "/")
 	provider := ListStageProvider{}
 	input := map[string]string{
 		"baseUrl":  ts.URL + "/",
@@ -126,6 +89,7 @@ func TestListProcessSites(t *testing.T) {
 
 func TestListProcessCatalogs(t *testing.T) {
 	ts := InitializeMockSymphonyAPI()
+	utils.UpdateApiClientUrl(ts.URL + "/")
 	provider := ListStageProvider{}
 	input := map[string]string{
 		"baseUrl":  ts.URL + "/",

--- a/api/pkg/apis/v1alpha1/providers/stage/list/list_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/list/list_test.go
@@ -11,13 +11,45 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
+	"github.com/eclipse-symphony/symphony/api/constants"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestListInitFromMap(t *testing.T) {
+	UseServiceAccountTokenEnvName := os.Getenv(constants.UseServiceAccountTokenEnvName)
+	if UseServiceAccountTokenEnvName != "false" {
+		t.Skip("Skipping becasue UseServiceAccountTokenEnvName is not false")
+	}
+	provider := ListStageProvider{}
+	input := map[string]string{
+		"user":     "admin",
+		"password": "",
+	}
+	err := provider.InitWithMap(input)
+	assert.Nil(t, err)
+
+	input = map[string]string{}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"user": "",
+	}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"user": "admin",
+	}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+}
 
 func TestListProcessInstances(t *testing.T) {
 	ts := InitializeMockSymphonyAPI()

--- a/api/pkg/apis/v1alpha1/providers/stage/materialize/materialize_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/materialize/materialize_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/eclipse-symphony/symphony/api/constants"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
-	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	"github.com/stretchr/testify/assert"
@@ -68,7 +67,7 @@ func TestMaterializeInitFromVendorMap(t *testing.T) {
 func TestMaterializeProcessWithStageNs(t *testing.T) {
 	stageNs := "testns"
 	ts := InitializeMockSymphonyAPI(t, stageNs)
-	utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	provider := MaterializeStageProvider{}
 	input := map[string]string{
 		"baseUrl":  ts.URL + "/",
@@ -93,7 +92,7 @@ func TestMaterializeProcessWithStageNs(t *testing.T) {
 
 func TestMaterializeProcessWithoutStageNs(t *testing.T) {
 	ts := InitializeMockSymphonyAPI(t, "objNS")
-	utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	provider := MaterializeStageProvider{}
 	input := map[string]string{
 		"baseUrl":  ts.URL + "/",
@@ -117,7 +116,7 @@ func TestMaterializeProcessWithoutStageNs(t *testing.T) {
 
 func TestMaterializeProcessFailedCase(t *testing.T) {
 	ts := InitializeMockSymphonyAPI(t, "objNS")
-	utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	provider := MaterializeStageProvider{}
 	input := map[string]string{
 		"baseUrl":  ts.URL + "/",

--- a/api/pkg/apis/v1alpha1/providers/stage/materialize/materialize_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/materialize/materialize_test.go
@@ -15,54 +15,11 @@ import (
 	"testing"
 
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestMaterializeInit(t *testing.T) {
-	provider := MaterializeStageProvider{}
-	input := map[string]string{
-		"baseUrl":  "http://symphony-service:8080/v1alpha2/",
-		"user":     "admin",
-		"password": "",
-	}
-	err := provider.InitWithMap(input)
-	assert.Nil(t, err)
-	assert.Equal(t, "http://symphony-service:8080/v1alpha2/", provider.Config.BaseUrl)
-	assert.Equal(t, "admin", provider.Config.User)
-	assert.Equal(t, "", provider.Config.Password)
-
-	input = map[string]string{}
-	err = provider.InitWithMap(input)
-	assert.NotNil(t, err)
-
-	input = map[string]string{
-		"baseUrl": "",
-	}
-	err = provider.InitWithMap(input)
-	assert.NotNil(t, err)
-
-	input = map[string]string{
-		"baseUrl": "http://symphony-service:8080/v1alpha2/",
-	}
-	err = provider.InitWithMap(input)
-	assert.NotNil(t, err)
-
-	input = map[string]string{
-		"baseUrl": "http://symphony-service:8080/v1alpha2/",
-		"user":    "",
-	}
-	err = provider.InitWithMap(input)
-	assert.NotNil(t, err)
-
-	input = map[string]string{
-		"baseUrl": "http://symphony-service:8080/v1alpha2/",
-		"user":    "admin",
-	}
-	err = provider.InitWithMap(input)
-	assert.NotNil(t, err)
-}
 
 func TestMaterializeInitFromVendorMap(t *testing.T) {
 	input := map[string]string{
@@ -74,13 +31,11 @@ func TestMaterializeInitFromVendorMap(t *testing.T) {
 	assert.Nil(t, err)
 	provider := MaterializeStageProvider{}
 	provider.Init(config)
-	assert.Equal(t, "http://symphony-service:8080/v1alpha2/", provider.Config.BaseUrl)
-	assert.Equal(t, "admin", provider.Config.User)
-	assert.Equal(t, "", provider.Config.Password)
 }
 func TestMaterializeProcessWithStageNs(t *testing.T) {
 	stageNs := "testns"
 	ts := InitializeMockSymphonyAPI(t, stageNs)
+	utils.UpdateApiClientUrl(ts.URL + "/")
 	provider := MaterializeStageProvider{}
 	input := map[string]string{
 		"baseUrl":  ts.URL + "/",
@@ -105,6 +60,7 @@ func TestMaterializeProcessWithStageNs(t *testing.T) {
 
 func TestMaterializeProcessWithoutStageNs(t *testing.T) {
 	ts := InitializeMockSymphonyAPI(t, "objNS")
+	utils.UpdateApiClientUrl(ts.URL + "/")
 	provider := MaterializeStageProvider{}
 	input := map[string]string{
 		"baseUrl":  ts.URL + "/",
@@ -128,6 +84,7 @@ func TestMaterializeProcessWithoutStageNs(t *testing.T) {
 
 func TestMaterializeProcessFailedCase(t *testing.T) {
 	ts := InitializeMockSymphonyAPI(t, "objNS")
+	utils.UpdateApiClientUrl(ts.URL + "/")
 	provider := MaterializeStageProvider{}
 	input := map[string]string{
 		"baseUrl":  ts.URL + "/",

--- a/api/pkg/apis/v1alpha1/providers/stage/materialize/materialize_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/materialize/materialize_test.go
@@ -12,8 +12,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
+	"github.com/eclipse-symphony/symphony/api/constants"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
@@ -21,6 +23,37 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestMaterializeInitForNonServiceAccount(t *testing.T) {
+	UseServiceAccountTokenEnvName := os.Getenv(constants.UseServiceAccountTokenEnvName)
+	if UseServiceAccountTokenEnvName != "false" {
+		t.Skip("Skipping becasue UseServiceAccountTokenEnvName is not false")
+	}
+	provider := MaterializeStageProvider{}
+	input := map[string]string{
+		"user":     "admin",
+		"password": "",
+	}
+	err := provider.InitWithMap(input)
+	assert.Nil(t, err)
+	assert.Equal(t, "admin", provider.Config.User)
+	assert.Equal(t, "", provider.Config.Password)
+
+	input = map[string]string{}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"user": "",
+	}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"user": "admin",
+	}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+}
 func TestMaterializeInitFromVendorMap(t *testing.T) {
 	input := map[string]string{
 		"wait.baseUrl":  "http://symphony-service:8080/v1alpha2/",

--- a/api/pkg/apis/v1alpha1/providers/stage/patch/patch.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/patch/patch.go
@@ -26,14 +26,12 @@ var msLock sync.Mutex
 var sLog = logger.NewLogger("coa.runtime")
 
 type PatchStageProviderConfig struct {
-	BaseUrl  string `json:"baseUrl"`
-	User     string `json:"user"`
-	Password string `json:"password"`
 }
 
 type PatchStageProvider struct {
-	Config  PatchStageProviderConfig
-	Context *contexts.ManagerContext
+	Config    PatchStageProviderConfig
+	Context   *contexts.ManagerContext
+	ApiClient *utils.APIClient
 }
 
 func (s *PatchStageProvider) Init(config providers.IProviderConfig) error {
@@ -44,6 +42,7 @@ func (s *PatchStageProvider) Init(config providers.IProviderConfig) error {
 		return err
 	}
 	s.Config = mockConfig
+	s.ApiClient, err = utils.GetApiClient()
 	return nil
 }
 func (s *PatchStageProvider) SetContext(ctx *contexts.ManagerContext) {
@@ -67,27 +66,6 @@ func (i *PatchStageProvider) InitWithMap(properties map[string]string) error {
 }
 func SymphonyStageProviderConfigFromMap(properties map[string]string) (PatchStageProviderConfig, error) {
 	ret := PatchStageProviderConfig{}
-	baseUrl, err := utils.GetString(properties, "baseUrl")
-	if err != nil {
-		return ret, err
-	}
-	ret.BaseUrl = baseUrl
-	if ret.BaseUrl == "" {
-		return ret, v1alpha2.NewCOAError(nil, "baseUrl is required", v1alpha2.BadConfig)
-	}
-	user, err := utils.GetString(properties, "user")
-	if err != nil {
-		return ret, err
-	}
-	ret.User = user
-	if ret.User == "" {
-		return ret, v1alpha2.NewCOAError(nil, "user is required", v1alpha2.BadConfig)
-	}
-	password, err := utils.GetString(properties, "password")
-	if err != nil {
-		return ret, err
-	}
-	ret.Password = password
 	return ret, nil
 }
 func (m *PatchStageProvider) traceValue(v interface{}, ctx interface{}) (interface{}, error) {
@@ -168,7 +146,7 @@ func (i *PatchStageProvider) Process(ctx context.Context, mgrContext contexts.Ma
 	switch patchSource {
 	case "", "catalog":
 		if v, ok := patchContent.(string); ok {
-			catalog, err = utils.GetCatalog(ctx, i.Config.BaseUrl, v, i.Config.User, i.Config.Password, objectNamespace)
+			catalog, err = i.ApiClient.GetCatalog(ctx, v, objectNamespace)
 
 			if err != nil {
 				sLog.Errorf("  P (Patch Stage): error getting catalog %s", v)
@@ -226,7 +204,7 @@ func (i *PatchStageProvider) Process(ctx context.Context, mgrContext contexts.Ma
 	switch objectType {
 	case "solution":
 		var solution model.SolutionState
-		solution, err = utils.GetSolution(ctx, i.Config.BaseUrl, objectName, i.Config.User, i.Config.Password, objectNamespace)
+		solution, err = i.ApiClient.GetSolution(ctx, objectName, objectNamespace)
 		if err != nil {
 			sLog.Errorf("  P (Patch Stage): error getting solution %s", objectName)
 			return nil, false, err
@@ -341,7 +319,7 @@ func (i *PatchStageProvider) Process(ctx context.Context, mgrContext contexts.Ma
 		}
 		if udpated {
 			jData, _ := json.Marshal(solution)
-			err = utils.UpsertSolution(ctx, i.Config.BaseUrl, objectName, i.Config.User, i.Config.Password, jData, objectNamespace)
+			err = i.ApiClient.UpsertSolution(ctx, objectName, jData, objectNamespace)
 			if err != nil {
 				sLog.Errorf("  P (Patch Stage): error updating solution %s", objectName)
 				return nil, false, err

--- a/api/pkg/apis/v1alpha1/providers/stage/patch/patch_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/patch/patch_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	api_utils "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/utils"
 	"github.com/stretchr/testify/assert"
@@ -34,11 +35,7 @@ func TestPatchSolution(t *testing.T) {
 		t.Skip("Skipping becasue TEST_PATCH_SOLUTION is missing or not set to 'yes'")
 	}
 	provider := PatchStageProvider{}
-	err := provider.Init(PatchStageProviderConfig{
-		BaseUrl:  "http://localhost:8082/v1alpha2/",
-		User:     "admin",
-		Password: "",
-	})
+	err := provider.Init(PatchStageProviderConfig{})
 
 	provider.SetContext(&contexts.ManagerContext{
 		VencorContext: &contexts.VendorContext{
@@ -67,11 +64,7 @@ func TestPatchSolutionWholeComponent(t *testing.T) {
 		t.Skip("Skipping becasue TEST_PATCH_SOLUTION is missing or not set to 'yes'")
 	}
 	provider := PatchStageProvider{}
-	err := provider.Init(PatchStageProviderConfig{
-		BaseUrl:  "http://localhost:8082/v1alpha2/",
-		User:     "admin",
-		Password: "",
-	})
+	err := provider.Init(PatchStageProviderConfig{})
 
 	provider.SetContext(&contexts.ManagerContext{
 		VencorContext: &contexts.VendorContext{
@@ -110,52 +103,9 @@ func TestPatchSolutionWholeComponent(t *testing.T) {
 	assert.Equal(t, "OK", outputs["status"])
 }
 
-func TestPatchInitFromMap(t *testing.T) {
-	provider := PatchStageProvider{}
-	input := map[string]string{
-		"baseUrl":  "http://symphony-service:8080/v1alpha2/",
-		"user":     "admin",
-		"password": "",
-	}
-	err := provider.InitWithMap(input)
-	assert.Nil(t, err)
-	assert.Equal(t, "http://symphony-service:8080/v1alpha2/", provider.Config.BaseUrl)
-	assert.Equal(t, "admin", provider.Config.User)
-	assert.Equal(t, "", provider.Config.Password)
-
-	input = map[string]string{}
-	err = provider.InitWithMap(input)
-	assert.NotNil(t, err)
-
-	input = map[string]string{
-		"baseUrl": "",
-	}
-	err = provider.InitWithMap(input)
-	assert.NotNil(t, err)
-
-	input = map[string]string{
-		"baseUrl": "http://symphony-service:8080/v1alpha2/",
-	}
-	err = provider.InitWithMap(input)
-	assert.NotNil(t, err)
-
-	input = map[string]string{
-		"baseUrl": "http://symphony-service:8080/v1alpha2/",
-		"user":    "",
-	}
-	err = provider.InitWithMap(input)
-	assert.NotNil(t, err)
-
-	input = map[string]string{
-		"baseUrl": "http://symphony-service:8080/v1alpha2/",
-		"user":    "admin",
-	}
-	err = provider.InitWithMap(input)
-	assert.NotNil(t, err)
-}
-
 func TestPatchProcessInline(t *testing.T) {
 	ts := InitializeMockSymphonyAPI()
+	api_utils.UpdateApiClientUrl(ts.URL + "/")
 	provider := PatchStageProvider{}
 	input := map[string]string{
 		"baseUrl":  ts.URL + "/",
@@ -215,6 +165,7 @@ func TestPatchProcessInline(t *testing.T) {
 
 func TestPatchProcessCatalog(t *testing.T) {
 	ts := InitializeMockSymphonyAPI()
+	api_utils.UpdateApiClientUrl(ts.URL + "/")
 	provider := PatchStageProvider{}
 	input := map[string]string{
 		"baseUrl":  ts.URL + "/",

--- a/api/pkg/apis/v1alpha1/providers/stage/patch/patch_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/patch/patch_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/eclipse-symphony/symphony/api/constants"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	api_utils "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
@@ -101,6 +102,38 @@ func TestPatchSolutionWholeComponent(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, outputs)
 	assert.Equal(t, "OK", outputs["status"])
+}
+
+func TestPatchInitFromMap(t *testing.T) {
+	UseServiceAccountTokenEnvName := os.Getenv(constants.UseServiceAccountTokenEnvName)
+	if UseServiceAccountTokenEnvName != "false" {
+		t.Skip("Skipping becasue UseServiceAccountTokenEnvName is not false")
+	}
+	provider := PatchStageProvider{}
+	input := map[string]string{
+		"user":     "admin",
+		"password": "",
+	}
+	err := provider.InitWithMap(input)
+	assert.Nil(t, err)
+	assert.Equal(t, "admin", provider.Config.User)
+	assert.Equal(t, "", provider.Config.Password)
+
+	input = map[string]string{}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"user": "",
+	}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"user": "admin",
+	}
+	err = provider.InitWithMap(input)
+	assert.NotNil(t, err)
 }
 
 func TestPatchProcessInline(t *testing.T) {

--- a/api/pkg/apis/v1alpha1/providers/stage/patch/patch_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/patch/patch_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/eclipse-symphony/symphony/api/constants"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
-	api_utils "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/utils"
 	"github.com/stretchr/testify/assert"
@@ -138,7 +137,7 @@ func TestPatchInitFromMap(t *testing.T) {
 
 func TestPatchProcessInline(t *testing.T) {
 	ts := InitializeMockSymphonyAPI()
-	api_utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	provider := PatchStageProvider{}
 	input := map[string]string{
 		"baseUrl":  ts.URL + "/",
@@ -198,7 +197,7 @@ func TestPatchProcessInline(t *testing.T) {
 
 func TestPatchProcessCatalog(t *testing.T) {
 	ts := InitializeMockSymphonyAPI()
-	api_utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	provider := PatchStageProvider{}
 	input := map[string]string{
 		"baseUrl":  ts.URL + "/",

--- a/api/pkg/apis/v1alpha1/providers/stage/wait/wait_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/wait/wait_test.go
@@ -14,69 +14,28 @@ import (
 	"testing"
 
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestWaitInitFromVendorMap(t *testing.T) {
 	input := map[string]string{
-		"wait.baseUrl":       "http://symphony-service:8080/v1alpha2/",
-		"wait.user":          "admin",
-		"wait.password":      "",
 		"wait.wait.interval": "15",
 		"wait.wait.count":    "10",
 	}
 	config, err := WaitStageProviderConfigFromVendorMap(input)
 	assert.Nil(t, err)
-	assert.Equal(t, "http://symphony-service:8080/v1alpha2/", config.BaseUrl)
-	assert.Equal(t, "admin", config.User)
-	assert.Equal(t, "", config.Password)
 	assert.Equal(t, 15, config.WaitInterval)
 	assert.Equal(t, 10, config.WaitCount)
 
-	input = map[string]string{}
-	config, err = WaitStageProviderConfigFromVendorMap(input)
-	assert.NotNil(t, err)
-
 	input = map[string]string{
-		"wait.baseUrl": "",
-	}
-	config, err = WaitStageProviderConfigFromVendorMap(input)
-	assert.NotNil(t, err)
-
-	input = map[string]string{
-		"wait.baseUrl": "http://symphony-service:8080/v1alpha2/",
-	}
-	config, err = WaitStageProviderConfigFromVendorMap(input)
-	assert.NotNil(t, err)
-
-	input = map[string]string{
-		"wait.baseUrl": "http://symphony-service:8080/v1alpha2/",
-		"wait.user":    "",
-	}
-	config, err = WaitStageProviderConfigFromVendorMap(input)
-	assert.NotNil(t, err)
-
-	input = map[string]string{
-		"wait.baseUrl": "http://symphony-service:8080/v1alpha2/",
-		"wait.user":    "admin",
-	}
-	config, err = WaitStageProviderConfigFromVendorMap(input)
-	assert.NotNil(t, err)
-
-	input = map[string]string{
-		"wait.baseUrl":       "http://symphony-service:8080/v1alpha2/",
-		"wait.user":          "admin",
-		"wait.password":      "",
 		"wait.wait.interval": "abc",
 	}
 	config, err = WaitStageProviderConfigFromVendorMap(input)
 	assert.NotNil(t, err)
 
 	input = map[string]string{
-		"wait.baseUrl":       "http://symphony-service:8080/v1alpha2/",
-		"wait.user":          "admin",
-		"wait.password":      "",
 		"wait.wait.interval": "15",
 		"wait.wait.count":    "abc",
 	}
@@ -86,6 +45,7 @@ func TestWaitInitFromVendorMap(t *testing.T) {
 
 func TestWaitProcess(t *testing.T) {
 	ts := InitializeMockSymphonyAPI()
+	utils.UpdateApiClientUrl(ts.URL + "/")
 	config := map[string]string{
 		"baseUrl":       ts.URL + "/",
 		"user":          "admin",

--- a/api/pkg/apis/v1alpha1/providers/stage/wait/wait_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/wait/wait_test.go
@@ -11,31 +11,61 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
+	"github.com/eclipse-symphony/symphony/api/constants"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWaitInitFromVendorMap(t *testing.T) {
+func TestWaitInitFromVendorMapForNonServiceAccount(t *testing.T) {
+	UseServiceAccountTokenEnvName := os.Getenv(constants.UseServiceAccountTokenEnvName)
+	if UseServiceAccountTokenEnvName != "false" {
+		t.Skip("Skipping becasue UseServiceAccountTokenEnvName is not false")
+	}
 	input := map[string]string{
+		"wait.user":          "admin",
+		"wait.password":      "",
 		"wait.wait.interval": "15",
 		"wait.wait.count":    "10",
 	}
 	config, err := WaitStageProviderConfigFromVendorMap(input)
 	assert.Nil(t, err)
+	assert.Equal(t, "admin", config.User)
+	assert.Equal(t, "", config.Password)
 	assert.Equal(t, 15, config.WaitInterval)
 	assert.Equal(t, 10, config.WaitCount)
 
+	input = map[string]string{}
+	config, err = WaitStageProviderConfigFromVendorMap(input)
+	assert.NotNil(t, err)
+
 	input = map[string]string{
+		"wait.user": "",
+	}
+	config, err = WaitStageProviderConfigFromVendorMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"wait.user": "admin",
+	}
+	config, err = WaitStageProviderConfigFromVendorMap(input)
+	assert.NotNil(t, err)
+
+	input = map[string]string{
+		"wait.user":          "admin",
+		"wait.password":      "",
 		"wait.wait.interval": "abc",
 	}
 	config, err = WaitStageProviderConfigFromVendorMap(input)
 	assert.NotNil(t, err)
 
 	input = map[string]string{
+		"wait.user":          "admin",
+		"wait.password":      "",
 		"wait.wait.interval": "15",
 		"wait.wait.count":    "abc",
 	}

--- a/api/pkg/apis/v1alpha1/providers/stage/wait/wait_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/wait/wait_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/eclipse-symphony/symphony/api/constants"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
-	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	"github.com/stretchr/testify/assert"
 )
@@ -75,7 +74,7 @@ func TestWaitInitFromVendorMapForNonServiceAccount(t *testing.T) {
 
 func TestWaitProcess(t *testing.T) {
 	ts := InitializeMockSymphonyAPI()
-	utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	config := map[string]string{
 		"baseUrl":       ts.URL + "/",
 		"user":          "admin",

--- a/api/pkg/apis/v1alpha1/providers/target/staging/staging_test.go
+++ b/api/pkg/apis/v1alpha1/providers/target/staging/staging_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/conformance"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	"github.com/stretchr/testify/assert"
@@ -250,6 +251,7 @@ func TestApply(t *testing.T) {
 		json.NewEncoder(w).Encode(response)
 	}))
 	defer ts.Close()
+	utils.UpdateApiClientUrl(ts.URL + "/")
 	assert.Nil(t, err)
 
 	provider.Context = &contexts.ManagerContext{
@@ -349,6 +351,7 @@ func TestGet(t *testing.T) {
 		json.NewEncoder(w).Encode(response)
 	}))
 	defer ts.Close()
+	utils.UpdateApiClientUrl(ts.URL + "/")
 	assert.Nil(t, err)
 
 	provider.Context = &contexts.ManagerContext{
@@ -419,6 +422,7 @@ func TestGetCatalogsFailed(t *testing.T) {
 		json.NewEncoder(w).Encode(response)
 	}))
 	defer ts.Close()
+	utils.UpdateApiClientUrl(ts.URL + "/")
 	assert.Nil(t, err)
 
 	provider.Context = &contexts.ManagerContext{

--- a/api/pkg/apis/v1alpha1/providers/target/staging/staging_test.go
+++ b/api/pkg/apis/v1alpha1/providers/target/staging/staging_test.go
@@ -14,9 +14,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/eclipse-symphony/symphony/api/constants"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/conformance"
-	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	"github.com/stretchr/testify/assert"
@@ -213,13 +213,6 @@ type AuthResponse struct {
 }
 
 func TestApply(t *testing.T) {
-	config := StagingTargetProviderConfig{
-		Name:       "default",
-		TargetName: "target",
-	}
-	provider := StagingTargetProvider{}
-	err := provider.Init(config)
-
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var response interface{}
 		switch r.URL.Path {
@@ -251,8 +244,14 @@ func TestApply(t *testing.T) {
 		json.NewEncoder(w).Encode(response)
 	}))
 	defer ts.Close()
-	utils.UpdateApiClientUrl(ts.URL + "/")
-	assert.Nil(t, err)
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
+
+	config := StagingTargetProviderConfig{
+		Name:       "default",
+		TargetName: "target",
+	}
+	provider := StagingTargetProvider{}
+	err := provider.Init(config)
 
 	provider.Context = &contexts.ManagerContext{
 		SiteInfo: v1alpha2.SiteInfo{
@@ -310,14 +309,6 @@ func TestApply(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-
-	config := StagingTargetProviderConfig{
-		Name:       "default",
-		TargetName: "target",
-	}
-	provider := StagingTargetProvider{}
-	err := provider.Init(config)
-
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var response interface{}
 		switch r.URL.Path {
@@ -351,9 +342,14 @@ func TestGet(t *testing.T) {
 		json.NewEncoder(w).Encode(response)
 	}))
 	defer ts.Close()
-	utils.UpdateApiClientUrl(ts.URL + "/")
-	assert.Nil(t, err)
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 
+	config := StagingTargetProviderConfig{
+		Name:       "default",
+		TargetName: "target",
+	}
+	provider := StagingTargetProvider{}
+	err := provider.Init(config)
 	provider.Context = &contexts.ManagerContext{
 		SiteInfo: v1alpha2.SiteInfo{
 			CurrentSite: v1alpha2.SiteConnection{
@@ -397,13 +393,6 @@ func TestGet(t *testing.T) {
 }
 
 func TestGetCatalogsFailed(t *testing.T) {
-	config := StagingTargetProviderConfig{
-		Name:       "default",
-		TargetName: "target",
-	}
-	provider := StagingTargetProvider{}
-	err := provider.Init(config)
-
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var response interface{}
 		switch r.URL.Path {
@@ -422,7 +411,14 @@ func TestGetCatalogsFailed(t *testing.T) {
 		json.NewEncoder(w).Encode(response)
 	}))
 	defer ts.Close()
-	utils.UpdateApiClientUrl(ts.URL + "/")
+	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
+
+	config := StagingTargetProviderConfig{
+		Name:       "default",
+		TargetName: "target",
+	}
+	provider := StagingTargetProvider{}
+	err := provider.Init(config)
 	assert.Nil(t, err)
 
 	provider.Context = &contexts.ManagerContext{

--- a/api/pkg/apis/v1alpha1/utils/apiclient.go
+++ b/api/pkg/apis/v1alpha1/utils/apiclient.go
@@ -30,67 +30,68 @@ import (
 )
 
 type (
-	APIClient struct {
+	apiClient struct {
 		baseUrl       string
 		tokenProvider TokenProvider
 		client        *http.Client
 		caCertPath    string
 	}
 
-	ApiClientOption func(*APIClient)
+	ApiClientOption func(*apiClient)
 
-	TokenProvider func(ctx context.Context, baseUrl string, client *http.Client) (string, error)
+	TokenProvider func(ctx context.Context, baseUrl string, client *http.Client, user string, password string) (string, error)
 
 	SummaryGetter interface {
-		GetSummary(ctx context.Context, id string, namespace string) (*model.SummaryResult, error)
+		GetSummary(ctx context.Context, id string, namespace string, user string, password string) (*model.SummaryResult, error)
 	}
 
 	Dispatcher interface {
-		QueueJob(ctx context.Context, id string, namespace string, isDelete bool, isTarget bool) error
-		QueueDeploymentJob(ctx context.Context, namespace string, isDelete bool, deployment model.DeploymentSpec) error
+		QueueJob(ctx context.Context, id string, namespace string, isDelete bool, isTarget bool, user string, password string) error
+		QueueDeploymentJob(ctx context.Context, namespace string, isDelete bool, deployment model.DeploymentSpec, user string, password string) error
 	}
 
 	ApiClient interface {
 		SummaryGetter
 		Dispatcher
-		GetInstancesForAllNamespaces(ctx context.Context) ([]model.InstanceState, error)
-		GetInstances(ctx context.Context, namespace string) ([]model.InstanceState, error)
-		GetInstance(ctx context.Context, instance string, namespace string) (model.InstanceState, error)
-		CreateInstance(ctx context.Context, instance string, payload []byte, namespace string) error
-		DeleteInstance(ctx context.Context, instance string, namespace string) error
-		DeleteTarget(ctx context.Context, target string, namespace string) error
-		GetSolutions(ctx context.Context, namespace string) ([]model.SolutionState, error)
-		GetSolution(ctx context.Context, solution string, namespace string) (model.SolutionState, error)
-		CreateSolution(ctx context.Context, solution string, payload []byte, namespace string) error
-		DeleteSolution(ctx context.Context, solution string, namespace string) error
-		GetTargetsForAllNamespaces(ctx context.Context) ([]model.TargetState, error)
-		GetTarget(ctx context.Context, target string, namespace string) (model.TargetState, error)
-		GetTargets(ctx context.Context, namespace string) ([]model.TargetState, error)
-		CreateTarget(ctx context.Context, target string, payload []byte, namespace string) error
-		Reconcile(ctx context.Context, deployment model.DeploymentSpec, isDelete bool, namespace string) (model.SummarySpec, error)
-		CatalogHook(ctx context.Context, payload []byte) error
-		PublishActivationEvent(ctx context.Context, event v1alpha2.ActivationData) error
-		GetCatalog(ctx context.Context, catalog string, namespace string) (model.CatalogState, error)
-		UpsertCatalog(ctx context.Context, catalog string, payload []byte) error
-		DeleteCatalog(ctx context.Context, catalog string) error
-		UpsertSolution(ctx context.Context, solution string, payload []byte, namespace string) error
-		GetSites(ctx context.Context) ([]model.SiteState, error)
-		GetCatalogs(ctx context.Context, namespace string) ([]model.CatalogState, error)
-		GetCatalogsWithFilter(ctx context.Context, namespace string, filterType string, filterValue string) ([]model.CatalogState, error)
-		UpdateSite(ctx context.Context, site string, payload []byte) error
-		GetABatchForSite(ctx context.Context, site string) (model.SyncPackage, error)
-		SyncActivationStatus(ctx context.Context, status model.ActivationStatus) error
-		SendVisualizationPacket(ctx context.Context, payload []byte) error
+		GetInstancesForAllNamespaces(ctx context.Context, user string, password string) ([]model.InstanceState, error)
+		GetInstances(ctx context.Context, namespace string, user string, password string) ([]model.InstanceState, error)
+		GetInstance(ctx context.Context, instance string, namespace string, user string, password string) (model.InstanceState, error)
+		CreateInstance(ctx context.Context, instance string, payload []byte, namespace string, user string, password string) error
+		DeleteInstance(ctx context.Context, instance string, namespace string, user string, password string) error
+		DeleteTarget(ctx context.Context, target string, namespace string, user string, password string) error
+		GetSolutions(ctx context.Context, namespace string, user string, password string) ([]model.SolutionState, error)
+		GetSolution(ctx context.Context, solution string, namespace string, user string, password string) (model.SolutionState, error)
+		CreateSolution(ctx context.Context, solution string, payload []byte, namespace string, user string, password string) error
+		DeleteSolution(ctx context.Context, solution string, namespace string, user string, password string) error
+		GetTargetsForAllNamespaces(ctx context.Context, user string, password string) ([]model.TargetState, error)
+		GetTarget(ctx context.Context, target string, namespace string, user string, password string) (model.TargetState, error)
+		GetTargets(ctx context.Context, namespace string, user string, password string) ([]model.TargetState, error)
+		CreateTarget(ctx context.Context, target string, payload []byte, namespace string, user string, password string) error
+		Reconcile(ctx context.Context, deployment model.DeploymentSpec, isDelete bool, namespace string, user string, password string) (model.SummarySpec, error)
+		CatalogHook(ctx context.Context, payload []byte, user string, password string) error
+		PublishActivationEvent(ctx context.Context, event v1alpha2.ActivationData, user string, password string) error
+		GetCatalog(ctx context.Context, catalog string, namespace string, user string, password string) (model.CatalogState, error)
+		UpsertCatalog(ctx context.Context, catalog string, payload []byte, user string, password string) error
+		DeleteCatalog(ctx context.Context, catalog string, user string, password string) error
+		UpsertSolution(ctx context.Context, solution string, payload []byte, namespace string, user string, password string) error
+		GetSites(ctx context.Context, user string, password string) ([]model.SiteState, error)
+		GetCatalogs(ctx context.Context, namespace string, user string, password string) ([]model.CatalogState, error)
+		GetCatalogsWithFilter(ctx context.Context, namespace string, filterType string, filterValue string, user string, password string) ([]model.CatalogState, error)
+		UpdateSite(ctx context.Context, site string, payload []byte, user string, password string) error
+		GetABatchForSite(ctx context.Context, site string, user string, password string) (model.SyncPackage, error)
+		SyncActivationStatus(ctx context.Context, status model.ActivationStatus, user string, password string) error
+		SendVisualizationPacket(ctx context.Context, payload []byte, user string, password string) error
+		ReportCatalogs(ctx context.Context, instance string, components []model.ComponentSpec, user string, password string) error
 	}
 )
 
-func noTokenProvider(ctx context.Context, baseUrl string, client *http.Client) (string, error) {
+func noTokenProvider(ctx context.Context, baseUrl string, client *http.Client, user string, passowrd string) (string, error) {
 	return "", nil
 }
 
 func WithUserPassword(ctx context.Context, user string, password string) ApiClientOption {
-	return func(a *APIClient) {
-		a.tokenProvider = func(ctx context.Context, baseUrl string, _ *http.Client) (string, error) {
+	return func(a *apiClient) {
+		a.tokenProvider = func(ctx context.Context, baseUrl string, _ *http.Client, user string, password string) (string, error) {
 			request := authRequest{Username: user, Password: password}
 			requestData, _ := json.Marshal(request)
 			ret, err := a.callRestAPI(ctx, "users/auth", "POST", requestData, "")
@@ -110,8 +111,8 @@ func WithUserPassword(ctx context.Context, user string, password string) ApiClie
 }
 
 func WithServiceAccountToken() ApiClientOption {
-	return func(a *APIClient) {
-		a.tokenProvider = func(ctx context.Context, _ string, _ *http.Client) (string, error) {
+	return func(a *apiClient) {
+		a.tokenProvider = func(ctx context.Context, _ string, _ *http.Client, _ string, _ string) (string, error) {
 			path := os.Getenv(constants.SATokenPathName)
 			if path == "" {
 				path = constants.SATokenPath
@@ -126,12 +127,12 @@ func WithServiceAccountToken() ApiClientOption {
 }
 
 func WithCertAuth(caCertPath string) ApiClientOption {
-	return func(a *APIClient) {
+	return func(a *apiClient) {
 		a.caCertPath = caCertPath
 	}
 }
 
-func NewAPIClient(ctx context.Context, baseUrl string, opts ...ApiClientOption) (*APIClient, error) {
+func NewApiClient(ctx context.Context, baseUrl string, opts ...ApiClientOption) (*apiClient, error) {
 	rUrl, err := url.Parse(baseUrl)
 	if err != nil {
 		return nil, err
@@ -144,7 +145,7 @@ func NewAPIClient(ctx context.Context, baseUrl string, opts ...ApiClientOption) 
 		return nil, err
 	}
 
-	a := &APIClient{
+	a := &apiClient{
 		baseUrl:       baseUrl,
 		tokenProvider: noTokenProvider,
 		client:        client,
@@ -157,9 +158,9 @@ func NewAPIClient(ctx context.Context, baseUrl string, opts ...ApiClientOption) 
 	return a, nil
 }
 
-func (a *APIClient) GetInstances(ctx context.Context, namespace string) ([]model.InstanceState, error) {
+func (a *apiClient) GetInstances(ctx context.Context, namespace string, user string, password string) ([]model.InstanceState, error) {
 	ret := make([]model.InstanceState, 0)
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return ret, err
 	}
@@ -176,9 +177,9 @@ func (a *APIClient) GetInstances(ctx context.Context, namespace string) ([]model
 	return ret, nil
 }
 
-func (a *APIClient) GetInstancesForAllNamespaces(ctx context.Context) ([]model.InstanceState, error) {
+func (a *apiClient) GetInstancesForAllNamespaces(ctx context.Context, user string, password string) ([]model.InstanceState, error) {
 	ret := make([]model.InstanceState, 0)
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return ret, err
 	}
@@ -196,9 +197,9 @@ func (a *APIClient) GetInstancesForAllNamespaces(ctx context.Context) ([]model.I
 	return ret, nil
 }
 
-func (a *APIClient) GetInstance(ctx context.Context, instance string, namespace string) (model.InstanceState, error) {
+func (a *apiClient) GetInstance(ctx context.Context, instance string, namespace string, user string, password string) (model.InstanceState, error) {
 	ret := model.InstanceState{}
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 
 	if err != nil {
 		return ret, err
@@ -217,8 +218,8 @@ func (a *APIClient) GetInstance(ctx context.Context, instance string, namespace 
 	return ret, nil
 }
 
-func (a *APIClient) CreateInstance(ctx context.Context, instance string, payload []byte, namespace string) error {
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+func (a *apiClient) CreateInstance(ctx context.Context, instance string, payload []byte, namespace string, user string, password string) error {
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return err
 	}
@@ -231,8 +232,8 @@ func (a *APIClient) CreateInstance(ctx context.Context, instance string, payload
 	return nil
 }
 
-func (a *APIClient) DeleteInstance(ctx context.Context, instance string, namespace string) error {
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+func (a *apiClient) DeleteInstance(ctx context.Context, instance string, namespace string, user string, password string) error {
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return err
 	}
@@ -245,8 +246,8 @@ func (a *APIClient) DeleteInstance(ctx context.Context, instance string, namespa
 	return nil
 }
 
-func (a *APIClient) DeleteTarget(ctx context.Context, target string, namespace string) error {
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+func (a *apiClient) DeleteTarget(ctx context.Context, target string, namespace string, user string, password string) error {
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return err
 	}
@@ -259,9 +260,9 @@ func (a *APIClient) DeleteTarget(ctx context.Context, target string, namespace s
 	return nil
 }
 
-func (a *APIClient) GetSolutions(ctx context.Context, namespace string) ([]model.SolutionState, error) {
+func (a *apiClient) GetSolutions(ctx context.Context, namespace string, user string, password string) ([]model.SolutionState, error) {
 	ret := make([]model.SolutionState, 0)
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return ret, err
 	}
@@ -279,9 +280,9 @@ func (a *APIClient) GetSolutions(ctx context.Context, namespace string) ([]model
 	return ret, nil
 }
 
-func (a *APIClient) GetSolution(ctx context.Context, solution string, namespace string) (model.SolutionState, error) {
+func (a *apiClient) GetSolution(ctx context.Context, solution string, namespace string, user string, password string) (model.SolutionState, error) {
 	ret := model.SolutionState{}
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return ret, err
 	}
@@ -299,8 +300,8 @@ func (a *APIClient) GetSolution(ctx context.Context, solution string, namespace 
 	return ret, nil
 }
 
-func (a *APIClient) CreateSolution(ctx context.Context, solution string, payload []byte, namespace string) error {
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+func (a *apiClient) CreateSolution(ctx context.Context, solution string, payload []byte, namespace string, user string, password string) error {
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return err
 	}
@@ -313,8 +314,8 @@ func (a *APIClient) CreateSolution(ctx context.Context, solution string, payload
 	return nil
 }
 
-func (a *APIClient) DeleteSolution(ctx context.Context, solution string, namespace string) error {
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+func (a *apiClient) DeleteSolution(ctx context.Context, solution string, namespace string, user string, password string) error {
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return err
 	}
@@ -327,9 +328,9 @@ func (a *APIClient) DeleteSolution(ctx context.Context, solution string, namespa
 	return nil
 }
 
-func (a *APIClient) GetTarget(ctx context.Context, target string, namespace string) (model.TargetState, error) {
+func (a *apiClient) GetTarget(ctx context.Context, target string, namespace string, user string, password string) (model.TargetState, error) {
 	ret := model.TargetState{}
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return ret, err
 	}
@@ -347,9 +348,9 @@ func (a *APIClient) GetTarget(ctx context.Context, target string, namespace stri
 	return ret, nil
 }
 
-func (a *APIClient) GetTargets(ctx context.Context, namespace string) ([]model.TargetState, error) {
+func (a *apiClient) GetTargets(ctx context.Context, namespace string, user string, password string) ([]model.TargetState, error) {
 	ret := []model.TargetState{}
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return ret, err
 	}
@@ -367,9 +368,9 @@ func (a *APIClient) GetTargets(ctx context.Context, namespace string) ([]model.T
 	return ret, nil
 }
 
-func (a *APIClient) GetTargetsForAllNamespaces(ctx context.Context) ([]model.TargetState, error) {
+func (a *apiClient) GetTargetsForAllNamespaces(ctx context.Context, user string, password string) ([]model.TargetState, error) {
 	ret := []model.TargetState{}
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return ret, err
 	}
@@ -387,8 +388,8 @@ func (a *APIClient) GetTargetsForAllNamespaces(ctx context.Context) ([]model.Tar
 	return ret, nil
 }
 
-func (a *APIClient) CreateTarget(ctx context.Context, target string, payload []byte, namespace string) error {
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+func (a *apiClient) CreateTarget(ctx context.Context, target string, payload []byte, namespace string, user string, password string) error {
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return err
 	}
@@ -401,18 +402,18 @@ func (a *APIClient) CreateTarget(ctx context.Context, target string, payload []b
 	return nil
 }
 
-func (a *APIClient) GetSummary(ctx context.Context, id string, namespace string) (*model.SummaryResult, error) {
+func (a *apiClient) GetSummary(ctx context.Context, id string, namespace string, user string, password string) (*model.SummaryResult, error) {
 	result := model.SummaryResult{}
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return nil, err
 	}
 
-	log.Debugf("APIClient.GetSummary: id: %s, namespace: %s", id, namespace)
+	log.Debugf("apiClient.GetSummary: id: %s, namespace: %s", id, namespace)
 	ret, err := a.callRestAPI(ctx, "solution/queue?instance="+url.QueryEscape(id)+"&namespace="+url.QueryEscape(namespace), "GET", nil, token)
 	// callRestApi Does a weird thing where it returns nil if the status code is 404 so we'll recreate the error here
 	if err == nil && ret == nil {
-		log.Debugf("APIClient.GetSummary: Not found")
+		log.Debugf("apiClient.GetSummary: Not found")
 		return nil, v1alpha2.NewCOAError(nil, "Not found", v1alpha2.NotFound)
 	}
 
@@ -420,7 +421,7 @@ func (a *APIClient) GetSummary(ctx context.Context, id string, namespace string)
 		return nil, err
 	}
 	if ret != nil {
-		log.Debugf("APIClient.GetSummary: ret: %s", string(ret))
+		log.Debugf("apiClient.GetSummary: ret: %s", string(ret))
 		err = json.Unmarshal(ret, &result)
 		if err != nil {
 			return nil, err
@@ -429,8 +430,8 @@ func (a *APIClient) GetSummary(ctx context.Context, id string, namespace string)
 	return &result, nil
 }
 
-func (a *APIClient) QueueDeploymentJob(ctx context.Context, namespace string, isDelete bool, deployment model.DeploymentSpec) error {
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+func (a *apiClient) QueueDeploymentJob(ctx context.Context, namespace string, isDelete bool, deployment model.DeploymentSpec, user string, password string) error {
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	path := "solution/queue"
 	query := url.Values{
 		"namespace":  []string{namespace},
@@ -442,7 +443,7 @@ func (a *APIClient) QueueDeploymentJob(ctx context.Context, namespace string, is
 		return err
 	}
 	payload, err = json.Marshal(deployment)
-	log.Debugf("APIClient.QueueDeploymentJob: Deployment payload: %s", string(payload))
+	log.Debugf("apiClient.QueueDeploymentJob: Deployment payload: %s", string(payload))
 	if err != nil {
 		return err
 	}
@@ -455,8 +456,8 @@ func (a *APIClient) QueueDeploymentJob(ctx context.Context, namespace string, is
 }
 
 // Deprecated: Use QueueDeploymentJob instead
-func (a *APIClient) QueueJob(ctx context.Context, id string, namespace string, isDelete bool, isTarget bool) error {
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+func (a *apiClient) QueueJob(ctx context.Context, id string, namespace string, isDelete bool, isTarget bool, user string, password string) error {
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return err
 	}
@@ -479,7 +480,7 @@ func (a *APIClient) QueueJob(ctx context.Context, id string, namespace string, i
 	return nil
 }
 
-func (a *APIClient) Reconcile(ctx context.Context, deployment model.DeploymentSpec, isDelete bool, namespace string) (model.SummarySpec, error) {
+func (a *apiClient) Reconcile(ctx context.Context, deployment model.DeploymentSpec, isDelete bool, namespace string, user string, password string) (model.SummarySpec, error) {
 	summary := model.SummarySpec{}
 	payload, _ := json.Marshal(deployment)
 
@@ -487,7 +488,7 @@ func (a *APIClient) Reconcile(ctx context.Context, deployment model.DeploymentSp
 	if isDelete {
 		path = path + "&delete=true"
 	}
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return summary, err
 	}
@@ -504,8 +505,8 @@ func (a *APIClient) Reconcile(ctx context.Context, deployment model.DeploymentSp
 	return summary, nil
 }
 
-func (a *APIClient) CatalogHook(ctx context.Context, payload []byte) error {
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+func (a *apiClient) CatalogHook(ctx context.Context, payload []byte, user string, password string) error {
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return err
 	}
@@ -517,8 +518,8 @@ func (a *APIClient) CatalogHook(ctx context.Context, payload []byte) error {
 	return nil
 }
 
-func (a *APIClient) PublishActivationEvent(ctx context.Context, event v1alpha2.ActivationData) error {
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+func (a *apiClient) PublishActivationEvent(ctx context.Context, event v1alpha2.ActivationData, user string, password string) error {
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 
 	if err != nil {
 		return err
@@ -532,9 +533,9 @@ func (a *APIClient) PublishActivationEvent(ctx context.Context, event v1alpha2.A
 	return nil
 }
 
-func (a *APIClient) GetCatalog(ctx context.Context, catalog string, namespace string) (model.CatalogState, error) {
+func (a *apiClient) GetCatalog(ctx context.Context, catalog string, namespace string, user string, password string) (model.CatalogState, error) {
 	ret := model.CatalogState{}
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 
 	if err != nil {
 		return ret, err
@@ -561,9 +562,9 @@ func (a *APIClient) GetCatalog(ctx context.Context, catalog string, namespace st
 	return ret, nil
 }
 
-func (a *APIClient) GetCatalogsWithFilter(ctx context.Context, namespace string, filterType string, filterValue string) ([]model.CatalogState, error) {
+func (a *apiClient) GetCatalogsWithFilter(ctx context.Context, namespace string, filterType string, filterValue string, user string, password string) ([]model.CatalogState, error) {
 	ret := make([]model.CatalogState, 0)
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return ret, err
 	}
@@ -586,12 +587,12 @@ func (a *APIClient) GetCatalogsWithFilter(ctx context.Context, namespace string,
 	}
 	return ret, nil
 }
-func (a *APIClient) GetCatalogs(ctx context.Context, namespace string) ([]model.CatalogState, error) {
-	return a.GetCatalogsWithFilter(ctx, namespace, "", "")
+func (a *apiClient) GetCatalogs(ctx context.Context, namespace string, user string, password string) ([]model.CatalogState, error) {
+	return a.GetCatalogsWithFilter(ctx, namespace, "", "", user, password)
 }
 
-func (a *APIClient) UpsertCatalog(ctx context.Context, catalog string, payload []byte) error {
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+func (a *apiClient) UpsertCatalog(ctx context.Context, catalog string, payload []byte, user string, password string) error {
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return err
 	}
@@ -603,8 +604,8 @@ func (a *APIClient) UpsertCatalog(ctx context.Context, catalog string, payload [
 	return nil
 }
 
-func (a *APIClient) DeleteCatalog(ctx context.Context, catalog string) error {
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+func (a *apiClient) DeleteCatalog(ctx context.Context, catalog string, user string, password string) error {
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return err
 	}
@@ -616,8 +617,8 @@ func (a *APIClient) DeleteCatalog(ctx context.Context, catalog string) error {
 	return nil
 }
 
-func (a *APIClient) ReportCatalogs(ctx context.Context, instance string, components []model.ComponentSpec) error {
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+func (a *apiClient) ReportCatalogs(ctx context.Context, instance string, components []model.ComponentSpec, user string, password string) error {
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return err
 	}
@@ -630,8 +631,8 @@ func (a *APIClient) ReportCatalogs(ctx context.Context, instance string, compone
 	return nil
 }
 
-func (a *APIClient) UpsertSolution(ctx context.Context, solution string, payload []byte, namespace string) error {
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+func (a *apiClient) UpsertSolution(ctx context.Context, solution string, payload []byte, namespace string, user string, password string) error {
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return err
 	}
@@ -644,9 +645,9 @@ func (a *APIClient) UpsertSolution(ctx context.Context, solution string, payload
 	return nil
 }
 
-func (a *APIClient) GetSites(ctx context.Context) ([]model.SiteState, error) {
+func (a *apiClient) GetSites(ctx context.Context, user string, password string) ([]model.SiteState, error) {
 	ret := make([]model.SiteState, 0)
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return ret, err
 	}
@@ -664,8 +665,8 @@ func (a *APIClient) GetSites(ctx context.Context) ([]model.SiteState, error) {
 	return ret, nil
 }
 
-func (a *APIClient) UpdateSite(ctx context.Context, site string, payload []byte) error {
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+func (a *apiClient) UpdateSite(ctx context.Context, site string, payload []byte, user string, password string) error {
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return err
 	}
@@ -678,9 +679,9 @@ func (a *APIClient) UpdateSite(ctx context.Context, site string, payload []byte)
 	return nil
 }
 
-func (a *APIClient) GetABatchForSite(ctx context.Context, site string) (model.SyncPackage, error) {
+func (a *apiClient) GetABatchForSite(ctx context.Context, site string, user string, password string) (model.SyncPackage, error) {
 	ret := model.SyncPackage{}
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 
 	if err != nil {
 		return ret, err
@@ -698,8 +699,8 @@ func (a *APIClient) GetABatchForSite(ctx context.Context, site string) (model.Sy
 	return ret, nil
 }
 
-func (a *APIClient) SyncActivationStatus(ctx context.Context, status model.ActivationStatus) error {
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+func (a *apiClient) SyncActivationStatus(ctx context.Context, status model.ActivationStatus, user string, password string) error {
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 
 	if err != nil {
 		return err
@@ -713,8 +714,8 @@ func (a *APIClient) SyncActivationStatus(ctx context.Context, status model.Activ
 	return nil
 }
 
-func (a *APIClient) SendVisualizationPacket(ctx context.Context, payload []byte) error {
-	token, err := a.tokenProvider(ctx, a.baseUrl, a.client)
+func (a *apiClient) SendVisualizationPacket(ctx context.Context, payload []byte, user string, password string) error {
+	token, err := a.tokenProvider(ctx, a.baseUrl, a.client, user, password)
 	if err != nil {
 		return err
 	}
@@ -725,7 +726,7 @@ func (a *APIClient) SendVisualizationPacket(ctx context.Context, payload []byte)
 	return nil
 }
 
-func (a *APIClient) callRestAPI(ctx context.Context, route string, method string, payload []byte, token string) ([]byte, error) {
+func (a *apiClient) callRestAPI(ctx context.Context, route string, method string, payload []byte, token string) ([]byte, error) {
 	urlString := fmt.Sprintf("%s%s", a.baseUrl, path.Clean(route))
 	ctx, span := observability.StartSpan("Symphony-API-Client", ctx, &map[string]string{
 		"method":      "callRestAPI",

--- a/api/pkg/apis/v1alpha1/utils/symphony-api.go
+++ b/api/pkg/apis/v1alpha1/utils/symphony-api.go
@@ -107,7 +107,7 @@ func getApiClient() (*apiClient, error) {
 	return client, nil
 }
 
-func GetUPApiClient(baseUrl string) (*apiClient, error) {
+func GetParentApiClient(baseUrl string) (*apiClient, error) {
 	clientOptions := make([]ApiClientOption, 0)
 
 	if caCert, ok := os.LookupEnv(constants.ApiCertEnvName); ok {

--- a/api/pkg/apis/v1alpha1/utils/symphony-api.go
+++ b/api/pkg/apis/v1alpha1/utils/symphony-api.go
@@ -69,30 +69,27 @@ func GetSymphonyAPIAddressBase() string {
 }
 
 var getApiClientOnce sync.Once
-var apiClient *APIClient
-var err error
+var symphonyApiClient *apiClient
+var apiClientError error
 
-func GetApiClient() (*APIClient, error) {
+func GetApiClient() (*apiClient, error) {
 	getApiClientOnce.Do(func() {
-		apiClient, err = getApiClient()
+		symphonyApiClient, apiClientError = getApiClient()
 	})
-	return apiClient, err
+	return symphonyApiClient, apiClientError
 }
 
 // For testing purpose only
 func UpdateApiClientUrl(url string) {
-	if apiClient == nil {
+	if symphonyApiClient == nil {
 		GetApiClient()
 	}
-	apiClient.baseUrl = url
+	symphonyApiClient.baseUrl = url
 }
 
-func getApiClient() (*APIClient, error) {
+func getApiClient() (*apiClient, error) {
 	clientOptions := make([]ApiClientOption, 0)
 	baseUrl := GetSymphonyAPIAddressBase()
-	if err != nil {
-		return nil, err
-	}
 	if caCert, ok := os.LookupEnv(constants.ApiCertEnvName); ok {
 		clientOptions = append(clientOptions, WithCertAuth(caCert))
 	}
@@ -100,32 +97,25 @@ func getApiClient() (*APIClient, error) {
 	if ShouldUseSATokens() {
 		clientOptions = append(clientOptions, WithServiceAccountToken())
 	} else {
-		user := "admin"
-		password := ""
-		clientOptions = append(clientOptions, WithUserPassword(context.TODO(), user, password))
+		clientOptions = append(clientOptions, WithUserPassword(context.TODO(), "", ""))
 	}
 
-	client, err := NewAPIClient(context.Background(), baseUrl, clientOptions...)
+	client, err := NewApiClient(context.Background(), baseUrl, clientOptions...)
 	if err != nil {
 		return nil, err
 	}
 	return client, nil
 }
 
-func GetUPApiClient(baseUrl string) (*APIClient, error) {
+func GetUPApiClient(baseUrl string) (*apiClient, error) {
 	clientOptions := make([]ApiClientOption, 0)
-	if err != nil {
-		return nil, err
-	}
+
 	if caCert, ok := os.LookupEnv(constants.ApiCertEnvName); ok {
 		clientOptions = append(clientOptions, WithCertAuth(caCert))
 	}
 
-	user := "admin"
-	password := ""
-
-	clientOptions = append(clientOptions, WithUserPassword(context.TODO(), user, password))
-	client, err := NewAPIClient(context.Background(), baseUrl, clientOptions...)
+	clientOptions = append(clientOptions, WithUserPassword(context.TODO(), "", ""))
+	client, err := NewApiClient(context.Background(), baseUrl, clientOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -134,6 +124,10 @@ func GetUPApiClient(baseUrl string) (*APIClient, error) {
 
 func ShouldUseSATokens() bool {
 	return useSAToken == "true"
+}
+
+func ShouldUseUserCreds() bool {
+	return useSAToken == "false"
 }
 
 var log = logger.NewLogger("coa.runtime")

--- a/api/pkg/apis/v1alpha1/utils/symphony-api.go
+++ b/api/pkg/apis/v1alpha1/utils/symphony-api.go
@@ -75,19 +75,14 @@ func GetApiClient() (*apiClient, error) {
 		client, ok := value.(*apiClient)
 		if !ok {
 			log.Infof("Symphony base url apiclient is broken. Recreating it.")
-			client, err := getApiClient()
-			if err != nil {
-				log.Errorf("Failed to recreate the apiclient. %s\n", err.Error())
-				return nil, err
-			}
-			symphonyApiClients.Store(symphonyBaseUrl, client)
+		} else {
+			return client, nil
 		}
-		return client, nil
 	}
 	log.Infof("Creating the symphony base url apiclient.")
 	client, err := getApiClient()
 	if err != nil {
-		log.Errorf("Failed to create the apiclient. %s\n", err.Error())
+		log.Errorf("Failed to create the apiclient: %+v", err.Error())
 		return nil, err
 	}
 	symphonyApiClients.Store(symphonyBaseUrl, client)

--- a/api/pkg/apis/v1alpha1/utils/symphony-api_test.go
+++ b/api/pkg/apis/v1alpha1/utils/symphony-api_test.go
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	testApiClient ApiClient = &apiClient{
+	testApiClient ApiClient = &APIClient{
 		baseUrl: baseUrl,
 	}
 )

--- a/api/pkg/apis/v1alpha1/utils/symphony-api_test.go
+++ b/api/pkg/apis/v1alpha1/utils/symphony-api_test.go
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	testApiClient ApiClient = &APIClient{
+	testApiClient ApiClient = &apiClient{
 		baseUrl: baseUrl,
 	}
 )
@@ -52,7 +52,7 @@ func TestGetInstancesWhenSomeInstances(t *testing.T) {
 		panic(err)
 	}
 
-	err = testApiClient.CreateSolution(context.Background(), solutionName, solution1, "default")
+	err = testApiClient.CreateSolution(context.Background(), solutionName, solution1, "default", user, password)
 	require.NoError(t, err)
 
 	targetName := "target1"
@@ -157,7 +157,7 @@ func TestGetInstancesWhenSomeInstances(t *testing.T) {
 	target1, err := json.Marshal(target1JsonObj)
 	require.NoError(t, err)
 
-	err = testApiClient.CreateTarget(context.Background(), targetName, target1, "default")
+	err = testApiClient.CreateTarget(context.Background(), targetName, target1, "default", user, password)
 	require.NoError(t, err)
 
 	instanceName := "instance1"
@@ -174,13 +174,13 @@ func TestGetInstancesWhenSomeInstances(t *testing.T) {
 		panic(err)
 	}
 
-	err = testApiClient.CreateInstance(context.Background(), instanceName, instance1, "default")
+	err = testApiClient.CreateInstance(context.Background(), instanceName, instance1, "default", user, password)
 	require.NoError(t, err)
 
 	// ensure instance gets created properly
 	time.Sleep(time.Second)
 
-	instancesRes, err := testApiClient.GetInstances(context.Background(), "default")
+	instancesRes, err := testApiClient.GetInstances(context.Background(), "default", user, password)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(instancesRes))
@@ -190,7 +190,7 @@ func TestGetInstancesWhenSomeInstances(t *testing.T) {
 	require.Equal(t, "1", instancesRes[0].Status.Properties["targets"])
 	require.Equal(t, "OK", instancesRes[0].Status.Properties["status"])
 
-	instanceRes, err := testApiClient.GetInstance(context.Background(), instanceName, "default")
+	instanceRes, err := testApiClient.GetInstance(context.Background(), instanceName, "default", user, password)
 	require.NoError(t, err)
 
 	require.Equal(t, instanceName, instanceRes.Spec.DisplayName)
@@ -199,13 +199,13 @@ func TestGetInstancesWhenSomeInstances(t *testing.T) {
 	require.Equal(t, "1", instanceRes.Status.Properties["targets"])
 	require.Equal(t, "OK", instanceRes.Status.Properties["status"])
 
-	err = testApiClient.DeleteTarget(context.Background(), targetName, "default")
+	err = testApiClient.DeleteTarget(context.Background(), targetName, "default", user, password)
 	require.NoError(t, err)
 
-	err = testApiClient.DeleteSolution(context.Background(), solutionName, "default")
+	err = testApiClient.DeleteSolution(context.Background(), solutionName, "default", user, password)
 	require.NoError(t, err)
 
-	err = testApiClient.DeleteInstance(context.Background(), instanceName, "default")
+	err = testApiClient.DeleteInstance(context.Background(), instanceName, "default", user, password)
 	require.NoError(t, err)
 }
 
@@ -232,21 +232,21 @@ func TestGetSolutionsWhenSomeSolution(t *testing.T) {
 		panic(err)
 	}
 
-	err = testApiClient.CreateSolution(context.Background(), solutionName, solution1, "default")
+	err = testApiClient.CreateSolution(context.Background(), solutionName, solution1, "default", user, password)
 	require.NoError(t, err)
 
-	solutionsRes, err := testApiClient.GetSolutions(context.Background(), "default")
+	solutionsRes, err := testApiClient.GetSolutions(context.Background(), "default", user, password)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(solutionsRes))
 	require.Equal(t, solutionName, solutionsRes[0].Spec.DisplayName)
 
-	solutionRes, err := testApiClient.GetSolution(context.Background(), solutionName, "default")
+	solutionRes, err := testApiClient.GetSolution(context.Background(), solutionName, "default", user, password)
 	require.NoError(t, err)
 
 	require.Equal(t, solutionName, solutionRes.Spec.DisplayName)
 
-	err = testApiClient.DeleteSolution(context.Background(), solutionName, "default")
+	err = testApiClient.DeleteSolution(context.Background(), solutionName, "default", user, password)
 	require.NoError(t, err)
 }
 
@@ -358,13 +358,13 @@ func TestGetTargetsWithSomeTargets(t *testing.T) {
 	target1, err := json.Marshal(target1JsonObj)
 	require.NoError(t, err)
 
-	err = testApiClient.CreateTarget(context.Background(), targetName, target1, "default")
+	err = testApiClient.CreateTarget(context.Background(), targetName, target1, "default", user, password)
 	require.NoError(t, err)
 
 	// Ensure target gets created properly
 	time.Sleep(time.Second)
 
-	targetsRes, err := testApiClient.GetTargets(context.Background(), "default")
+	targetsRes, err := testApiClient.GetTargets(context.Background(), "default", user, password)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(targetsRes))
@@ -373,7 +373,7 @@ func TestGetTargetsWithSomeTargets(t *testing.T) {
 	require.Equal(t, "1", targetsRes[0].Status.Properties["targets"])
 	require.Equal(t, "OK", targetsRes[0].Status.Properties["status"])
 
-	targetRes, err := testApiClient.GetTarget(context.Background(), targetName, "default")
+	targetRes, err := testApiClient.GetTarget(context.Background(), targetName, "default", user, password)
 	require.NoError(t, err)
 
 	require.Equal(t, targetName, targetRes.Spec.DisplayName)
@@ -381,7 +381,7 @@ func TestGetTargetsWithSomeTargets(t *testing.T) {
 	require.Equal(t, "1", targetRes.Status.Properties["targets"])
 	require.Equal(t, "OK", targetRes.Status.Properties["status"])
 
-	err = testApiClient.DeleteTarget(context.Background(), targetName, "default")
+	err = testApiClient.DeleteTarget(context.Background(), targetName, "default", user, password)
 	require.NoError(t, err)
 }
 

--- a/api/pkg/apis/v1alpha1/vendors/federation-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/federation-vendor.go
@@ -38,7 +38,7 @@ type FederationVendor struct {
 	StagingManager  *staging.StagingManager
 	SyncManager     *sync.SyncManager
 	TrailsManager   *trails.TrailsManager
-	apiClient       *utils.APIClient
+	apiClient       utils.ApiClient
 }
 
 func (f *FederationVendor) GetInfo() vendors.VendorInfo {
@@ -108,7 +108,9 @@ func (f *FederationVendor) Init(config vendors.VendorConfig, factories []manager
 		var status model.ActivationStatus
 		err := json.Unmarshal(jData, &status)
 		if err == nil {
-			err := f.apiClient.SyncActivationStatus(context.TODO(), status)
+			err := f.apiClient.SyncActivationStatus(context.TODO(), status,
+				f.Vendor.Context.SiteInfo.ParentSite.Username,
+				f.Vendor.Context.SiteInfo.ParentSite.Password)
 			if err != nil {
 				fLog.Errorf("V (Federation): error while syncing activation status: %v", err)
 				return err

--- a/api/pkg/apis/v1alpha1/vendors/federation-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/federation-vendor.go
@@ -79,8 +79,10 @@ func (f *FederationVendor) Init(config vendors.VendorConfig, factories []manager
 	if f.CatalogsManager == nil {
 		return v1alpha2.NewCOAError(nil, "catalogs manager is not supplied", v1alpha2.MissingConfig)
 	}
-	f.apiClient, err = utils.GetUPApiClient(f.Vendor.Context.SiteInfo.ParentSite.BaseUrl)
-
+	f.apiClient, err = utils.GetParentApiClient(f.Vendor.Context.SiteInfo.ParentSite.BaseUrl)
+	if err != nil {
+		return err
+	}
 	f.Vendor.Context.Subscribe("catalog", func(topic string, event v1alpha2.Event) error {
 		sites, err := f.SitesManager.ListState(context.TODO())
 		if err != nil {

--- a/api/pkg/apis/v1alpha1/vendors/visualization-client-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/visualization-client-vendor.go
@@ -26,7 +26,7 @@ var cvLog = logger.NewLogger("coa.runtime")
 
 type VisualizationClientVendor struct {
 	vendors.Vendor
-	apiClient *utils.APIClient
+	apiClient utils.ApiClient
 }
 
 func (s *VisualizationClientVendor) GetInfo() vendors.VendorInfo {
@@ -43,6 +43,9 @@ func (e *VisualizationClientVendor) Init(config vendors.VendorConfig, factories 
 		return err
 	}
 	e.apiClient, err = utils.GetApiClient()
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -90,7 +93,9 @@ func (c *VisualizationClientVendor) onVisClient(request v1alpha2.COARequest) v1a
 		}
 
 		jData, _ := json.Marshal(packet)
-		err = c.apiClient.SendVisualizationPacket(ctx, jData)
+		err = c.apiClient.SendVisualizationPacket(ctx, jData,
+			c.Vendor.Context.SiteInfo.CurrentSite.Username,
+			c.Vendor.Context.SiteInfo.CurrentSite.Password)
 
 		if err != nil {
 			cvLog.Errorf("V (VisualizationClient): onVisClient failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())

--- a/api/pkg/apis/v1alpha1/vendors/visualization-client-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/visualization-client-vendor.go
@@ -26,6 +26,7 @@ var cvLog = logger.NewLogger("coa.runtime")
 
 type VisualizationClientVendor struct {
 	vendors.Vendor
+	apiClient *utils.APIClient
 }
 
 func (s *VisualizationClientVendor) GetInfo() vendors.VendorInfo {
@@ -41,6 +42,7 @@ func (e *VisualizationClientVendor) Init(config vendors.VendorConfig, factories 
 	if err != nil {
 		return err
 	}
+	e.apiClient, err = utils.GetApiClient()
 	return nil
 }
 
@@ -88,11 +90,7 @@ func (c *VisualizationClientVendor) onVisClient(request v1alpha2.COARequest) v1a
 		}
 
 		jData, _ := json.Marshal(packet)
-		err = utils.SendVisualizationPacket(ctx,
-			c.Vendor.Context.SiteInfo.CurrentSite.BaseUrl,
-			c.Vendor.Context.SiteInfo.CurrentSite.Username,
-			c.Vendor.Context.SiteInfo.CurrentSite.Password,
-			jData)
+		err = c.apiClient.SendVisualizationPacket(ctx, jData)
 
 		if err != nil {
 			cvLog.Errorf("V (VisualizationClient): onVisClient failed - %s, traceId: %s", err.Error(), span.SpanContext().TraceID().String())

--- a/api/symphony-api-no-k8s.json
+++ b/api/symphony-api-no-k8s.json
@@ -39,7 +39,6 @@
               "catalog": {
                 "type": "providers.config.catalog",
                 "config": {
-                  "baseUrl": "http://localhost:8082/v1alpha2/",
                   "user": "admin",
                   "password": ""
                 }
@@ -56,7 +55,6 @@
             "name": "stage-manager",
             "type": "managers.symphony.stage",
             "properties": {   
-              "baseUrl": "http://localhost:8082/v1alpha2/",
               "user": "admin",
               "password": "",
               "providers.state": "k8s-state"        
@@ -98,7 +96,6 @@
           }
         ],
         "properties": {
-          "wait.baseUrl": "http://localhost:8082/v1alpha2/",
           "wait.user": "admin",
           "wait.password": "",
           "wait.wait.interval": "15",
@@ -182,7 +179,6 @@
             "type": "managers.symphony.jobs",
             "properties": {
               "providers.state": "mem-state",
-              "baseUrl": "http://localhost:8082/v1alpha2/",
               "user": "admin",
               "password": "",
               "interval": "#15",
@@ -397,15 +393,11 @@
               },
               "http-reference": {
                 "type": "providers.reference.http",
-                "config": {
-                  "url": "http://localhost:8082/v1alpha2/"
-                }
+                "config": {}
               },
               "http-reporter": {
                 "type": "providers.reporter.http",
-                "config": {
-                  "url": "http://localhost:8082/v1alpha2/"
-                }
+                "config": {}
               }
             }
           }

--- a/coa/pkg/apis/v1alpha2/bindings/http/http_test.go
+++ b/coa/pkg/apis/v1alpha2/bindings/http/http_test.go
@@ -309,7 +309,7 @@ func TestHTTPEchoWithPipeline(t *testing.T) {
 						ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)),
 						IssuedAt:  jwt.NewNumericDate(time.Now()),
 						NotBefore: jwt.NewNumericDate(time.Now()),
-						Issuer:    "test",
+						Issuer:    "symphony",
 						Subject:   "test",
 						ID:        "1",
 						Audience:  []string{"*"},

--- a/coa/pkg/apis/v1alpha2/bindings/http/jwt.go
+++ b/coa/pkg/apis/v1alpha2/bindings/http/jwt.go
@@ -41,6 +41,7 @@ type AuthServer string
 const (
 	// AuthServerKuberenetes means we are using kubernetes api server as auth server
 	AuthServerKuberenetes AuthServer = "kubernetes"
+	SymphonyIssuer        string     = "symphony"
 )
 
 var (
@@ -92,17 +93,14 @@ func (j JWT) JWT(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 			log.Errorf("JWT: Token is empty.\n")
 			ctx.Response.SetStatusCode(fasthttp.StatusForbidden)
 		} else {
-			if j.AuthServer == AuthServerKuberenetes {
-				log.Debugf("JWT: Validating token with k8s.\n")
-				err := j.validateServiceAccountToken(ctx, tokenStr)
-				if err != nil {
-					log.Errorf("JWT: Validate token with k8s failed. %s\n", err.Error())
-					ctx.Response.SetStatusCode(fasthttp.StatusForbidden)
-					return
-				}
-				next(ctx)
-			} else {
-				log.Debugf("JWT: Validating token with username plus pwd.\n")
+			issuer, err := decodeJWTTokenForIssuer(tokenStr)
+			if err != nil {
+				log.Errorf("JWT: Could not decode issuer from token. %s\n", err.Error())
+				ctx.Response.SetStatusCode(fasthttp.StatusForbidden)
+				return
+			}
+			if issuer == SymphonyIssuer {
+				log.Debugf("JWT: Validating token with username plus pwd.")
 				_, roles, err := j.validateToken(tokenStr)
 				if err != nil {
 					log.Error("JWT: Validate token with user creds failed. %s\n", err.Error())
@@ -128,6 +126,21 @@ func (j JWT) JWT(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 						return
 					}
 					next(ctx)
+				}
+			} else {
+				if j.AuthServer == AuthServerKuberenetes {
+					log.Debugf("JWT: Validating token with k8s.")
+					err := j.validateServiceAccountToken(ctx, tokenStr)
+					if err != nil {
+						log.Errorf("JWT: Validate token with k8s failed. %s\n", err.Error())
+						ctx.Response.SetStatusCode(fasthttp.StatusForbidden)
+						return
+					}
+					next(ctx)
+				} else {
+					log.Errorf("JWT: Not supported auth server, %s.\n", j.AuthServer)
+					ctx.Response.SetStatusCode(fasthttp.StatusForbidden)
+					return
 				}
 			}
 		}
@@ -210,6 +223,27 @@ func (j *JWT) validateToken(tokenStr string) (map[string]interface{}, []string, 
 	}
 	return ret, roles, nil
 }
+
+func decodeJWTTokenForIssuer(tokenString string) (string, error) {
+	token, _, err := new(jwt.Parser).ParseUnverified(tokenString, jwt.MapClaims{})
+	if err != nil {
+		return "", err
+	}
+
+	if claims, ok := token.Claims.(jwt.MapClaims); ok {
+		issuer, ok := claims["iss"].(string)
+		if !ok {
+			fmt.Println("The iss claim is not a string")
+			return "", errors.New("the iss claim is not a string")
+		}
+		fmt.Println("Issuer:", issuer)
+		return issuer, nil
+	} else {
+		fmt.Println("Invalid token")
+		return "", errors.New("invalid token")
+	}
+}
+
 func (j *JWT) validateServiceAccountToken(ctx *fasthttp.RequestCtx, tokenStr string) error {
 	clientset, err := getKubernetesClient()
 	if err != nil {

--- a/coa/pkg/apis/v1alpha2/bindings/http/jwt.go
+++ b/coa/pkg/apis/v1alpha2/bindings/http/jwt.go
@@ -233,13 +233,13 @@ func decodeJWTTokenForIssuer(tokenString string) (string, error) {
 	if claims, ok := token.Claims.(jwt.MapClaims); ok {
 		issuer, ok := claims["iss"].(string)
 		if !ok {
-			fmt.Println("The iss claim is not a string")
+			log.Debugf("The iss claim is not a string")
 			return "", errors.New("the iss claim is not a string")
 		}
-		fmt.Println("Issuer:", issuer)
+		log.Debugf("Issuer: %s", issuer)
 		return issuer, nil
 	} else {
-		fmt.Println("Invalid token")
+		log.Debugf("Invalid token")
 		return "", errors.New("invalid token")
 	}
 }

--- a/docs/symphony-book/build_deployment/symphony_mode.md
+++ b/docs/symphony-book/build_deployment/symphony_mode.md
@@ -50,7 +50,7 @@ And under standalone mode, the reconciliation policy is not configured on indivi
 Symphony runs as a single process in standalone mode. To launch Symphony in standalone mode, simply launch the `symphony-api` binary with a configuration file and an optional tracing level switch (such as `Error`, `Info` and `Debug`):
 
 ```bash
-./symphony-api -c ~/symphony-api-no-k8s.json -l Debug
+SYMPHONY_API_URL="http://localhost:8082/v1alpha2/" USE_SERVICE_ACCOUNT_TOKENS="false"  ./bin/symphony-api -c symphony-api-no-k8s.json -l Debug
 ```
 
 Once launched, you can access Symphony's [REST API](../api/_overview.md) using any web clients.

--- a/k8s/controllers/federation/catalog_controller.go
+++ b/k8s/controllers/federation/catalog_controller.go
@@ -51,7 +51,7 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	if catalog.ObjectMeta.DeletionTimestamp.IsZero() { // update
 		jData, _ := json.Marshal(catalog)
-		err := r.ApiClient.CatalogHook(ctx, jData)
+		err := r.ApiClient.CatalogHook(ctx, jData, "", "")
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/k8s/controllers/federation/catalog_controller.go
+++ b/k8s/controllers/federation/catalog_controller.go
@@ -17,13 +17,15 @@ import (
 
 	federationv1 "gopls-workspace/apis/federation/v1"
 
-	api_utils "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 )
 
 // CatalogReconciler reconciles a Site object
 type CatalogReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+	// ApiClient is the client for Symphony API
+	ApiClient utils.ApiClient
 }
 
 //+kubebuilder:rbac:groups=federation.symphony,resources=catalogs,verbs=get;list;watch;create;update;patch;delete
@@ -49,7 +51,7 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	if catalog.ObjectMeta.DeletionTimestamp.IsZero() { // update
 		jData, _ := json.Marshal(catalog)
-		err := api_utils.CatalogHook(ctx, "http://symphony-service:8080/v1alpha2/", "admin", "", jData)
+		err := r.ApiClient.CatalogHook(ctx, jData)
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/k8s/controllers/workflow/activation_controller.go
+++ b/k8s/controllers/workflow/activation_controller.go
@@ -19,14 +19,15 @@ import (
 
 	workflowv1 "gopls-workspace/apis/workflow/v1"
 
-	api_utils "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // ActivationReconciler reconciles a Campaign object
 type ActivationReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme    *runtime.Scheme
+	ApiClient utils.ApiClient
 }
 
 //+kubebuilder:rbac:groups=workflow.symphony,resources=activations,verbs=get;list;watch;create;update;patch;delete
@@ -59,7 +60,7 @@ func (r *ActivationReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if activation.ObjectMeta.DeletionTimestamp.IsZero() {
 		log.Info(fmt.Sprintf("Activation status: %v", activation.Status.Status))
 		if !activation.Status.IsActive && activation.Status.Status != v1alpha2.Paused && activation.Status.Status != v1alpha2.Done && activation.Status.ActivationGeneration == "" {
-			err := api_utils.PublishActivationEvent(ctx, "http://symphony-service:8080/v1alpha2/", "admin", "", v1alpha2.ActivationData{
+			err := r.ApiClient.PublishActivationEvent(ctx, v1alpha2.ActivationData{
 				Campaign:             activation.Spec.Campaign,
 				Activation:           activation.Name,
 				ActivationGeneration: strconv.FormatInt(activation.Generation, 10),

--- a/k8s/controllers/workflow/activation_controller.go
+++ b/k8s/controllers/workflow/activation_controller.go
@@ -67,7 +67,7 @@ func (r *ActivationReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				Stage:                "",
 				Inputs:               convertRawExtensionToMap(&activation.Spec.Inputs),
 				Namespace:            activation.Namespace,
-			})
+			}, "", "")
 			if err != nil {
 				return ctrl.Result{}, err
 			}

--- a/k8s/main.go
+++ b/k8s/main.go
@@ -195,8 +195,9 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&workflowcontrollers.ActivationReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		ApiClient: apiClient,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Activation")
 		os.Exit(1)
@@ -261,8 +262,9 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&federationcontrollers.CatalogReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		ApiClient: apiClient,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Catalog")
 		os.Exit(1)

--- a/k8s/main.go
+++ b/k8s/main.go
@@ -146,7 +146,7 @@ func main() {
 		apiClientOptions = append(apiClientOptions, utils.WithUserPassword(ctx, "admin", ""))
 	}
 
-	apiClient, err := utils.NewAPIClient(
+	apiClient, err := utils.NewApiClient(
 		ctx,
 		utils.GetSymphonyAPIAddressBase(),
 		apiClientOptions...,

--- a/k8s/reconcilers/deployment.go
+++ b/k8s/reconcilers/deployment.go
@@ -440,7 +440,7 @@ func (r *DeploymentReconciler) queueDeploymentJob(ctx context.Context, object Re
 	}
 
 	// Send the deployment object to the api to queue a job
-	err = r.apiClient.QueueDeploymentJob(ctx, object.GetNamespace(), isRemoval, *deployment)
+	err = r.apiClient.QueueDeploymentJob(ctx, object.GetNamespace(), isRemoval, *deployment, "", "")
 	if err != nil {
 		return err
 	}
@@ -448,7 +448,7 @@ func (r *DeploymentReconciler) queueDeploymentJob(ctx context.Context, object Re
 }
 
 func (r *DeploymentReconciler) getDeploymentSummary(ctx context.Context, object Reconcilable) (*model.SummaryResult, error) {
-	return r.apiClient.GetSummary(ctx, r.deploymentKeyResolver(object), object.GetNamespace())
+	return r.apiClient.GetSummary(ctx, r.deploymentKeyResolver(object), object.GetNamespace(), "", "")
 }
 
 func (r *DeploymentReconciler) updateCorrelationIdMetaData(ctx context.Context, object Reconcilable, operationStartTimeKey string) error {

--- a/k8s/testing/mocks.go
+++ b/k8s/testing/mocks.go
@@ -248,7 +248,7 @@ func MockInProgressDeleteSummaryResult(obj reconcilers.Reconcilable, hash string
 }
 
 // GetSummary implements ApiClient.
-func (c *MockApiClient) GetSummary(ctx context.Context, id string, namespace string) (*model.SummaryResult, error) {
+func (c *MockApiClient) GetSummary(ctx context.Context, id string, namespace string, user string, password string) (*model.SummaryResult, error) {
 	args := c.Called(ctx, id, namespace)
 	summary := args.Get(0)
 	if summary == nil {
@@ -258,14 +258,14 @@ func (c *MockApiClient) GetSummary(ctx context.Context, id string, namespace str
 }
 
 // QueueDeploymentJob implements utils.ApiClient.
-func (c *MockApiClient) QueueDeploymentJob(ctx context.Context, namespace string, isDelete bool, deployment model.DeploymentSpec) error {
+func (c *MockApiClient) QueueDeploymentJob(ctx context.Context, namespace string, isDelete bool, deployment model.DeploymentSpec, user string, password string) error {
 	args := c.Called(ctx, namespace, isDelete, deployment)
 	return args.Error(0)
 }
 
 // QueueJob implements ApiClient.
 // Deprecated and not used.
-func (c *MockApiClient) QueueJob(ctx context.Context, id string, scope string, isDelete bool, isTarget bool) error {
+func (c *MockApiClient) QueueJob(ctx context.Context, id string, scope string, isDelete bool, isTarget bool, user string, password string) error {
 	panic("implement me")
 }
 

--- a/packages/helm/symphony/files/symphony-api.json
+++ b/packages/helm/symphony/files/symphony-api.json
@@ -13,7 +13,9 @@
       "lng": "-122.12826"
     },
     "currentSite": {
-      "baseUrl": {{ include "symphony.httpsUrl" . | quote }}
+      "baseUrl": {{ include "symphony.httpsUrl" . | quote }},
+      "username": "admin",
+      "password": ""
     }
     {{- if .Values.parent.url }}
     ,
@@ -58,7 +60,10 @@
             "providers": {
               "catalog": {
                 "type": "providers.config.catalog",
-                "config": {}
+                "config": {
+                  "user": "admin",
+                  "password": ""
+                }
               }
             }
           }
@@ -71,7 +76,9 @@
           {
             "name": "stage-manager",
             "type": "managers.symphony.stage",
-            "properties": {   
+            "properties": { 
+              "user": "admin",
+              "password": "",  
               "providers.state": "k8s-state"          
             },
             "providers": {
@@ -115,6 +122,8 @@
           }
         ],
         "properties": {
+          "wait.user": "admin",
+          "wait.password": "",
           "wait.wait.interval": "15",
           "wait.wait.count": "10"
         }
@@ -200,6 +209,8 @@
             "type": "managers.symphony.jobs",
             "properties": {
               "providers.state": "mem-state",
+              "user": "admin",
+              "password": "",
               "interval": "#15",
               "poll.enabled": "false",
               "schedule.enabled": "true"                            
@@ -503,7 +514,9 @@
             "type": "managers.symphony.sync",
             "properties": {
               "interval": "#15",
-              "sync.enabled": "true"           
+              "sync.enabled": "true"  ,
+              "user": "admin",
+              "password": ""         
             }
           }
         ]

--- a/packages/helm/symphony/files/symphony-api.json
+++ b/packages/helm/symphony/files/symphony-api.json
@@ -13,9 +13,7 @@
       "lng": "-122.12826"
     },
     "currentSite": {
-      "baseUrl": "http://symphony-service:8080/v1alpha2/",
-      "username": "admin",
-      "password": ""
+      "baseUrl": {{ include "symphony.httpsUrl" . | quote }}
     }
     {{- if .Values.parent.url }}
     ,
@@ -60,11 +58,7 @@
             "providers": {
               "catalog": {
                 "type": "providers.config.catalog",
-                "config": {
-                  "baseUrl": "http://symphony-service:8080/v1alpha2/",
-                  "user": "admin",
-                  "password": ""
-                }
+                "config": {}
               }
             }
           }
@@ -78,9 +72,6 @@
             "name": "stage-manager",
             "type": "managers.symphony.stage",
             "properties": {   
-              "baseUrl": "http://symphony-service:8080/v1alpha2/",
-              "user": "admin",
-              "password": "",
               "providers.state": "k8s-state"          
             },
             "providers": {
@@ -124,9 +115,6 @@
           }
         ],
         "properties": {
-          "wait.baseUrl": "http://symphony-service:8080/v1alpha2/",
-          "wait.user": "admin",
-          "wait.password": "",
           "wait.wait.interval": "15",
           "wait.wait.count": "10"
         }
@@ -212,9 +200,6 @@
             "type": "managers.symphony.jobs",
             "properties": {
               "providers.state": "mem-state",
-              "baseUrl": {{ include "symphony.url" . | quote}},
-              "user": "admin",
-              "password": "",
               "interval": "#15",
               "poll.enabled": "false",
               "schedule.enabled": "true"                            
@@ -518,10 +503,7 @@
             "type": "managers.symphony.sync",
             "properties": {
               "interval": "#15",
-              "sync.enabled": "true",               
-              "baseUrl": "http://symphony-service:8080/v1alpha2/",
-              "user": "admin",
-              "password": ""
+              "sync.enabled": "true"           
             }
           }
         ]

--- a/packages/helm/symphony/templates/env-configmap.yaml
+++ b/packages/helm/symphony/templates/env-configmap.yaml
@@ -7,5 +7,5 @@ data:
   APP_VERSION: {{ .Chart.AppVersion }}
   CHART_VERSION: {{ .Chart.Version }}
   API_SERVING_CA: {{ include "symphony.apiServingCA" . }}
-  SYMPHONY_API_URL: {{ include "symphony.url" . }}
+  SYMPHONY_API_URL: {{ include "symphony.httpsUrl" . }}
   USE_SERVICE_ACCOUNT_TOKENS: "true"

--- a/packages/helm/symphony/templates/symphony-core/_helpers.tpl
+++ b/packages/helm/symphony/templates/symphony-core/_helpers.tpl
@@ -147,8 +147,15 @@ Symphony API ServingCertIssuerName
 {{/*
 Symphony full url Endpoint
 */}}
-{{- define "symphony.url" -}}
+{{- define "symphony.httpsUrl" -}}
 {{- printf "https://%s:%s/v1alpha2/" (include "symphony.serviceName" .)  (include "symphony.apiContainerPortHttps" .) }}
+{{- end }}
+
+{{/*
+Symphony full url Endpoint
+*/}}
+{{- define "symphony.httpUrl" -}}
+{{- printf "http://%s:%s/v1alpha2/" (include "symphony.serviceName" .)  (include "symphony.apiContainerPortHttp" .) }}
 {{- end }}
 
 {{/* Symphony Env Config Name */}}

--- a/packages/helm/symphony/templates/symphony-core/symphony-api.yaml
+++ b/packages/helm/symphony/templates/symphony-core/symphony-api.yaml
@@ -97,7 +97,7 @@ spec:
             - serviceAccountToken:
                 path: symphony-api-token
                 expirationSeconds: 600
-                audience: {{ include "symphony.url" . }}
+                audience: {{ include "symphony.httpsUrl" . }}
         - name: serving-cert
           secret:
             secretName: {{ include "symphony.apiServingCertName" . }}

--- a/packages/helm/symphony/templates/symphony-core/symphonyk8s.yaml
+++ b/packages/helm/symphony/templates/symphony-core/symphonyk8s.yaml
@@ -2145,7 +2145,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: '{{ include "symphony.url" . }}'
+              audience: '{{ include "symphony.httpsUrl" . }}'
               expirationSeconds: 600
               path: symphony-api-token
       - name: api-ca-cert

--- a/packages/helm/symphony/values.yaml
+++ b/packages/helm/symphony/values.yaml
@@ -27,10 +27,10 @@ redis:
   image: redis/redis-stack-server:latest
   port: 6379
 parent:
-  url: http://57.151.43.118:8080/v1alpha2/
+  url:
   username: admin
   password:
-siteId: jesseminikube
+siteId: hq
 imagePrivateRegistryUrl: ghcr.io
 api:
   apiContainerPortHttp: 8080

--- a/packages/helm/symphony/values.yaml
+++ b/packages/helm/symphony/values.yaml
@@ -27,10 +27,10 @@ redis:
   image: redis/redis-stack-server:latest
   port: 6379
 parent:
-  url: 
+  url: http://57.151.43.118:8080/v1alpha2/
   username: admin
   password:
-siteId: hq
+siteId: jesseminikube
 imagePrivateRegistryUrl: ghcr.io
 api:
   apiContainerPortHttp: 8080


### PR DESCRIPTION
All the api to api calls are now using TLS + SAT. We do this by initializing an overall apiclient with the symphony api address set in the pod env parameter.

We keep the http + user creds for child and parent communications since TLS + SAT by default doesn't work. The reason why we don't use an overall apiclient for parent calls is that parent urls may change. (Thought it doesn't work like this now) That's why we think singleton doesn't apply to parent-children apiclient.

Definitely some corresponding tests changes. I manually tested the multisite scenario.