### PR TITLE
Add statusMessage in activation for better display

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/activations/activations-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/activations/activations-manager_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
 	"github.com/stretchr/testify/assert"
 )
@@ -46,7 +47,10 @@ func TestCleanupOldActivationSpec(t *testing.T) {
 	spec, err := manager.GetState(context.Background(), "test", "default")
 	assert.Nil(t, err)
 	assert.Equal(t, "test", spec.ObjectMeta.Name)
-	err = manager.ReportStatus(context.Background(), "test", "default", model.ActivationStatus{Status: 9996})
+	err = manager.ReportStatus(context.Background(), "test", "default", model.ActivationStatus{
+		Status:        v1alpha2.Done,
+		StatusMessage: v1alpha2.Done.String(),
+	})
 	assert.Nil(t, err)
 	errList := cleanupmanager.Poll()
 	assert.Empty(t, errList)

--- a/api/pkg/apis/v1alpha1/managers/stage/stage-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/stage/stage-manager_test.go
@@ -73,6 +73,7 @@ func TestCampaignWithSingleMockStageLoop(t *testing.T) {
 		}
 	}
 	assert.Equal(t, v1alpha2.Done, status.Status)
+	assert.True(t, v1alpha2.Done.EqualsWithString(status.StatusMessage))
 	assert.Equal(t, int64(5), status.Outputs["foo"])
 	assert.Equal(t, "fakens", status.Outputs["__namespace"])
 	assert.Equal(t, "test-campaign", status.Outputs["__campaign"])
@@ -129,6 +130,7 @@ func TestCampaignWithSingleCounterStageLoop(t *testing.T) {
 		}
 	}
 	assert.Equal(t, v1alpha2.Done, status.Status)
+	assert.True(t, v1alpha2.Done.EqualsWithString(status.StatusMessage))
 	assert.Equal(t, int64(5), status.Outputs["foo"])
 	assert.Equal(t, "fakens", status.Outputs["__namespace"])
 	assert.Equal(t, "test-campaign", status.Outputs["__campaign"])
@@ -186,6 +188,7 @@ func TestCampaignWithSingleMegativeCounterStageLoop(t *testing.T) {
 		}
 	}
 	assert.Equal(t, v1alpha2.Done, status.Status)
+	assert.True(t, v1alpha2.Done.EqualsWithString(status.StatusMessage))
 	assert.Equal(t, int64(-50), status.Outputs["foo"])
 	assert.Equal(t, "fakens", status.Outputs["__namespace"])
 	assert.Equal(t, "test-campaign", status.Outputs["__campaign"])
@@ -248,6 +251,7 @@ func TestCampaignWithTwoCounterStageLoop(t *testing.T) {
 		}
 	}
 	assert.Equal(t, v1alpha2.Done, status.Status)
+	assert.True(t, v1alpha2.Done.EqualsWithString(status.StatusMessage))
 	assert.Equal(t, int64(5), status.Outputs["foo"])
 	assert.Equal(t, int64(5), status.Outputs["bar"])
 	assert.Equal(t, "fakens", status.Outputs["__namespace"])
@@ -314,6 +318,7 @@ func TestCampaignWithHTTPCounterStageLoop(t *testing.T) {
 		}
 	}
 	assert.Equal(t, v1alpha2.Done, status.Status)
+	assert.True(t, v1alpha2.Done.EqualsWithString(status.StatusMessage))
 	assert.Equal(t, int64(5), status.Outputs["success"])
 	assert.Equal(t, "fakens", status.Outputs["__namespace"])
 	assert.Equal(t, "test-campaign", status.Outputs["__campaign"])
@@ -370,6 +375,7 @@ func TestCampaignWithDelay(t *testing.T) {
 		}
 	}
 	assert.Equal(t, v1alpha2.Done, status.Status)
+	assert.True(t, v1alpha2.Done.EqualsWithString(status.StatusMessage))
 	assert.Equal(t, v1alpha2.OK, status.Outputs[v1alpha2.StatusOutput])
 	assert.True(t, time.Now().UTC().Sub(timeStamp) > 5*time.Second)
 	assert.Equal(t, "fakens", status.Outputs["__namespace"])
@@ -436,6 +442,7 @@ func TestErrorHandler(t *testing.T) {
 		}
 	}
 	assert.Equal(t, v1alpha2.Done, status.Status)
+	assert.True(t, v1alpha2.Done.EqualsWithString(status.StatusMessage))
 	assert.Equal(t, int64(0), status.Outputs["success"])
 	assert.Equal(t, "fakens", status.Outputs["__namespace"])
 	assert.Equal(t, "test-campaign", status.Outputs["__campaign"])
@@ -499,6 +506,7 @@ func TestErrorHandlerNotSet(t *testing.T) {
 		}
 	}
 	assert.Equal(t, v1alpha2.InternalError, status.Status)
+	assert.True(t, v1alpha2.InternalError.EqualsWithString(status.StatusMessage))
 }
 func TestAccessingPreviousStage(t *testing.T) {
 	stateProvider := &memorystate.MemoryStateProvider{}
@@ -661,6 +669,7 @@ func TestIntentionalError(t *testing.T) {
 		assert.Equal(t, v1alpha2.BadRequest, status.Outputs["__status"])
 	}
 	assert.Equal(t, v1alpha2.Done, status.Status)
+	assert.True(t, v1alpha2.Done.EqualsWithString(status.StatusMessage))
 }
 func TestIntentionalErrorState(t *testing.T) {
 	stateProvider := &memorystate.MemoryStateProvider{}
@@ -715,6 +724,7 @@ func TestIntentionalErrorState(t *testing.T) {
 		assert.Equal(t, v1alpha2.DeleteFailed, status.Outputs["__status"])
 	}
 	assert.Equal(t, v1alpha2.Done, status.Status)
+	assert.True(t, v1alpha2.Done.EqualsWithString(status.StatusMessage))
 }
 func TestIntentionalErrorString(t *testing.T) {
 	stateProvider := &memorystate.MemoryStateProvider{}
@@ -768,6 +778,7 @@ func TestIntentionalErrorString(t *testing.T) {
 		assert.Equal(t, v1alpha2.InternalError, status.Outputs["__status"]) // non-successful state is returned without __error, set to InternalError
 	}
 	assert.Equal(t, v1alpha2.Done, status.Status)
+	assert.True(t, v1alpha2.Done.EqualsWithString(status.StatusMessage))
 }
 func TestIntentionalErrorStringProper(t *testing.T) {
 	stateProvider := &memorystate.MemoryStateProvider{}
@@ -823,6 +834,7 @@ func TestIntentionalErrorStringProper(t *testing.T) {
 		assert.Equal(t, "Bad Request: this_is_an_error", status.Outputs["__error"])
 	}
 	assert.Equal(t, v1alpha2.Done, status.Status)
+	assert.True(t, v1alpha2.Done.EqualsWithString(status.StatusMessage))
 }
 func TestAccessingPreviousStageInExpression(t *testing.T) {
 	stateProvider := &memorystate.MemoryStateProvider{}
@@ -920,9 +932,10 @@ func TestResumeStage(t *testing.T) {
 		},
 	})
 	activation := model.ActivationStatus{
-		Status:  v1alpha2.Done,
-		Stage:   "test",
-		Outputs: output,
+		Status:        v1alpha2.Done,
+		StatusMessage: v1alpha2.Done.String(),
+		Stage:         "test",
+		Outputs:       output,
 	}
 	campaign := model.CampaignSpec{
 		SelfDriving: true,
@@ -985,9 +998,10 @@ func TestResumeStageFailed(t *testing.T) {
 		},
 	})
 	activation := model.ActivationStatus{
-		Status:  v1alpha2.Done,
-		Stage:   "test",
-		Outputs: output,
+		Status:        v1alpha2.Done,
+		StatusMessage: v1alpha2.Done.String(),
+		Stage:         "test",
+		Outputs:       output,
 	}
 	campaign := model.CampaignSpec{
 		SelfDriving: true,
@@ -1050,6 +1064,7 @@ func TestHandleDirectTriggerEvent(t *testing.T) {
 	}
 	status := manager.HandleDirectTriggerEvent(context.Background(), activation)
 	assert.Equal(t, v1alpha2.Done, status.Status)
+	assert.True(t, v1alpha2.Done.EqualsWithString(status.StatusMessage))
 	assert.Equal(t, "test-campaign", status.Outputs["__campaign"])
 	assert.Equal(t, "test-activation", status.Outputs["__activation"])
 	assert.Equal(t, "1", status.Outputs["__activationGeneration"])
@@ -1097,6 +1112,7 @@ func TestHandleDirectTriggerScheduleEvent(t *testing.T) {
 	}
 	status := manager.HandleDirectTriggerEvent(context.Background(), activation)
 	assert.Equal(t, v1alpha2.Paused, status.Status)
+	assert.True(t, v1alpha2.Paused.EqualsWithString(status.StatusMessage))
 
 	assert.Equal(t, v1alpha2.Delayed, status.Outputs["__status"])
 	assert.Equal(t, false, status.IsActive)
@@ -1220,5 +1236,6 @@ func TestTriggerEventWithSchedule(t *testing.T) {
 		},
 	}, *activation)
 	assert.Equal(t, v1alpha2.Paused, status.Status)
+	assert.True(t, v1alpha2.Paused.EqualsWithString(status.StatusMessage))
 	assert.Equal(t, false, status.IsActive)
 }

--- a/api/pkg/apis/v1alpha1/model/campaign.go
+++ b/api/pkg/apis/v1alpha1/model/campaign.go
@@ -73,6 +73,7 @@ type ActivationStatus struct {
 	Inputs               map[string]interface{} `json:"inputs,omitempty"`
 	Outputs              map[string]interface{} `json:"outputs,omitempty"`
 	Status               v1alpha2.State         `json:"status,omitempty"`
+	StatusMessage        string                 `json:"statusMessage,omitempty"`
 	ErrorMessage         string                 `json:"errorMessage,omitempty"`
 	IsActive             bool                   `json:"isActive,omitempty"`
 	ActivationGeneration string                 `json:"activationGeneration,omitempty"`

--- a/api/pkg/apis/v1alpha1/vendors/activations-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/activations-vendor_test.go
@@ -48,7 +48,8 @@ func TestActivationsInfo(t *testing.T) {
 func TestActivationsOnStatus(t *testing.T) {
 	vendor := createActivationsVendor()
 	status := model.ActivationStatus{
-		Status: 9996,
+		Status:        v1alpha2.Done,
+		StatusMessage: v1alpha2.Done.String(),
 	}
 	data, _ := json.Marshal(status)
 	resp := vendor.onStatus(v1alpha2.COARequest{
@@ -149,7 +150,8 @@ func TestActivationsOnActivations(t *testing.T) {
 	assert.Equal(t, campaignName, activations[0].Spec.Campaign)
 
 	status := model.ActivationStatus{
-		Status: 9996,
+		Status:        v1alpha2.Done,
+		StatusMessage: v1alpha2.Done.String(),
 	}
 	data, _ = json.Marshal(status)
 	resp = vendor.onStatus(v1alpha2.COARequest{

--- a/api/pkg/apis/v1alpha1/vendors/federation-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/federation-vendor_test.go
@@ -243,6 +243,7 @@ func TestFederationOnSyncPost(t *testing.T) {
 			"output2": "value2",
 		},
 		Status:               v1alpha2.OK,
+		StatusMessage:        v1alpha2.OK.String(),
 		IsActive:             true,
 		ActivationGeneration: "1",
 		UpdateTime:           "exampleUpdateTime",

--- a/api/pkg/apis/v1alpha1/vendors/stage-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/stage-vendor_test.go
@@ -196,5 +196,5 @@ func createStageVendor() StageVendor {
 // 	assert.NotNil(t, activation)
 // 	assert.Equal(t, "test-activation", activation.Id)
 // 	assert.NotNil(t, activation.Status.UpdateTime)
-// 	assert.Equal(t, v1alpha2.Done, activation.Status.Status)
+//  assert.True(t, v1alpha2.Done.EqualsWithString(activation.Status.Status))
 // }

--- a/coa/pkg/apis/v1alpha2/types.go
+++ b/coa/pkg/apis/v1alpha2/types.go
@@ -99,6 +99,10 @@ const (
 	TargetPropertyNotFound State = 12000
 )
 
+func (s State) EqualsWithString(str string) bool {
+	return s.String() == str
+}
+
 func (s State) String() string {
 	switch s {
 	case OK:

--- a/docs/samples/opera/app/types.d.ts
+++ b/docs/samples/opera/app/types.d.ts
@@ -141,6 +141,7 @@ export interface ActivationStatus {
     inputs: Record<string, any>;
     outputs: Record<string, any>;
     status: number;
+    statusMessage: string;
     errorMessage: string;
     isActive: boolean;
     activationGeneration: string;

--- a/docs/samples/opera/components/campaigns/CampaignCard.tsx
+++ b/docs/samples/opera/components/campaigns/CampaignCard.tsx
@@ -85,7 +85,7 @@ function CampaignCard(props: CampaignCardProps) {
             <CardFooter  className="flex gap-3 justify-between">                
                 <button className="btn btn-primary" onClick={()=>ActivateCampaign(campaign)}><BiPlay/></button>
                 {activation && (
-                    <div className="flex gap-2">{` ${stateToString(activation.status.status)} ${activation.status.stage === '' ? '': 'stage (' + activation.status.stage + ')'}`}</div>
+                    <div className="flex gap-2">{` ${activation.status.statusMessage} ${activation.status.stage === '' ? '': 'stage (' + activation.status.stage + ')'}`}</div>
                 )}
             </CardFooter>
         </Card>

--- a/k8s/apis/workflow/v1/activation_types.go
+++ b/k8s/apis/workflow/v1/activation_types.go
@@ -24,6 +24,7 @@ type ActivationStatus struct {
 	// +kubebuilder:validation:Schemaless
 	Outputs              runtime.RawExtension `json:"outputs,omitempty"`
 	Status               v1alpha2.State       `json:"status,omitempty"`
+	StatusMessage        string               `json:"statusMessage,omitempty"`
 	ErrorMessage         string               `json:"errorMessage,omitempty"`
 	IsActive             bool                 `json:"isActive,omitempty"`
 	ActivationGeneration string               `json:"activationGeneration,omitempty"`
@@ -33,7 +34,7 @@ type ActivationStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Next Stage",type=string,JSONPath=`.status.nextStage`
-// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.status`
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.statusMessage`
 // Activation is the Schema for the activations API
 type Activation struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/k8s/config/oss/crd/bases/workflow.symphony_activations.yaml
+++ b/k8s/config/oss/crd/bases/workflow.symphony_activations.yaml
@@ -19,7 +19,7 @@ spec:
     - jsonPath: .status.nextStage
       name: Next Stage
       type: string
-    - jsonPath: .status.status
+    - jsonPath: .status.statusMessage
       name: Status
       type: string
     name: v1
@@ -68,6 +68,8 @@ spec:
                 type: string
               status:
                 type: integer
+              statusMessage:
+                type: string
               updateTime:
                 type: string
             required:

--- a/packages/helm/symphony/templates/symphony-core/symphonyk8s.yaml
+++ b/packages/helm/symphony/templates/symphony-core/symphonyk8s.yaml
@@ -29,7 +29,7 @@ spec:
     - jsonPath: .status.nextStage
       name: Next Stage
       type: string
-    - jsonPath: .status.status
+    - jsonPath: .status.statusMessage
       name: Status
       type: string
     name: v1
@@ -78,6 +78,8 @@ spec:
                 type: string
               status:
                 type: integer
+              statusMessage:
+                type: string
               updateTime:
                 type: string
             required:


### PR DESCRIPTION
```yaml
$ kubectl get activation
NAME         NEXT STAGE   STATUS
04workflow                Done  // printColumn will use statusMessage to display.
$ kubectl describe activation
Name:         04workflow
Namespace:    default
Labels:       <none>
Annotations:  <none>
API Version:  workflow.symphony/v1
Kind:         Activation
Metadata:
  Creation Timestamp:  2024-05-11T02:29:08Z
  Generation:          1
  Resource Version:    1239
  UID:                 cf8dfab3-ec72-49af-b1e1-de7478563487
Spec:
  Campaign:  04campaign
Status:
  Outputs:
    __activation:            04workflow
    __activationGeneration:  1
    __campaign:              04campaign
    __namespace:             default
    __site:                  hq
    __stage:                 deploy
    __status:                200
  Stage:                     deploy
  Status:                    9996
  Status Message:            Done  // add statusMessage to show status more user-friendly.
  Update Time:               2024-05-11T02:29:11Z
Events:                      <none>
```