### PR TITLE
Set env variables for noK8s mode in the Maestro CLI tool

### DIFF
--- a/cli/cmd/up.go
+++ b/cli/cmd/up.go
@@ -64,6 +64,8 @@ var UpCmd = &cobra.Command{
 			if !updateSymphonyContext("no-k8s", "localhost") {
 				return
 			}
+			os.Setenv("SYMPHONY_API_URL", "http://localhost:8082/v1alpha2/")
+			os.Setenv("USE_SERVICE_ACCOUNT_TOKENS", "false")
 			_, err := utils.RunCommandNoCapture("Launching Symphony in standalone mode", "done", filepath.Join(u.HomeDir, ".symphony/symphony-api"), "-c", filepath.Join(u.HomeDir, ".symphony/symphony-api-no-k8s.json"), "-l", "Debug")
 			if err != nil {
 				fmt.Printf("\n%s  Failed: %s%s\n\n", utils.ColorRed(), err.Error(), utils.ColorReset())


### PR DESCRIPTION
The Maestro CLI tool does not set these environment variables `SYMPHONY_API_URL` and `USE_SERVICE_ACCOUNT_TOKENS`, whereas the Symphony API binary does (https://github.com/eclipse-symphony/symphony/blob/main/docs/symphony-book/get-started/quick_start_binary.md?plain=1#L24).

I would receive the following error when running Maestro:
```bash
ERRO[0014]  M (Job): error getting instance target-runtime-remote-cmd-instance, namespace: default: Post "http://symphony-service:8080/v1alpha2/users/auth"
```

The hostname `symphony-service` cannot be resolved so the error occurs.

I've added two lines to set the required environment variables when running in `noK8s` mode