### PR TITLE
Let Minikube load image from docker

### DIFF
--- a/test/localenv/magefile.go
+++ b/test/localenv/magefile.go
@@ -652,9 +652,9 @@ func runParallel(commands ...shellcmd.Command) error {
 func load(names ...string) []shellcmd.Command {
 	loads := make([]shellcmd.Command, len(names))
 	for i, name := range names {
-		shellcmd.Command(fmt.Sprintf("docker image save -o %s.tar %s/%s", name, getContainerRegistry(), name)).Run()
 		loads[i] = shellcmd.Command(fmt.Sprintf(
-			"minikube image load %s.tar",
+			"minikube image load %s/%s",
+			OSS_CONTAINER_REGISTRY,
 			name,
 		))
 	}


### PR DESCRIPTION
Old minikube has some issues to load docker image directly so we made a workaround to first save the docker image to local tar and then let minikube load tar file. The issue has been fixed in the latest minikube release 1.33.1 so change it back.