### PR TITLE
Use persistent state store in Job and Solution manager

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/jobs/jobs-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/jobs/jobs-manager.go
@@ -210,7 +210,7 @@ func (s *JobsManager) pollSchedules() []error {
 		Metadata: map[string]interface{}{
 			"group":    model.WorkflowGroup,
 			"version":  "v1",
-			"resource": "scheduled",
+			"resource": Scheduled,
 		},
 	})
 	if err != nil {

--- a/api/pkg/apis/v1alpha1/managers/jobs/jobs-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/jobs/jobs-manager_test.go
@@ -35,11 +35,12 @@ func TestHandleEvent(t *testing.T) {
 	manager := JobsManager{}
 	err := manager.Init(nil, managers.ManagerConfig{
 		Properties: map[string]string{
-			"providers.volatilestate": "state",
-			"baseUrl":                 "http://localhost:8082/v1alpha2/",
-			"password":                "",
-			"user":                    "admin",
-			"interval":                "#15",
+			"providers.volatilestate":   "state",
+			"providers.persistentstate": "state",
+			"baseUrl":                   "http://localhost:8082/v1alpha2/",
+			"password":                  "",
+			"user":                      "admin",
+			"interval":                  "#15",
 		},
 	}, map[string]providers.IProvider{
 		"state": stateProvider,
@@ -67,11 +68,12 @@ func TestHandleJobEvent(t *testing.T) {
 	jobManager := JobsManager{}
 	err := jobManager.Init(nil, managers.ManagerConfig{
 		Properties: map[string]string{
-			"providers.volatilestate": "state",
-			"baseUrl":                 ts.URL + "/",
-			"password":                "",
-			"user":                    "admin",
-			"interval":                "#15",
+			"providers.volatilestate":   "state",
+			"providers.persistentstate": "state",
+			"baseUrl":                   ts.URL + "/",
+			"password":                  "",
+			"user":                      "admin",
+			"interval":                  "#15",
 		},
 	}, map[string]providers.IProvider{
 		"state": stateProvider,
@@ -114,11 +116,12 @@ func TestHandleScheduleEvent(t *testing.T) {
 	jobManager := JobsManager{}
 	err := jobManager.Init(nil, managers.ManagerConfig{
 		Properties: map[string]string{
-			"providers.volatilestate": "state",
-			"baseUrl":                 "http://localhost:8082/v1alpha2/",
-			"password":                "",
-			"user":                    "admin",
-			"interval":                "#15",
+			"providers.volatilestate":   "state",
+			"providers.persistentstate": "state",
+			"baseUrl":                   "http://localhost:8082/v1alpha2/",
+			"password":                  "",
+			"user":                      "admin",
+			"interval":                  "#15",
 		},
 	}, map[string]providers.IProvider{
 		"state": stateProvider,
@@ -140,11 +143,12 @@ func TestHandleheartbeatEvent(t *testing.T) {
 	jobManager := JobsManager{}
 	err := jobManager.Init(nil, managers.ManagerConfig{
 		Properties: map[string]string{
-			"providers.volatilestate": "state",
-			"baseUrl":                 "http://localhost:8082/v1alpha2/",
-			"password":                "",
-			"user":                    "admin",
-			"interval":                "#15",
+			"providers.volatilestate":   "state",
+			"providers.persistentstate": "state",
+			"baseUrl":                   "http://localhost:8082/v1alpha2/",
+			"password":                  "",
+			"user":                      "admin",
+			"interval":                  "#15",
 		},
 	}, map[string]providers.IProvider{
 		"state": stateProvider,
@@ -169,13 +173,14 @@ func TestPoll(t *testing.T) {
 	jobManager := JobsManager{}
 	err := jobManager.Init(nil, managers.ManagerConfig{
 		Properties: map[string]string{
-			"providers.volatilestate": "state",
-			"baseUrl":                 ts.URL + "/",
-			"password":                "",
-			"user":                    "admin",
-			"interval":                "#15",
-			"poll.enabled":            "true",
-			"schedule.enabled":        "true",
+			"providers.volatilestate":   "state",
+			"providers.persistentstate": "state",
+			"baseUrl":                   ts.URL + "/",
+			"password":                  "",
+			"user":                      "admin",
+			"interval":                  "#15",
+			"poll.enabled":              "true",
+			"schedule.enabled":          "true",
 		},
 	}, map[string]providers.IProvider{
 		"state": stateProvider,
@@ -199,13 +204,14 @@ func TestDelayOrSkipJobPoll(t *testing.T) {
 	jobManager := JobsManager{}
 	err := jobManager.Init(nil, managers.ManagerConfig{
 		Properties: map[string]string{
-			"providers.volatilestate": "state",
-			"baseUrl":                 ts.URL + "/",
-			"password":                "",
-			"user":                    "admin",
-			"interval":                "#15",
-			"poll.enabled":            "true",
-			"schedule.enabled":        "true",
+			"providers.volatilestate":   "state",
+			"providers.persistentstate": "state",
+			"baseUrl":                   ts.URL + "/",
+			"password":                  "",
+			"user":                      "admin",
+			"interval":                  "#15",
+			"poll.enabled":              "true",
+			"schedule.enabled":          "true",
 		},
 	}, map[string]providers.IProvider{
 		"state": stateProvider,

--- a/api/pkg/apis/v1alpha1/managers/solution/solution-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/solution/solution-manager.go
@@ -50,6 +50,9 @@ const (
 	// DeploymentType_Delete indicates the type of deployment is Delete. This is
 	// to give a deployment status on Symphony Target deployment.
 	DeploymentType_Delete string = "Target Delete"
+
+	Summary         = "Summary"
+	DeploymentState = "DeployState"
 )
 
 type SolutionManager struct {
@@ -80,7 +83,7 @@ func (s *SolutionManager) Init(context *contexts.VendorContext, config managers.
 		}
 	}
 
-	stateprovider, err := managers.GetVolatileStateProvider(config, providers)
+	stateprovider, err := managers.GetPersistentStateProvider(config, providers)
 	if err == nil {
 		s.StateProvider = stateprovider
 	} else {
@@ -144,6 +147,9 @@ func (s *SolutionManager) getPreviousState(ctx context.Context, instance string,
 		ID: instance,
 		Metadata: map[string]interface{}{
 			"namespace": namespace,
+			"group":     model.SolutionGroup,
+			"version":   "v1",
+			"resource":  DeploymentState,
 		},
 	})
 	if err == nil {
@@ -174,6 +180,9 @@ func (s *SolutionManager) GetSummary(ctx context.Context, key string, namespace 
 		ID: fmt.Sprintf("%s-%s", "summary", key),
 		Metadata: map[string]interface{}{
 			"namespace": namespace,
+			"group":     model.SolutionGroup,
+			"version":   "v1",
+			"resource":  Summary,
 		},
 	})
 	if err != nil {
@@ -467,6 +476,9 @@ func (s *SolutionManager) Reconcile(ctx context.Context, deployment model.Deploy
 		},
 		Metadata: map[string]interface{}{
 			"namespace": namespace,
+			"group":     model.SolutionGroup,
+			"version":   "v1",
+			"resource":  DeploymentState,
 		},
 	})
 	//}
@@ -516,6 +528,9 @@ func (s *SolutionManager) saveSummary(ctx context.Context, deployment model.Depl
 		},
 		Metadata: map[string]interface{}{
 			"namespace": namespace,
+			"group":     model.SolutionGroup,
+			"version":   "v1",
+			"resource":  Summary,
 		},
 	})
 }

--- a/api/pkg/apis/v1alpha1/vendors/job-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/job-vendor_test.go
@@ -29,7 +29,8 @@ func createJobVendor() JobVendor {
 	stateProvider := &memorystate.MemoryStateProvider{}
 	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
 	manager := jobs.JobsManager{
-		StateProvider: stateProvider,
+		VolatileStateProvider:   stateProvider,
+		PersistentStateProvider: stateProvider,
 	}
 	vendor := JobVendor{
 		JobsManager: &manager,
@@ -62,10 +63,11 @@ func TestJobsInit(t *testing.T) {
 				Name: "jobs-manager",
 				Type: "managers.symphony.jobs",
 				Properties: map[string]string{
-					"providers.volatilestate": "mem-state",
-					"baseUrl":                 "http://localhost:8082/v1alpha2/",
-					"user":                    "admin",
-					"password":                "",
+					"providers.volatilestate":   "mem-state",
+					"providers.persistentstate": "mem-state",
+					"baseUrl":                   "http://localhost:8082/v1alpha2/",
+					"user":                      "admin",
+					"password":                  "",
 				},
 				Providers: map[string]managers.ProviderConfig{
 					"mem-state": {

--- a/api/pkg/apis/v1alpha1/vendors/solution-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/solution-vendor_test.go
@@ -46,9 +46,9 @@ func createSolutionVendor() SolutionVendor {
 				Name: "solution-manager",
 				Type: "managers.symphony.solution",
 				Properties: map[string]string{
-					"providers.volatilestate": "mem-state",
-					"providers.config":        "mock-config",
-					"providers.secret":        "mock-secret",
+					"providers.persistentstate": "mem-state",
+					"providers.config":          "mock-config",
+					"providers.secret":          "mock-secret",
 				},
 				Providers: map[string]managers.ProviderConfig{
 					"mem-state": {

--- a/api/symphony-api-dev-console-trace.json
+++ b/api/symphony-api-dev-console-trace.json
@@ -240,7 +240,7 @@
             "name": "solution-manager",
             "type": "managers.symphony.solution",
             "properties": {
-              "providers.volatilestate": "mem-state",
+              "providers.persistentstate": "mem-state",
               "providers.config": "mock-config",  
               "providers.secret": "mock-secret"
             },

--- a/api/symphony-api-dev-zipkin-trace.json
+++ b/api/symphony-api-dev-zipkin-trace.json
@@ -239,7 +239,7 @@
             "name": "solution-manager",
             "type": "managers.symphony.solution",
             "properties": {
-              "providers.volatilestate": "mem-state",
+              "providers.persistentstate": "mem-state",
               "providers.config": "mock-config",  
               "providers.secret": "mock-secret"
             },

--- a/api/symphony-api-dev.json
+++ b/api/symphony-api-dev.json
@@ -239,7 +239,7 @@
             "name": "solution-manager",
             "type": "managers.symphony.solution",
             "properties": {
-              "providers.volatilestate": "mem-state",
+              "providers.persistentstate": "mem-state",
               "providers.config": "mock-config",  
               "providers.secret": "mock-secret"
             },

--- a/api/symphony-api-no-k8s-munchen.json
+++ b/api/symphony-api-no-k8s-munchen.json
@@ -186,6 +186,7 @@
             "type": "managers.symphony.jobs",
             "properties": {
               "providers.volatilestate": "mem-state",
+              "providers.persistentstate": "mem-state",
               "baseUrl": "http://localhost:8082/v1alpha2/",
               "user": "admin",
               "password": "",
@@ -417,7 +418,7 @@
             "name": "solution-manager",
             "type": "managers.symphony.solution",
             "properties": {
-              "providers.volatilestate": "mem-state",
+              "providers.persistentstate": "mem-state",
               "providers.config": "mock-config",
               "providers.secret": "mock-secret"
             },

--- a/api/symphony-api-no-k8s-new-york.json
+++ b/api/symphony-api-no-k8s-new-york.json
@@ -184,6 +184,7 @@
             "type": "managers.symphony.jobs",
             "properties": {
               "providers.volatilestate": "mem-state",
+              "providers.persistentstate": "mem-state",
               "baseUrl": "http://localhost:8084/v1alpha2/",
               "user": "admin",
               "password": "",
@@ -415,10 +416,10 @@
             "name": "solution-manager",
             "type": "managers.symphony.solution",
             "properties": {
-              "providers.volatilestate": "mem-state",
+              "providers.persistentstate": "mem-state",
               "providers.config": "mock-config",
               "providers.secret": "mock-secret"
-            },
+            },"providers.volatilestate": "mem-state",
             "providers": {
               "mem-state": {
                 "type": "providers.state.memory",

--- a/api/symphony-api-no-k8s-tokyo.json
+++ b/api/symphony-api-no-k8s-tokyo.json
@@ -184,6 +184,7 @@
             "type": "managers.symphony.jobs",
             "properties": {
               "providers.volatilestate": "mem-state",
+              "providers.persistentstate": "mem-state",
               "baseUrl": "http://localhost:8083/v1alpha2/",
               "user": "admin",
               "password": "",
@@ -415,7 +416,7 @@
             "name": "solution-manager",
             "type": "managers.symphony.solution",
             "properties": {
-              "providers.volatilestate": "mem-state",
+              "providers.persistentstate": "mem-state",
               "providers.config": "mock-config",
               "providers.secret": "mock-secret"
             },

--- a/api/symphony-api-no-k8s.json
+++ b/api/symphony-api-no-k8s.json
@@ -198,6 +198,7 @@
             "type": "managers.symphony.jobs",
             "properties": {
               "providers.volatilestate": "mem-state",
+              "providers.persistentstate": "mem-state",
               "user": "admin",
               "password": "",
               "interval": "#15",
@@ -428,7 +429,7 @@
             "name": "solution-manager",
             "type": "managers.symphony.solution",
             "properties": {
-              "providers.volatilestate": "mem-state",
+              "providers.persistentstate": "mem-state",
               "providers.config": "mock-config",
               "providers.secret": "mock-secret"
             },

--- a/api/symphony-api-production.json
+++ b/api/symphony-api-production.json
@@ -217,6 +217,7 @@
             "type": "managers.symphony.jobs",
             "properties": {
               "providers.volatilestate": "mem-state",
+              "providers.persistentstate": "redis-state",
               "baseUrl": "http://symphony-service:8080/v1alpha2/",
               "user": "admin",
               "password": "",
@@ -225,6 +226,15 @@
               "schedule.enabled": "true"             
             },
             "providers": {
+              "redis-state": {
+                "type": "providers.state.redis",
+                "config": {
+                  "name": "redis",
+                  "host": "localhost:6379",
+                  "requireTLS": false,
+                  "password": ""
+                }
+              },
               "mem-state": {
                 "type": "providers.state.memory",
                 "config": {}
@@ -455,14 +465,19 @@
             "name": "solution-manager",
             "type": "managers.symphony.solution",
             "properties": {
-              "providers.volatilestate": "mem-state",
+              "providers.persistentstate": "redis-state",
               "providers.config": "mock-config",  
               "providers.secret": "mock-secret"
             },
             "providers": {
-              "mem-state": {
-                "type": "providers.state.memory",
-                "config": {}
+              "redis-state": {
+                "type": "providers.state.redis",
+                "config": {
+                  "name": "redis",
+                  "host": "localhost:6379",
+                  "requireTLS": false,
+                  "password": ""
+                }
               },
               "mock-config": {
                 "type": "providers.config.mock",

--- a/api/symphony-api-test.json
+++ b/api/symphony-api-test.json
@@ -25,7 +25,7 @@
               "name": "solution-manager",
               "type": "managers.symphony.solution",
               "properties": {
-                "providers.volatilestate": "mem-state",
+                "providers.persistentstate": "mem-state",
                 "providers.config": "mock-config",
                 "providers.secret": "mock-secret"
               },

--- a/api/symphony-api.json
+++ b/api/symphony-api.json
@@ -202,6 +202,7 @@
             "type": "managers.symphony.jobs",
             "properties": {
               "providers.volatilestate": "mem-state",
+              "providers.persistentstate": "mem-state",
               "baseUrl": "http://symphony-service:8080/v1alpha2/",
               "user": "admin",
               "password": "",

--- a/api/symphony-k8s-poll-agent.json
+++ b/api/symphony-k8s-poll-agent.json
@@ -35,7 +35,7 @@
             "name": "solution-manager",
             "type": "managers.symphony.solution",
             "properties": {
-              "providers.volatilestate": "mem-state",                
+              "providers.persistentstate": "mem-state",                
               "providers.config": "mock-config",  
               "providers.secret": "mock-secret",
               "isTarget": "true",

--- a/api/symphony-k8s-proxy-mqtt.json
+++ b/api/symphony-k8s-proxy-mqtt.json
@@ -23,7 +23,7 @@
             "name": "solution-manager",
             "type": "managers.symphony.solution",
             "properties": {
-              "providers.volatilestate": "mem-state",  
+              "providers.persistentstate": "mem-state",  
               "providers.target": "k8s",
               "providers.config": "mock-config",  
               "providers.secret": "mock-secret"

--- a/api/symphony-powershell-over-mqtt.json
+++ b/api/symphony-powershell-over-mqtt.json
@@ -24,7 +24,7 @@
             "type": "managers.symphony.solution",
             "properties": {
               "providers.target": "script",
-              "providers.volatilestate": "mem-state",
+              "providers.persistentstate": "mem-state",
               "providers.config": "mock-config",  
               "providers.secret": "mock-secret"
             },

--- a/api/symphony-script-over-mqtt.json
+++ b/api/symphony-script-over-mqtt.json
@@ -24,7 +24,7 @@
             "type": "managers.symphony.solution",
             "properties": {
               "providers.target": "script",
-              "providers.volatilestate": "mem-state",
+              "providers.persistentstate": "mem-state",
               "providers.config": "mock-config",  
               "providers.secret": "mock-secret"
             },

--- a/api/symphony-script-proxy.json
+++ b/api/symphony-script-proxy.json
@@ -24,7 +24,7 @@
             "type": "managers.symphony.solution",
             "properties": {
               "providers.target": "script",
-              "providers.volatilestate": "mem-state",
+              "providers.persistentstate": "mem-state",
               "providers.config": "mock-config",  
               "providers.secret": "mock-secret"
             },

--- a/api/symphony-win-proxy.json
+++ b/api/symphony-win-proxy.json
@@ -24,7 +24,7 @@
             "type": "managers.symphony.solution",
             "properties": {
               "providers.target": "sideload",
-              "providers.volatilestate": "mem-state",
+              "providers.persistentstate": "mem-state",
               "providers.config": "mock-config",  
               "providers.secret": "mock-secret"
             },

--- a/k8s/main.go
+++ b/k8s/main.go
@@ -295,7 +295,7 @@ func main() {
 			os.Exit(1)
 		}
 		if err = (&workflowv1.Activation{}).SetupWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "Skill")
+			setupLog.Error(err, "unable to create webhook", "webhook", "Activation")
 			os.Exit(1)
 		}
 		if err = (&federationv1.Catalog{}).SetupWebhookWithManager(mgr); err != nil {

--- a/packages/helm/symphony/files/symphony-api.json
+++ b/packages/helm/symphony/files/symphony-api.json
@@ -230,6 +230,7 @@
             "type": "managers.symphony.jobs",
             "properties": {
               "providers.volatilestate": "mem-state",
+              "providers.persistentstate": "redis-state",
               "user": "admin",
               "password": "",
               "interval": "#15",
@@ -240,6 +241,19 @@
               "mem-state": {
                 "type": "providers.state.memory",
                 "config": {}
+              },
+              "redis-state": {
+                {{- if .Values.redis.enabled }}
+                "type": "providers.state.redis",
+                "config": {
+                  "host": "{{ include "symphony.redisHost" . }}",
+                  "requireTLS": false,
+                  "password": ""
+                }
+                {{- else }}
+                "type": "providers.state.memory",
+                "config": {}
+                {{- end }}
               }
             }
           }
@@ -467,14 +481,23 @@
             "name": "solution-manager",
             "type": "managers.symphony.solution",
             "properties": {
-              "providers.volatilestate": "mem-state",
+              "providers.persistentstate": "redis-state",
               "providers.config": "mock-config",  
               "providers.secret": "mock-secret"
             },
             "providers": {
-              "mem-state": {
+              "redis-state": {
+                {{- if .Values.redis.enabled }}
+                "type": "providers.state.redis",
+                "config": {
+                  "host": "{{ include "symphony.redisHost" . }}",
+                  "requireTLS": false,
+                  "password": ""
+                }
+                {{- else }}
                 "type": "providers.state.memory",
                 "config": {}
+                {{- end }}
               },
               "mock-config": {
                 "type": "providers.config.mock",


### PR DESCRIPTION
There are two objects that we are storing in memory should be persistent. 

One is SolutionManagerDeploymentState. It tracks the previous deployment state which is used in three-way merge.
The other is scheduled stage event. It tracks when a scheduled stage should be triggered. Also fixed issue https://github.com/eclipse-symphony/symphony/issues/256 as part of the change.

