### PR TITLE
Pubsub stop retry for nonretriable errors and add max retry count in memory&redis pubsub

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/stage/stage-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/stage/stage-manager.go
@@ -54,36 +54,36 @@ func (t *TaskResult) GetError() error {
 			state := v1alpha2.State(int(sv))
 			stateValue := reflect.ValueOf(state)
 			if stateValue.Type() != reflect.TypeOf(v1alpha2.State(0)) {
-				return fmt.Errorf("invalid state %v", sv)
+				return v1alpha2.NewCOAError(nil, fmt.Sprintf("invalid state %v", sv), v1alpha2.InternalError)
 			}
 			t.Outputs["__status"] = state
 		case int:
 			state := v1alpha2.State(sv)
 			stateValue := reflect.ValueOf(state)
 			if stateValue.Type() != reflect.TypeOf(v1alpha2.State(0)) {
-				return fmt.Errorf("invalid state %d", sv)
+				return v1alpha2.NewCOAError(nil, fmt.Sprintf("invalid state %d", sv), v1alpha2.InternalError)
 			}
 			t.Outputs["__status"] = state
 		case string:
 			vInt, err := strconv.ParseInt(sv, 10, 32)
 			if err != nil {
-				return fmt.Errorf("invalid state %s", sv)
+				return v1alpha2.NewCOAError(nil, fmt.Sprintf("invalid state %s", sv), v1alpha2.InternalError)
 			}
 			state := v1alpha2.State(vInt)
 			stateValue := reflect.ValueOf(state)
 			if stateValue.Type() != reflect.TypeOf(v1alpha2.State(0)) {
-				return fmt.Errorf("invalid state %d", vInt)
+				return v1alpha2.NewCOAError(nil, fmt.Sprintf("invalid state %d", vInt), v1alpha2.InternalError)
 			}
 			t.Outputs["__status"] = state
 		default:
-			return fmt.Errorf("invalid state %v", v)
+			return v1alpha2.NewCOAError(nil, fmt.Sprintf("invalid state %v", v), v1alpha2.InternalError)
 		}
 
 		if t.Outputs["__status"] != v1alpha2.OK {
 			if v, ok := t.Outputs["__error"]; ok {
 				return v1alpha2.NewCOAError(nil, utils.FormatAsString(v), t.Outputs["__status"].(v1alpha2.State))
 			} else {
-				return fmt.Errorf("stage returned unsuccessful status without an error")
+				return v1alpha2.NewCOAError(nil, "stage returned unsuccessful status without an error", v1alpha2.InternalError)
 			}
 		}
 	}
@@ -122,27 +122,27 @@ func (s *StageManager) ResumeStage(status model.ActivationStatus, cam model.Camp
 	campaign, ok := status.Outputs["__campaign"].(string)
 	if !ok {
 		log.Errorf(" M (Stage): ResumeStage: campaign (%v) is not valid from output", status.Outputs["__campaign"])
-		return nil, fmt.Errorf("ResumeStage: campaign is not valid")
+		return nil, v1alpha2.NewCOAError(nil, "ResumeStage: campaign is not valid", v1alpha2.BadRequest)
 	}
 	activation, ok := status.Outputs["__activation"].(string)
 	if !ok {
 		log.Errorf(" M (Stage): ResumeStage: activation (%v) is not valid from output", status.Outputs["__activation"])
-		return nil, fmt.Errorf("ResumeStage: activation is not valid")
+		return nil, v1alpha2.NewCOAError(nil, "ResumeStage: activation is not valid", v1alpha2.BadRequest)
 	}
 	activationGeneration, ok := status.Outputs["__activationGeneration"].(string)
 	if !ok {
 		log.Errorf(" M (Stage): ResumeStage: activationGeneration (%v) is not valid from output", status.Outputs["__activationGeneration"])
-		return nil, fmt.Errorf("ResumeStage: activationGeneration is not valid")
+		return nil, v1alpha2.NewCOAError(nil, "ResumeStage: activationGeneration is not valid", v1alpha2.BadRequest)
 	}
 	site, ok := status.Outputs["__site"].(string)
 	if !ok {
 		log.Errorf(" M (Stage): ResumeStage: site (%v) is not valid from output", status.Outputs["__site"])
-		return nil, fmt.Errorf("ResumeStage: site is not valid")
+		return nil, v1alpha2.NewCOAError(nil, "ResumeStage: site is not valid", v1alpha2.BadRequest)
 	}
 	stage, ok := status.Outputs["__stage"].(string)
 	if !ok {
 		log.Errorf(" M (Stage): ResumeStage: stage (%v) is not valid from output", status.Outputs["__stage"])
-		return nil, fmt.Errorf("ResumeStage: stage is not valid")
+		return nil, v1alpha2.NewCOAError(nil, "ResumeStage: stage is not valid", v1alpha2.BadRequest)
 	}
 	namespace, ok := status.Outputs["__namespace"].(string)
 	if !ok {
@@ -171,7 +171,7 @@ func (s *StageManager) ResumeStage(status model.ActivationStatus, cam model.Camp
 		// 	}
 		// }
 		// if !found {
-		// 	return nil, fmt.Errorf("site %s is not found in pending task", site)
+		// 	return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("site %s is not found in pending task", site)
 		// }
 		//remove site from p.Sites
 		newSites := make([]string, 0)
@@ -223,7 +223,7 @@ func (s *StageManager) ResumeStage(status model.ActivationStatus, cam model.Camp
 						if _, ok := cam.Stages[sVal]; ok {
 							nextStage = sVal
 						} else {
-							return nil, fmt.Errorf("stage %s is not found", sVal)
+							return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("stage %s is not found", sVal), v1alpha2.InternalError)
 						}
 					}
 
@@ -266,7 +266,7 @@ func (s *StageManager) ResumeStage(status model.ActivationStatus, cam model.Camp
 			}
 		}
 	} else {
-		return nil, fmt.Errorf("invalid pending task")
+		return nil, v1alpha2.NewCOAError(err, "invalid pending task", v1alpha2.InternalError)
 	}
 
 	return nil, nil

--- a/api/pkg/apis/v1alpha1/managers/stage/stage-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/stage/stage-manager_test.go
@@ -1027,7 +1027,7 @@ func TestResumeStageFailed(t *testing.T) {
 	}
 	_, err := manager.ResumeStage(activation, campaign)
 	assert.NotNil(t, err)
-	assert.Equal(t, "ResumeStage: campaign is not valid", err.Error())
+	assert.Equal(t, "Bad Request: ResumeStage: campaign is not valid", err.Error())
 }
 
 func TestHandleDirectTriggerEvent(t *testing.T) {

--- a/api/pkg/apis/v1alpha1/model/campaign.go
+++ b/api/pkg/apis/v1alpha1/model/campaign.go
@@ -51,7 +51,7 @@ func (s *StageSpec) UnmarshalJSON(data []byte) error {
 	// validate if Schedule meet RFC 3339
 	if s.Schedule != "" {
 		if _, err := time.Parse(time.RFC3339, s.Schedule); err != nil {
-			return fmt.Errorf("invalid timestamp format: %v", err)
+			return v1alpha2.NewCOAError(nil, fmt.Sprintf("invalid timestamp format: %v", err), v1alpha2.BadConfig)
 		}
 	}
 	return nil
@@ -62,7 +62,7 @@ func (s StageSpec) MarshalJSON() ([]byte, error) {
 	type Alias StageSpec
 	if s.Schedule != "" {
 		if _, err := time.Parse(time.RFC3339, s.Schedule); err != nil {
-			return nil, fmt.Errorf("invalid timestamp format: %v", err)
+			return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("invalid timestamp format: %v", err), v1alpha2.BadConfig)
 		}
 	}
 	return json.Marshal(&struct {

--- a/api/pkg/apis/v1alpha1/model/objectmeta.go
+++ b/api/pkg/apis/v1alpha1/model/objectmeta.go
@@ -11,6 +11,8 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 )
 
 type ObjectMeta struct {
@@ -44,7 +46,7 @@ func (o *ObjectMeta) UnmarshalJSON(data []byte) error {
 		case float64:
 			o.Generation = strconv.FormatInt(int64(v), 10)
 		default:
-			return fmt.Errorf("unexpected type for generation field: %T", v)
+			return v1alpha2.NewCOAError(nil, fmt.Sprintf("unexpected type for generation field: %T", v), v1alpha2.BadConfig)
 		}
 	}
 

--- a/api/pkg/apis/v1alpha1/providers/stage/counter/counter.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/counter/counter.go
@@ -133,5 +133,5 @@ func getNumber(val interface{}) (int64, error) {
 			return v, nil
 		}
 	}
-	return 0, fmt.Errorf("cannot convert %v to number", val)
+	return 0, v1alpha2.NewCOAError(nil, fmt.Sprintf("cannot convert %v to number", val), v1alpha2.BadRequest)
 }

--- a/api/pkg/apis/v1alpha1/providers/states/k8s/k8s.go
+++ b/api/pkg/apis/v1alpha1/providers/states/k8s/k8s.go
@@ -205,13 +205,13 @@ func (s *K8sStateProvider) Upsert(ctx context.Context, entry states.UpsertReques
 		err = json.Unmarshal([]byte(template), &unc)
 		if err != nil {
 			sLog.Errorf("  P (K8s State): failed to deserialize template: %v", err)
-			return "", err
+			return "", v1alpha2.NewCOAError(err, "failed to upsert state because of bad template", v1alpha2.BadRequest)
 		}
 		var dict map[string]interface{}
 		err = json.Unmarshal(j, &dict)
 		if err != nil {
 			sLog.Errorf("  P (K8s State): failed to get object: %v", err)
-			return "", err
+			return "", v1alpha2.NewCOAError(err, "failed to upsert state because of bad inputs", v1alpha2.BadRequest)
 		}
 		unc.Object["spec"] = dict["spec"]
 		metaJson, _ := json.Marshal(dict["metadata"])
@@ -219,7 +219,7 @@ func (s *K8sStateProvider) Upsert(ctx context.Context, entry states.UpsertReques
 		err = json.Unmarshal(metaJson, &metadata)
 		if err != nil {
 			sLog.Errorf("  P (K8s State): failed to get object: %v", err)
-			return "", err
+			return "", v1alpha2.NewCOAError(err, "failed to upsert state because of bad inputs", v1alpha2.BadRequest)
 		}
 		unc.SetName(metadata.Name)
 		unc.SetNamespace(metadata.Namespace)
@@ -238,7 +238,7 @@ func (s *K8sStateProvider) Upsert(ctx context.Context, entry states.UpsertReques
 		err = json.Unmarshal(j, &dict)
 		if err != nil {
 			sLog.Errorf("  P (K8s State): failed to unmarshal object: %v", err)
-			return "", err
+			return "", v1alpha2.NewCOAError(err, "failed to upsert state because failed to unmarshal object", v1alpha2.BadRequest)
 		}
 		if v, ok := dict["metadata"]; ok {
 			metaJson, _ := json.Marshal(v)
@@ -246,7 +246,7 @@ func (s *K8sStateProvider) Upsert(ctx context.Context, entry states.UpsertReques
 			err = json.Unmarshal(metaJson, &metadata)
 			if err != nil {
 				sLog.Errorf("  P (K8s State): failed to unmarshal object metadata: %v", err)
-				return "", err
+				return "", v1alpha2.NewCOAError(err, "failed to upsert state because failed to unmarshal object metadata", v1alpha2.BadRequest)
 			}
 			item.SetName(metadata.Name)
 			item.SetNamespace(metadata.Namespace)
@@ -384,7 +384,7 @@ func (s *K8sStateProvider) List(ctx context.Context, request states.ListRequest)
 					err = json.Unmarshal(j, &dict)
 					if err != nil {
 						sLog.Errorf("  P (K8s State): failed to unmarshal object spec: %v", err)
-						return nil, "", err
+						return nil, "", v1alpha2.NewCOAError(err, "failed to upsert state because failed to unmarshal object spec", v1alpha2.BadRequest)
 					}
 					if v, e := utils.JsonPathQuery(dict, filterValue); e != nil || v == nil {
 						continue
@@ -395,8 +395,8 @@ func (s *K8sStateProvider) List(ctx context.Context, request states.ListRequest)
 						j, _ := json.Marshal(v.Object["status"])
 						err = json.Unmarshal(j, &dict)
 						if err != nil {
-							sLog.Errorf("  P (K8s State): failed to unmarshal object spec: %v", err)
-							return nil, "", err
+							sLog.Errorf("  P (K8s State): failed to unmarshal object status: %v", err)
+							return nil, "", v1alpha2.NewCOAError(err, "failed to upsert state because failed to unmarshal object status", v1alpha2.BadRequest)
 						}
 						if v, e := utils.JsonPathQuery(dict, filterValue); e != nil || v == nil {
 							continue

--- a/api/pkg/apis/v1alpha1/utils/parser.go
+++ b/api/pkg/apis/v1alpha1/utils/parser.go
@@ -154,7 +154,7 @@ func (n *UnaryNode) Eval(context utils.EvaluationContext) (interface{}, error) {
 		}
 		return fmt.Sprintf("{%v}", val), nil
 	}
-	return nil, fmt.Errorf("operator '%s' is not allowed in this context", opNames[n.Op])
+	return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("operator '%s' is not allowed in this context", opNames[n.Op]), v1alpha2.BadConfig)
 }
 
 type BinaryNode struct {
@@ -393,7 +393,7 @@ func (n *BinaryNode) Eval(context utils.EvaluationContext) (interface{}, error) 
 		return fmt.Sprintf("%v%v", lv, rv), nil
 	}
 
-	return nil, fmt.Errorf("operator '%s' is not allowed in this context", opNames[n.Op])
+	return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("operator '%s' is not allowed in this context", opNames[n.Op]), v1alpha2.BadConfig)
 }
 
 type FunctionNode struct {
@@ -405,13 +405,13 @@ func readProperty(properties map[string]string, key string) (string, error) {
 	if v, ok := properties[key]; ok {
 		return v, nil
 	}
-	return "", fmt.Errorf("property %s is not found", key)
+	return "", v1alpha2.NewCOAError(nil, fmt.Sprintf("property %s is not found", key), v1alpha2.BadConfig)
 }
 func readPropertyInterface(properties map[string]interface{}, key string) (interface{}, error) {
 	if v, ok := properties[key]; ok {
 		return v, nil
 	}
-	return "", fmt.Errorf("property %s is not found", key)
+	return "", v1alpha2.NewCOAError(nil, fmt.Sprintf("property %s is not found", key), v1alpha2.BadConfig)
 }
 func readArgument(deployment model.DeploymentSpec, component string, key string) (string, error) {
 	components := deployment.Solution.Spec.Components
@@ -422,7 +422,7 @@ func readArgument(deployment model.DeploymentSpec, component string, key string)
 			}
 		}
 	}
-	return "", fmt.Errorf("parameter %s is not found on component %s", key, component)
+	return "", v1alpha2.NewCOAError(nil, fmt.Sprintf("parameter %s is not found on component %s", key, component), v1alpha2.BadConfig)
 }
 
 func toIntIfPossible(f float64) interface{} {
@@ -487,7 +487,7 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 	case "param":
 		if len(n.Args) == 1 {
 			if context.Component == "" {
-				return nil, errors.New("a component name is needed to evaluate $param()")
+				return nil, v1alpha2.NewCOAError(nil, "a component name is needed to evaluate $param()", v1alpha2.BadConfig)
 			}
 			key, err := n.Args[0].Eval(context)
 			if err != nil {
@@ -500,13 +500,13 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 				}
 				return argument, nil
 			}
-			return nil, errors.New("deployment spec is not found")
+			return nil, v1alpha2.NewCOAError(nil, "deployment spec is not found", v1alpha2.BadConfig)
 		}
-		return nil, fmt.Errorf("$params() expects 1 argument, found %d", len(n.Args))
+		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$params() expects 1 argument, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "property":
 		if len(n.Args) == 1 {
 			if context.Properties == nil || len(context.Properties) == 0 {
-				return nil, errors.New("a property collection is needed to evaluate $property()")
+				return nil, v1alpha2.NewCOAError(nil, "a property collection is needed to evaluate $property()", v1alpha2.BadConfig)
 			}
 			key, err := n.Args[0].Eval(context)
 			if err != nil {
@@ -518,7 +518,7 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 			}
 			return property, nil
 		}
-		return nil, fmt.Errorf("$property() expects 1 argument, found %d", len(n.Args))
+		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$property() expects 1 argument, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "input":
 		if len(n.Args) == 1 {
 			if context.Inputs == nil || len(context.Inputs) == 0 {
@@ -534,7 +534,7 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 			}
 			return property, nil
 		}
-		return nil, fmt.Errorf("$input() expects 1 argument, found %d", len(n.Args))
+		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$input() expects 1 argument, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "output":
 		if len(n.Args) == 2 {
 			if context.Outputs == nil || len(context.Outputs) == 0 {
@@ -550,7 +550,7 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 				return nil, err
 			}
 			if _, ok := context.Outputs[FormatAsString(step)]; !ok {
-				return nil, fmt.Errorf("step %s is not found in output collection", FormatAsString(step))
+				return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("step %s is not found in output collection", FormatAsString(step)), v1alpha2.BadConfig)
 			}
 			property, err := readPropertyInterface(context.Outputs[FormatAsString(step)], FormatAsString(key))
 			if err != nil {
@@ -558,7 +558,7 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 			}
 			return property, nil
 		}
-		return nil, fmt.Errorf("$output() expects 2 argument, found %d", len(n.Args))
+		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$output() expects 2 argument, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "equal":
 		if len(n.Args) == 2 {
 			v1, err := n.Args[0].Eval(context)
@@ -571,7 +571,7 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 			}
 			return compareInterfaces(v1, v2), nil
 		}
-		return nil, fmt.Errorf("$equal() expects 2 arguments, found %d", len(n.Args))
+		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$equal() expects 2 arguments, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "and":
 		if len(n.Args) == 2 {
 			val1, err := n.Args[0].Eval(context)
@@ -584,7 +584,7 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 			}
 			return andBools(val1, val2)
 		}
-		return nil, fmt.Errorf("$and() expects 2 arguments, found %d", len(n.Args))
+		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$and() expects 2 arguments, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "or":
 		if len(n.Args) == 2 {
 			val1, err := n.Args[0].Eval(context)
@@ -597,7 +597,7 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 			}
 			return orBools(val1, val2)
 		}
-		return nil, fmt.Errorf("$or() expects 2 arguments, found %d", len(n.Args))
+		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$or() expects 2 arguments, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "not":
 		if len(n.Args) == 1 {
 			val, err := n.Args[0].Eval(context)
@@ -606,7 +606,7 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 			}
 			return notBool(val)
 		}
-		return nil, fmt.Errorf("$not() expects 1 argument, found %d", len(n.Args))
+		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$not() expects 1 argument, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "gt":
 		if len(n.Args) == 2 {
 			val1, err := n.Args[0].Eval(context)
@@ -621,11 +621,11 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 				if fVal2, ok2 := toNumber((val2)); ok2 {
 					return fVal1 > fVal2, nil
 				}
-				return nil, fmt.Errorf("%v is not a valid number", val2)
+				return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("%v is not a valid number", val2), v1alpha2.BadConfig)
 			}
-			return nil, fmt.Errorf("%v is not a valid number", val1)
+			return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("%v is not a valid number", val1), v1alpha2.BadConfig)
 		}
-		return nil, fmt.Errorf("$gt() expects 2 arguments, found %d", len(n.Args))
+		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$gt() expects 2 arguments, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "ge":
 		if len(n.Args) == 2 {
 			val1, err := n.Args[0].Eval(context)
@@ -640,11 +640,11 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 				if fVal2, ok2 := toNumber((val2)); ok2 {
 					return fVal1 >= fVal2, nil
 				}
-				return nil, fmt.Errorf("%v is not a valid number", val2)
+				return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("%v is not a valid number", val2), v1alpha2.BadConfig)
 			}
-			return nil, fmt.Errorf("%v is not a valid number", val1)
+			return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("%v is not a valid number", val1), v1alpha2.BadConfig)
 		}
-		return nil, fmt.Errorf("$ge() expects 2 arguments, found %d", len(n.Args))
+		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$ge() expects 2 arguments, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "if":
 		if len(n.Args) == 3 {
 			cond, err := n.Args[0].Eval(context)
@@ -657,7 +657,7 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 				return n.Args[2].Eval(context)
 			}
 		}
-		return nil, fmt.Errorf("$if() expects 3 arguments, found %d", len(n.Args))
+		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$if() expects 3 arguments, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "in":
 		if len(n.Args) >= 2 {
 			val, err := n.Args[0].Eval(context)
@@ -675,7 +675,7 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 			}
 			return false, nil
 		}
-		return nil, fmt.Errorf("$in() expects at least 2 arguments, found %d", len(n.Args))
+		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$in() expects at least 2 arguments, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "lt":
 		if len(n.Args) == 2 {
 			val1, err := n.Args[0].Eval(context)
@@ -690,11 +690,11 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 				if fVal2, ok2 := toNumber((val2)); ok2 {
 					return fVal1 < fVal2, nil
 				}
-				return nil, fmt.Errorf("%v is not a valid number", val2)
+				return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("%v is not a valid number", val2), v1alpha2.BadConfig)
 			}
-			return nil, fmt.Errorf("%v is not a valid number", val1)
+			return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("%v is not a valid number", val1), v1alpha2.BadConfig)
 		}
-		return nil, fmt.Errorf("$lt() expects 2 arguments, found %d", len(n.Args))
+		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$lt() expects 2 arguments, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "between":
 		if len(n.Args) == 3 {
 			val1, err := n.Args[0].Eval(context)
@@ -714,13 +714,13 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 					if fVal3, ok2 := toNumber((val3)); ok2 {
 						return fVal1 >= fVal2 && fVal1 <= fVal3, nil
 					}
-					return nil, fmt.Errorf("%v is not a valid number", val3)
+					return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("%v is not a valid number", val3), v1alpha2.BadConfig)
 				}
-				return nil, fmt.Errorf("%v is not a valid number", val2)
+				return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("%v is not a valid number", val2), v1alpha2.BadConfig)
 			}
-			return nil, fmt.Errorf("%v is not a valid number", val1)
+			return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("%v is not a valid number", val1), v1alpha2.BadConfig)
 		}
-		return nil, fmt.Errorf("$le() expects 2 arguments, found %d", len(n.Args))
+		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$le() expects 2 arguments, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "le":
 		if len(n.Args) == 2 {
 			val1, err := n.Args[0].Eval(context)
@@ -735,11 +735,11 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 				if fVal2, ok2 := toNumber((val2)); ok2 {
 					return fVal1 <= fVal2, nil
 				}
-				return nil, fmt.Errorf("%v is not a valid number", val2)
+				return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("%v is not a valid number", val2), v1alpha2.BadConfig)
 			}
-			return nil, fmt.Errorf("%v is not a valid number", val1)
+			return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("%v is not a valid number", val1), v1alpha2.BadConfig)
 		}
-		return nil, fmt.Errorf("$le() expects 2 arguments, found %d", len(n.Args))
+		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$le() expects 2 arguments, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "config":
 		if len(n.Args) >= 2 {
 			if context.ConfigProvider == nil {
@@ -767,7 +767,7 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 
 			return context.ConfigProvider.Get(FormatAsString(obj), FormatAsString(field), overlays, context)
 		}
-		return nil, fmt.Errorf("$config() expects 2 arguments, found %d", len(n.Args))
+		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$config() expects 2 arguments, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "secret":
 		if len(n.Args) == 2 {
 			if context.SecretProvider == nil {
@@ -783,7 +783,7 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 			}
 			return context.SecretProvider.Get(FormatAsString(obj), FormatAsString(field))
 		}
-		return nil, fmt.Errorf("$secret() expects 2 arguments, found %d", len(n.Args))
+		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$secret() expects 2 arguments, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "instance":
 		if len(n.Args) == 0 {
 			if deploymentSpec, ok := context.DeploymentSpec.(model.DeploymentSpec); ok {
@@ -791,7 +791,7 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 			}
 			return nil, errors.New("deployment spec is not found")
 		}
-		return nil, fmt.Errorf("$instance() expects 0 arguments, found %d", len(n.Args))
+		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$instance() expects 0 arguments, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "val", "context":
 		if len(n.Args) == 0 {
 			return context.Value, nil
@@ -813,14 +813,14 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 					if v, ok := mobj[path]; ok {
 						return v, nil
 					} else {
-						return nil, fmt.Errorf("key %s is not found in context value", path)
+						return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("key %s is not found in context value", path), v1alpha2.BadConfig)
 					}
 				} else {
-					return nil, fmt.Errorf("context value '%v' is not a map", context.Value)
+					return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("context value '%v' is not a map", context.Value), v1alpha2.BadConfig)
 				}
 			}
 		}
-		return nil, fmt.Errorf("$val() or $context() expects 0 or 1 argument, found %d", len(n.Args))
+		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$val() or $context() expects 0 or 1 argument, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "json":
 		if len(n.Args) == 1 {
 			val, err := n.Args[0].Eval(context)
@@ -833,9 +833,9 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 			}
 			return string(jData), nil
 		}
-		return nil, fmt.Errorf("$json() expects 1 argument, fount %d", len(n.Args))
+		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$json() expects 1 argument, fount %d", len(n.Args)), v1alpha2.BadConfig)
 	}
-	return nil, fmt.Errorf("invalid function name: '%s'", n.Name)
+	return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("invalid function name: '%s'", n.Name), v1alpha2.BadConfig)
 }
 
 type Parser struct {
@@ -1039,7 +1039,7 @@ func (p *ExpressionParser) match(t Token) error {
 	if p.token == t {
 		p.next()
 	} else {
-		return fmt.Errorf("expected %T, got %s", t, p.text)
+		return v1alpha2.NewCOAError(nil, fmt.Sprintf("expected %T, got %s", t, p.text), v1alpha2.BadConfig)
 	}
 	return nil
 }
@@ -1257,7 +1257,7 @@ func (p *ExpressionParser) function() (Node, error) {
 			return nil, err
 		}
 		if _, ok := node.(*NullNode); ok {
-			return nil, fmt.Errorf("invalid argument")
+			return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("invalid argument"), v1alpha2.BadConfig)
 		}
 		args = append(args, node)
 		if p.token == COMMA {
@@ -1282,7 +1282,7 @@ func EvaluateDeployment(context utils.EvaluationContext) (model.DeploymentSpec, 
 			if val != nil {
 				metadata, ok := val.(map[string]string)
 				if !ok {
-					return deploymentSpec, fmt.Errorf("metadata must be a map")
+					return deploymentSpec, v1alpha2.NewCOAError(nil, fmt.Sprintf("metadata must be a map"), v1alpha2.BadConfig)
 				}
 				stringMap := make(map[string]string)
 				for k, v := range metadata {
@@ -1297,7 +1297,7 @@ func EvaluateDeployment(context utils.EvaluationContext) (model.DeploymentSpec, 
 			}
 			props, ok := val.(map[string]interface{})
 			if !ok {
-				return deploymentSpec, fmt.Errorf("properties must be a map")
+				return deploymentSpec, v1alpha2.NewCOAError(nil, fmt.Sprintf("properties must be a map"), v1alpha2.BadConfig)
 			}
 			deploymentSpec.Solution.Spec.Components[ic].Properties = props
 		}
@@ -1333,24 +1333,24 @@ func andBools(a, b interface{}) (bool, error) {
 		if bBool, ok := toBool(b); ok {
 			return aBool && bBool, nil
 		}
-		return false, fmt.Errorf("%v is not a boolean value", b)
+		return false, v1alpha2.NewCOAError(nil, fmt.Sprintf("%v is not a boolean value", b), v1alpha2.BadConfig)
 	}
-	return false, fmt.Errorf("%v is not a boolean value", a)
+	return false, v1alpha2.NewCOAError(nil, fmt.Sprintf("%v is not a boolean value", a), v1alpha2.BadConfig)
 }
 func orBools(a, b interface{}) (bool, error) {
 	if aBool, ok := toBool(a); ok {
 		if bBool, ok := toBool(b); ok {
 			return aBool || bBool, nil
 		}
-		return false, fmt.Errorf("%v is not a boolean value", b)
+		return false, v1alpha2.NewCOAError(nil, fmt.Sprintf("%v is not a boolean value", b), v1alpha2.BadConfig)
 	}
-	return false, fmt.Errorf("%v is not a boolean value", a)
+	return false, v1alpha2.NewCOAError(nil, fmt.Sprintf("%v is not a boolean value", a), v1alpha2.BadConfig)
 }
 func notBool(a interface{}) (bool, error) {
 	if aBool, ok := toBool(a); ok {
 		return !aBool, nil
 	}
-	return false, fmt.Errorf("%v is not a boolean value", a)
+	return false, v1alpha2.NewCOAError(nil, fmt.Sprintf("%v is not a boolean value", a), v1alpha2.BadConfig)
 }
 func toBool(val interface{}) (bool, bool) {
 	switch val := val.(type) {

--- a/api/pkg/apis/v1alpha1/utils/utils.go
+++ b/api/pkg/apis/v1alpha1/utils/utils.go
@@ -62,10 +62,10 @@ func GetString(col map[string]string, key string) (string, error) {
 		if sok {
 			return s, nil
 		} else {
-			return "", fmt.Errorf("value of %s is not a string", key)
+			return "", v1alpha2.NewCOAError(nil, fmt.Sprintf("value of %s is not a string", key), v1alpha2.BadConfig)
 		}
 	}
-	return "", fmt.Errorf("key %s is not found", key)
+	return "", v1alpha2.NewCOAError(nil, fmt.Sprintf("key %s is not found", key), v1alpha2.BadConfig)
 }
 
 func ReadStringFromMapCompat(col map[string]interface{}, key string, defaultVal string) string {

--- a/api/pkg/apis/v1alpha1/utils/utils_test.go
+++ b/api/pkg/apis/v1alpha1/utils/utils_test.go
@@ -269,11 +269,11 @@ func TestGetString(t *testing.T) {
 
 	val, err = GetString(mapData, "c")
 	assert.NotNil(t, err)
-	assert.EqualError(t, err, "value of c is not a string")
+	assert.EqualError(t, err, "Bad Config: value of c is not a string")
 
 	val, err = GetString(mapData, "d")
 	assert.NotNil(t, err)
-	assert.EqualError(t, err, "key d is not found")
+	assert.EqualError(t, err, "Bad Config: key d is not found")
 }
 func TestReadStringFromMapCompat(t *testing.T) {
 	mapData := map[string]interface{}{

--- a/api/pkg/apis/v1alpha1/vendors/catalogs-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/catalogs-vendor.go
@@ -69,15 +69,15 @@ func (e *CatalogsVendor) Init(config vendors.VendorConfig, factories []managers.
 				}
 				err := e.CatalogsManager.UpsertState(context.TODO(), name, catalog)
 				if err != nil {
-					return v1alpha2.NewCOAError(err, "failed to upsert catalog", v1alpha2.InternalError)
+					return err
 				}
 			} else {
 				iLog.Errorf("Failed to unmarshal job body: %v", err)
-				return err
+				return v1alpha2.NewCOAError(err, "failed to unmarshal job body", v1alpha2.BadConfig)
 			}
 		} else {
 			iLog.Errorf("Failed to unmarshal job data: %v", err)
-			return err
+			return v1alpha2.NewCOAError(err, "failed to unmarshal catalog state", v1alpha2.BadConfig)
 		}
 		return nil
 	})

--- a/api/pkg/apis/v1alpha1/vendors/stage-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/stage-vendor.go
@@ -199,7 +199,7 @@ func (s *StageVendor) Init(config vendors.VendorConfig, factories []managers.IMa
 		campaign, ok := status.Outputs["__campaign"].(string)
 		if !ok {
 			sLog.Errorf("V (Stage): failed to get campaign name from job report")
-			return fmt.Errorf("job-report: campaign is not valid")
+			return v1alpha2.NewCOAError(nil, "job-report: campaign is not valid", v1alpha2.BadRequest)
 		}
 		namespace, ok := status.Outputs["__namespace"].(string)
 		if !ok {
@@ -209,7 +209,7 @@ func (s *StageVendor) Init(config vendors.VendorConfig, factories []managers.IMa
 		activation, ok := status.Outputs["__activation"].(string)
 		if !ok {
 			sLog.Errorf("V (Stage): failed to get activation name from job report")
-			return fmt.Errorf("job-report: activation is not valid")
+			return v1alpha2.NewCOAError(nil, "job-report: activation is not valid", v1alpha2.BadRequest)
 		}
 		if status.Status == v1alpha2.Done || status.Status == v1alpha2.OK {
 			campaignName := api_utils.ReplaceSeperator(campaign)

--- a/coa/pkg/apis/v1alpha2/errors.go
+++ b/coa/pkg/apis/v1alpha2/errors.go
@@ -83,3 +83,18 @@ func IsBadConfig(err error) bool {
 	}
 	return coaE.State == BadConfig
 }
+
+func IsRetriableErr(err error) bool {
+	coaE, ok := err.(COAError)
+	if !ok {
+		return true
+	}
+	switch coaE.State {
+	case BadRequest, Unauthorized, NotFound, BadConfig, MethodNotAllowed, Conflict, MissingConfig, InvalidArgument, DeserializeError, SerializationError:
+		return false
+	case ValidateFailed: // catalog manager
+		return false
+	default:
+		return true
+	}
+}

--- a/coa/pkg/apis/v1alpha2/events.go
+++ b/coa/pkg/apis/v1alpha2/events.go
@@ -23,6 +23,28 @@ func (e Event) MarshalBinary() (data []byte, err error) {
 
 type EventHandler func(topic string, message Event) error
 
+func EventShouldRetryWrapper(handler EventHandler, topic string, message Event) bool {
+	err := handler(topic, message)
+	if err != nil {
+		coaE, ok := err.(COAError)
+		if !ok {
+			// error is not a COAError, which comes from external system
+			// always retry
+			return true
+		}
+		switch coaE.State {
+		case BadRequest, Unauthorized, NotFound, BadConfig, MethodNotAllowed, Conflict, MissingConfig, InvalidArgument, DeserializeError, SerializationError:
+			return false
+		case ValidateFailed: // catalog manager
+			return false
+		default:
+			return true
+		}
+	}
+
+	return false
+}
+
 type JobAction string
 
 const (

--- a/coa/pkg/apis/v1alpha2/events.go
+++ b/coa/pkg/apis/v1alpha2/events.go
@@ -26,20 +26,7 @@ type EventHandler func(topic string, message Event) error
 func EventShouldRetryWrapper(handler EventHandler, topic string, message Event) bool {
 	err := handler(topic, message)
 	if err != nil {
-		coaE, ok := err.(COAError)
-		if !ok {
-			// error is not a COAError, which comes from external system
-			// always retry
-			return true
-		}
-		switch coaE.State {
-		case BadRequest, Unauthorized, NotFound, BadConfig, MethodNotAllowed, Conflict, MissingConfig, InvalidArgument, DeserializeError, SerializationError:
-			return false
-		case ValidateFailed: // catalog manager
-			return false
-		default:
-			return true
-		}
+		return IsRetriableErr(err)
 	}
 
 	return false

--- a/coa/pkg/apis/v1alpha2/providers/pubsub/memory/memory.go
+++ b/coa/pkg/apis/v1alpha2/providers/pubsub/memory/memory.go
@@ -8,14 +8,22 @@ package memory
 
 import (
 	"encoding/json"
+	"strconv"
+	"time"
 
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	contexts "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	providers "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/logger"
 )
 
 var log = logger.NewLogger("coa.runtime")
+
+const (
+	DefaultRetryCount      = 5
+	DefaultRetryWaitSecond = 10
+)
 
 type InMemoryPubSubProvider struct {
 	Config      InMemoryPubSubConfig               `json:"config"`
@@ -24,13 +32,43 @@ type InMemoryPubSubProvider struct {
 }
 
 type InMemoryPubSubConfig struct {
-	Name string `json:"name"`
+	Name                      string `json:"name"`
+	SubscriberRetryCount      int    `json:"subscriberRetryCount"`
+	SubscriberRetryWaitSecond int    `json:"subscriberRetryWaitSecond"`
 }
 
 func InMemoryPubSubConfigFromMap(properties map[string]string) (InMemoryPubSubConfig, error) {
 	ret := InMemoryPubSubConfig{}
 	if v, ok := properties["name"]; ok {
 		ret.Name = v
+	}
+	ret.SubscriberRetryCount = 0
+	if v, ok := properties["subscriberRetryCount"]; ok {
+		val := v
+		if val != "" {
+			n, err := strconv.Atoi(val)
+			if err != nil {
+				return ret, v1alpha2.NewCOAError(err, "invalid int value in the 'SubscriberRetryCount' setting of Memory pub-sub provider", v1alpha2.BadConfig)
+			}
+			ret.SubscriberRetryCount = n
+		}
+	}
+	if ret.SubscriberRetryCount == 0 {
+		ret.SubscriberRetryCount = DefaultRetryCount
+	}
+	ret.SubscriberRetryWaitSecond = 0
+	if v, ok := properties["subscriberRetryWaitSecond"]; ok {
+		val := v
+		if val != "" {
+			n, err := strconv.Atoi(val)
+			if err != nil {
+				return ret, v1alpha2.NewCOAError(err, "invalid int value in the 'SubscriberRetryWaitSecond' setting of Memory pub-sub provider", v1alpha2.BadConfig)
+			}
+			ret.SubscriberRetryWaitSecond = n
+		}
+	}
+	if ret.SubscriberRetryWaitSecond == 0 {
+		ret.SubscriberRetryWaitSecond = DefaultRetryWaitSecond
 	}
 	return ret, nil
 }
@@ -67,7 +105,15 @@ func (i *InMemoryPubSubProvider) Publish(topic string, event v1alpha2.Event) err
 	if ok && arr != nil {
 		for _, s := range arr {
 			go func(handler v1alpha2.EventHandler, topic string, event v1alpha2.Event) {
-				handler(topic, event)
+				shouldRetry := true
+				count := 0
+				for shouldRetry && count < i.Config.SubscriberRetryCount {
+					shouldRetry = v1alpha2.EventShouldRetryWrapper(handler, topic, event)
+					if shouldRetry {
+						count++
+						time.Sleep(time.Duration(i.Config.SubscriberRetryWaitSecond) * time.Second)
+					}
+				}
 			}(s, topic, event)
 		}
 	}
@@ -89,8 +135,21 @@ func toInMemoryPubSubConfig(config providers.IProviderConfig) (InMemoryPubSubCon
 	if err != nil {
 		return ret, err
 	}
-	err = json.Unmarshal(data, &ret)
-	//ret.Name = providers.LoadEnv(ret.Name)
+
+	var configs map[string]interface{}
+	err = json.Unmarshal(data, &configs)
+	if err != nil {
+		return ret, err
+	}
+	configStrings := map[string]string{}
+	for k, v := range configs {
+		configStrings[k] = utils.FormatAsString(v)
+	}
+
+	ret, err = InMemoryPubSubConfigFromMap(configStrings)
+	if err != nil {
+		return ret, err
+	}
 	return ret, err
 }
 


### PR DESCRIPTION
Fix https://github.com/eclipse-symphony/symphony/issues/306

1. Add EventShouldRetryWrapper which check handler error type and decide whether pubsub provider should retry the handler
2. Add retry mechanism to memory pubsub with retry max count and retry interval.
3. Add max retry count to redis pubsub so events won't stay in redis server forever
4. Unify return error type as COAError with appropriate status code