### PR TITLE
Change appendonly config for redis

### DIFF
--- a/packages/helm/symphony/templates/redis-configmap.yaml
+++ b/packages/helm/symphony/templates/redis-configmap.yaml
@@ -6,8 +6,10 @@ data:
   redis.conf: |
     protected-mode {{ include "symphony.protectedMode" . }}
     port {{ .Values.redis.port }}
+{{- if .Values.redis.persistentVolume.enabled }}
     appendonly yes
     appendfsync always
     dir data
     appenddirname appendonlydir
+{{- end }}
   


### PR DESCRIPTION
Only enable appendonly config when persistent volume is present.