### PR TITLE
Workflow fixes

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/activations/activations-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/activations/activations-manager.go
@@ -325,6 +325,8 @@ func mergeStageStatus(activationState *model.ActivationState, current model.Stag
 	latestStage := &activationState.Status.StageHistory[len(activationState.Status.StageHistory)-1]
 	if latestStage.Status == v1alpha2.Done && latestStage.NextStage == "" {
 		activationState.Status.Status = v1alpha2.Done
+	} else if latestStage.Status == v1alpha2.Paused {
+		activationState.Status.Status = v1alpha2.Paused
 	} else {
 		activationState.Status.Status = v1alpha2.Running
 	}

--- a/api/pkg/apis/v1alpha1/model/campaign.go
+++ b/api/pkg/apis/v1alpha1/model/campaign.go
@@ -110,7 +110,7 @@ type ActivationStatus struct {
 	UpdateTime           string         `json:"updateTime,omitempty"`
 	Status               v1alpha2.State `json:"status,omitempty"`
 	StatusMessage        string         `json:"statusMessage,omitempty"`
-	StageHistory         []StageStatus  `json:"stagehistory,omitempty"`
+	StageHistory         []StageStatus  `json:"stageHistory,omitempty"`
 }
 type StageStatus struct {
 	Stage         string                 `json:"stage,omitempty"`

--- a/coa/pkg/apis/v1alpha2/providers/states/redisstate/redisstate.go
+++ b/coa/pkg/apis/v1alpha2/providers/states/redisstate/redisstate.go
@@ -29,7 +29,7 @@ var rLog = logger.NewLogger("coa.runtime")
 
 const (
 	entryCountPerList = 100
-	separator         = ":"
+	separator         = "*"
 )
 
 type RedisStateProviderConfig struct {

--- a/k8s/apis/workflow/v1/activation_types.go
+++ b/k8s/apis/workflow/v1/activation_types.go
@@ -17,10 +17,9 @@ import (
 type ActivationStatus struct {
 	Status               v1alpha2.State `json:"status,omitempty"`
 	StatusMessage        string         `json:"statusMessage,omitempty"`
-	ErrorMessage         string         `json:"errorMessage,omitempty"`
 	ActivationGeneration string         `json:"activationGeneration,omitempty"`
 	UpdateTime           string         `json:"updateTime,omitempty"`
-	StageHistory         []StageStatus  `json:"stagehistory,omitempty"`
+	StageHistory         []StageStatus  `json:"stageHistory,omitempty"`
 }
 
 type StageStatus struct {

--- a/k8s/config/oss/crd/bases/workflow.symphony_activations.yaml
+++ b/k8s/config/oss/crd/bases/workflow.symphony_activations.yaml
@@ -53,9 +53,7 @@ spec:
             properties:
               activationGeneration:
                 type: string
-              errorMessage:
-                type: string
-              stagehistory:
+              stageHistory:
                 items:
                   properties:
                     errorMessage:

--- a/packages/helm/symphony/templates/symphony-core/symphonyk8s.yaml
+++ b/packages/helm/symphony/templates/symphony-core/symphonyk8s.yaml
@@ -64,9 +64,7 @@ spec:
             properties:
               activationGeneration:
                 type: string
-              errorMessage:
-                type: string
-              stagehistory:
+              stageHistory:
                 items:
                   properties:
                     errorMessage:

--- a/test/integration/scenarios/04.workflow/manifest/campaign.yaml
+++ b/test/integration/scenarios/04.workflow/manifest/campaign.yaml
@@ -36,6 +36,7 @@ spec:
       name: deploy
       provider: providers.stage.materialize
       stageSelector: ""
+      schedule: "2020-10-31T12:00:00-07:00"
       config:
         baseUrl: http://symphony-service:8080/v1alpha2/
         user: admin


### PR DESCRIPTION
- Change k8s Activation Custom resource

   - stagehistory -> stageHistory
   - remove unneeded errorMessage field

- Change activation status to Paused if latest stage status is paused
- Change redis state provider separator to "*" since ":" can be used by reference