### PR TITLE
using new tracing for config and secret managers and providers

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/configs/configs-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/configs/configs-manager.go
@@ -7,6 +7,7 @@
 package configs
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -14,6 +15,8 @@ import (
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
+	observability "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/observability"
+	observ_utils "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/observability/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/config"
 	"github.com/eclipse-symphony/symphony/coa/pkg/logger"
@@ -63,7 +66,13 @@ func (s *ConfigsManager) Init(context *contexts.VendorContext, cfg managers.Mana
 	return nil
 }
 func (s *ConfigsManager) Get(object string, field string, overlays []string, localContext interface{}) (interface{}, error) {
-	log.Debugf(" M (Config): Get %v, config provider size %d", object, len(s.ConfigProviders))
+	ctx, span := observability.StartSpan("Config Manager", context.TODO(), &map[string]string{
+		"method": "Get",
+	})
+	var err error = nil
+	defer observ_utils.CloseSpanWithError(span, &err)
+	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
+	log.DebugfCtx(ctx, " M (Config): Get %v, config provider size %d", object, len(s.ConfigProviders))
 	if strings.Index(object, "::") > 0 {
 		parts := strings.Split(object, "::")
 		if len(parts) != 2 {
@@ -71,27 +80,28 @@ func (s *ConfigsManager) Get(object string, field string, overlays []string, loc
 		}
 		if provider, ok := s.ConfigProviders[parts[0]]; ok {
 			if field == "" {
-				configObj, err := s.getObjectWithOverlay(provider, parts[1], overlays, localContext)
+				configObj, err := s.getObjectWithOverlay(ctx, provider, parts[1], overlays, localContext)
 				if err != nil {
 					return "", err
 				}
 				return configObj, nil
 			} else {
-				return s.getWithOverlay(provider, parts[1], field, overlays, localContext)
+				return s.getWithOverlay(ctx, provider, parts[1], field, overlays, localContext)
 			}
 		}
-		return "", v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid provider: %s", parts[0]), v1alpha2.BadRequest)
+		err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid provider: %s", parts[0]), v1alpha2.BadRequest)
+		return "", err
 	}
 	if len(s.ConfigProviders) == 1 {
 		for _, provider := range s.ConfigProviders {
 			if field == "" {
-				configObj, err := s.getObjectWithOverlay(provider, object, overlays, localContext)
+				configObj, err := s.getObjectWithOverlay(ctx, provider, object, overlays, localContext)
 				if err != nil {
 					return "", err
 				}
 				return configObj, nil
 			} else {
-				if value, err := s.getWithOverlay(provider, object, field, overlays, localContext); err == nil {
+				if value, err := s.getWithOverlay(ctx, provider, object, field, overlays, localContext); err == nil {
 					return value, nil
 				} else {
 					return "", err
@@ -102,46 +112,54 @@ func (s *ConfigsManager) Get(object string, field string, overlays []string, loc
 	for _, key := range s.Precedence {
 		if provider, ok := s.ConfigProviders[key]; ok {
 			if field == "" {
-				configObj, err := s.getObjectWithOverlay(provider, object, overlays, localContext)
+				configObj, err := s.getObjectWithOverlay(ctx, provider, object, overlays, localContext)
 				if err != nil {
 					return "", err
 				}
 				return configObj, nil
 			} else {
-				if value, err := s.getWithOverlay(provider, object, field, overlays, localContext); err == nil {
+				if value, err := s.getWithOverlay(ctx, provider, object, field, overlays, localContext); err == nil {
 					return value, nil
 				}
 			}
 		}
 	}
-	return "", v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid config object or key: %s, %s", object, field), v1alpha2.BadRequest)
+	err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid config object or key: %s, %s", object, field), v1alpha2.BadRequest)
+	return "", err
 }
-func (s *ConfigsManager) getWithOverlay(provider config.IConfigProvider, object string, field string, overlays []string, localContext interface{}) (interface{}, error) {
+func (s *ConfigsManager) getWithOverlay(ctx context.Context, provider config.IConfigProvider, object string, field string, overlays []string, localContext interface{}) (interface{}, error) {
 	if len(overlays) > 0 {
 		for _, overlay := range overlays {
-			if overlayObject, err := provider.Read(overlay, field, localContext); err == nil {
+			if overlayObject, err := provider.Read(ctx, overlay, field, localContext); err == nil {
 				return overlayObject, nil
 			}
 		}
 	}
-	return provider.Read(object, field, localContext)
+	return provider.Read(ctx, object, field, localContext)
 }
 
 func (s *ConfigsManager) GetObject(object string, overlays []string, localContext interface{}) (map[string]interface{}, error) {
-	log.Debugf(" M (Config): GetObject %v, config provider size %d", object, len(s.ConfigProviders))
+	ctx, span := observability.StartSpan("Config Manager", context.TODO(), &map[string]string{
+		"method": "GetObject",
+	})
+	var err error = nil
+	defer observ_utils.CloseSpanWithError(span, &err)
+	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
+	log.DebugfCtx(ctx, " M (Config): GetObject %v, config provider size %d", object, len(s.ConfigProviders))
 	if strings.Index(object, "::") > 0 {
 		parts := strings.Split(object, "::")
 		if len(parts) != 2 {
 			return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid object: %s", object), v1alpha2.BadRequest)
 		}
 		if provider, ok := s.ConfigProviders[parts[0]]; ok {
-			return s.getObjectWithOverlay(provider, parts[1], overlays, localContext)
+			return s.getObjectWithOverlay(ctx, provider, parts[1], overlays, localContext)
 		}
-		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid provider: %s", parts[0]), v1alpha2.BadRequest)
+		err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid provider: %s", parts[0]), v1alpha2.BadRequest)
+		return nil, err
 	}
 	if len(s.ConfigProviders) == 1 {
 		for _, provider := range s.ConfigProviders {
-			if value, err := s.getObjectWithOverlay(provider, object, overlays, localContext); err == nil {
+			if value, err := s.getObjectWithOverlay(ctx, provider, object, overlays, localContext); err == nil {
 				return value, nil
 			} else {
 				return nil, err
@@ -150,124 +168,161 @@ func (s *ConfigsManager) GetObject(object string, overlays []string, localContex
 	}
 	for _, key := range s.Precedence {
 		if provider, ok := s.ConfigProviders[key]; ok {
-			if value, err := s.getObjectWithOverlay(provider, object, overlays, localContext); err == nil {
+			if value, err := s.getObjectWithOverlay(ctx, provider, object, overlays, localContext); err == nil {
 				return value, nil
 			}
 		}
 	}
-	return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid config object: %s", object), v1alpha2.BadRequest)
+	err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid config object: %s", object), v1alpha2.BadRequest)
+	return nil, err
 }
-func (s *ConfigsManager) getObjectWithOverlay(provider config.IConfigProvider, object string, overlays []string, localContext interface{}) (map[string]interface{}, error) {
+func (s *ConfigsManager) getObjectWithOverlay(ctx context.Context, provider config.IConfigProvider, object string, overlays []string, localContext interface{}) (map[string]interface{}, error) {
 	if len(overlays) > 0 {
 		for _, overlay := range overlays {
-			if overlayObject, err := provider.ReadObject(overlay, localContext); err == nil {
+			if overlayObject, err := provider.ReadObject(ctx, overlay, localContext); err == nil {
 				return overlayObject, nil
 			}
 		}
 	}
-	return provider.ReadObject(object, localContext)
+	return provider.ReadObject(ctx, object, localContext)
 }
 func (s *ConfigsManager) Set(object string, field string, value interface{}) error {
-	log.Debugf(" M (Config): Set %v, config provider size %d", object, len(s.ConfigProviders))
+	ctx, span := observability.StartSpan("Config Manager", context.TODO(), &map[string]string{
+		"method": "Set",
+	})
+	var err error = nil
+	defer observ_utils.CloseSpanWithError(span, &err)
+	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
+	log.DebugfCtx(ctx, " M (Config): Set %v, config provider size %d", object, len(s.ConfigProviders))
 	if strings.Index(object, "::") > 0 {
 		parts := strings.Split(object, "::")
 		if len(parts) != 2 {
-			return v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid object: %s", object), v1alpha2.BadRequest)
+			err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid object: %s", object), v1alpha2.BadRequest)
+			return err
 		}
 		if provider, ok := s.ConfigProviders[parts[0]]; ok {
-			return provider.Set(parts[1], field, value)
+			return provider.Set(ctx, parts[1], field, value)
 		}
-		return v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid provider: %s", parts[0]), v1alpha2.BadRequest)
+		err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid provider: %s", parts[0]), v1alpha2.BadRequest)
+		return err
 	}
 	if len(s.ConfigProviders) == 1 {
 		for _, provider := range s.ConfigProviders {
-			return provider.Set(object, field, value)
+			return provider.Set(ctx, object, field, value)
 		}
 	}
 	for _, key := range s.Precedence {
 		if provider, ok := s.ConfigProviders[key]; ok {
-			if err := provider.Set(object, field, value); err == nil {
+			if err := provider.Set(ctx, object, field, value); err == nil {
 				return nil
 			}
 		}
 	}
-	return v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid config object or key: %s, %s", object, field), v1alpha2.BadRequest)
+	err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid config object or key: %s, %s", object, field), v1alpha2.BadRequest)
+	return err
 }
 func (s *ConfigsManager) SetObject(object string, values map[string]interface{}) error {
-	log.Debugf(" M (Config): SetObject %v, config provider size %d", object, len(s.ConfigProviders))
+	ctx, span := observability.StartSpan("Config Manager", context.TODO(), &map[string]string{
+		"method": "SetObject",
+	})
+	var err error = nil
+	defer observ_utils.CloseSpanWithError(span, &err)
+	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
+	log.DebugfCtx(ctx, " M (Config): SetObject %v, config provider size %d", object, len(s.ConfigProviders))
 	if strings.Index(object, "::") > 0 {
 		parts := strings.Split(object, "::")
 		if len(parts) != 2 {
-			return v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid object: %s", object), v1alpha2.BadRequest)
+			err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid object: %s", object), v1alpha2.BadRequest)
+			return err
 		}
 		if provider, ok := s.ConfigProviders[parts[0]]; ok {
-			return provider.SetObject(parts[1], values)
+			return provider.SetObject(ctx, parts[1], values)
 		}
-		return v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid provider: %s", parts[0]), v1alpha2.BadRequest)
+		err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid provider: %s", parts[0]), v1alpha2.BadRequest)
+		return err
 	}
 	if len(s.ConfigProviders) == 1 {
 		for _, provider := range s.ConfigProviders {
-			return provider.SetObject(object, values)
+			return provider.SetObject(ctx, object, values)
 		}
 	}
 	for _, key := range s.Precedence {
 		if provider, ok := s.ConfigProviders[key]; ok {
-			if err := provider.SetObject(object, values); err == nil {
+			if err := provider.SetObject(ctx, object, values); err == nil {
 				return nil
 			}
 		}
 	}
-	return v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid config object: %s", object), v1alpha2.BadRequest)
+	err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid config object: %s", object), v1alpha2.BadRequest)
+	return err
 }
 func (s *ConfigsManager) Delete(object string, field string) error {
-	log.Debugf(" M (Config): Delete %v, config provider size %d", object, len(s.ConfigProviders))
+	ctx, span := observability.StartSpan("Config Manager", context.TODO(), &map[string]string{
+		"method": "Delete",
+	})
+	var err error = nil
+	defer observ_utils.CloseSpanWithError(span, &err)
+	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
+	log.DebugfCtx(ctx, " M (Config): Delete %v, config provider size %d", object, len(s.ConfigProviders))
 	if strings.Index(object, "::") > 0 {
 		parts := strings.Split(object, "::")
 		if len(parts) != 2 {
-			return v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid object: %s", object), v1alpha2.BadRequest)
+			err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid object: %s", object), v1alpha2.BadRequest)
+			return err
 		}
 		if provider, ok := s.ConfigProviders[parts[0]]; ok {
-			return provider.Remove(parts[1], field)
+			return provider.Remove(ctx, parts[1], field)
 		}
-		return v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid provider: %s", parts[0]), v1alpha2.BadRequest)
+		err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid provider: %s", parts[0]), v1alpha2.BadRequest)
+		return err
 	}
 	if len(s.ConfigProviders) == 1 {
 		for _, provider := range s.ConfigProviders {
-			return provider.Remove(object, field)
+			return provider.Remove(ctx, object, field)
 		}
 	}
 	for _, key := range s.Precedence {
 		if provider, ok := s.ConfigProviders[key]; ok {
-			if err := provider.Remove(object, field); err == nil {
+			if err := provider.Remove(ctx, object, field); err == nil {
 				return nil
 			}
 		}
 	}
-	return v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid config object or key: %s, %s", object, field), v1alpha2.BadRequest)
+	err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid config object or key: %s, %s", object, field), v1alpha2.BadRequest)
+	return err
 }
 func (s *ConfigsManager) DeleteObject(object string) error {
-	log.Debugf(" M (Config): DeleteObject %v, config provider size %d", object, len(s.ConfigProviders))
+	ctx, span := observability.StartSpan("Config Manager", context.TODO(), &map[string]string{
+		"method": "DeleteObject",
+	})
+	var err error = nil
+	defer observ_utils.CloseSpanWithError(span, &err)
+	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
+	log.DebugfCtx(ctx, " M (Config): DeleteObject %v, config provider size %d", object, len(s.ConfigProviders))
 	if strings.Index(object, "::") > 0 {
 		parts := strings.Split(object, "::")
 		if len(parts) != 2 {
-			return v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid object: %s", object), v1alpha2.BadRequest)
+			err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid object: %s", object), v1alpha2.BadRequest)
+			return err
 		}
 		if provider, ok := s.ConfigProviders[parts[0]]; ok {
-			return provider.RemoveObject(parts[1])
+			return provider.RemoveObject(ctx, parts[1])
 		}
-		return v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid provider: %s", parts[0]), v1alpha2.BadRequest)
+		err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid provider: %s", parts[0]), v1alpha2.BadRequest)
+		return err
 	}
 	if len(s.ConfigProviders) == 1 {
 		for _, provider := range s.ConfigProviders {
-			return provider.RemoveObject(object)
+			return provider.RemoveObject(ctx, object)
 		}
 	}
 	for _, key := range s.Precedence {
 		if provider, ok := s.ConfigProviders[key]; ok {
-			if err := provider.RemoveObject(object); err == nil {
+			if err := provider.RemoveObject(ctx, object); err == nil {
 				return nil
 			}
 		}
 	}
-	return v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid config object: %s", object), v1alpha2.BadRequest)
+	err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid config object: %s", object), v1alpha2.BadRequest)
+	return err
 }

--- a/api/pkg/apis/v1alpha1/managers/configs/configs-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/configs/configs-manager_test.go
@@ -7,6 +7,7 @@
 package configs
 
 import (
+	"context"
 	"testing"
 
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
@@ -15,6 +16,8 @@ import (
 	memory "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/config/memoryconfig"
 	"github.com/stretchr/testify/assert"
 )
+
+var ctx = context.Background()
 
 func TestInit(t *testing.T) {
 	configProvider := memory.MemoryConfigProvider{}
@@ -215,8 +218,8 @@ func TestOverlayWithMultipleProviders(t *testing.T) {
 		Precedence: []string{"memory2", "memory1"},
 	}
 	assert.Nil(t, err)
-	provider1.Set("obj", "field", "obj::field")
-	provider2.Set("obj-overlay", "field", "overlay::field")
+	provider1.Set(ctx, "obj", "field", "obj::field")
+	provider2.Set(ctx, "obj-overlay", "field", "overlay::field")
 	val, err := manager.Get("obj", "field", []string{"obj-overlay"}, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "overlay::field", val)
@@ -248,7 +251,7 @@ func TestOverlayMissWithMultipleProviders(t *testing.T) {
 		Precedence: []string{"memory2", "memory1"},
 	}
 	assert.Nil(t, err)
-	provider1.Set("obj", "field", "obj::field")
+	provider1.Set(ctx, "obj", "field", "obj::field")
 	val, err := manager.Get("obj", "field", []string{"obj-overlay"}, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "obj::field", val)
@@ -280,8 +283,8 @@ func TestOverlayWithMultipleProvidersReversedPrecedence(t *testing.T) {
 		Precedence: []string{"memory1", "memory2"},
 	}
 	assert.Nil(t, err)
-	provider1.Set("obj", "field", "obj::field")
-	provider2.Set("obj-overlay", "field", "overlay::field")
+	provider1.Set(ctx, "obj", "field", "obj::field")
+	provider2.Set(ctx, "obj-overlay", "field", "overlay::field")
 	val, err := manager.Get("obj", "field", []string{"obj-overlay"}, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "obj::field", val)
@@ -314,8 +317,8 @@ func TestMultipleProvidersSameKey(t *testing.T) {
 		Precedence: []string{"memory2", "memory1"},
 	}
 	assert.Nil(t, err)
-	provider1.Set("obj", "field", "obj::field1")
-	provider2.Set("obj", "field", "obj::field2")
+	provider1.Set(ctx, "obj", "field", "obj::field1")
+	provider2.Set(ctx, "obj", "field", "obj::field2")
 	val, err := manager.Get("obj", "field", nil, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "obj::field2", val)

--- a/api/pkg/apis/v1alpha1/providers/config/catalog/catalogprovider.go
+++ b/api/pkg/apis/v1alpha1/providers/config/catalog/catalogprovider.go
@@ -115,7 +115,7 @@ func (m *CatalogConfigProvider) Read(ctx context.Context, object string, field s
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
-	clog.DebugCtx(ctx, " M (Catalog): Read, object: %s, field: %s", object, field)
+	clog.DebugfCtx(ctx, " M (Catalog): Read, object: %s, field: %s", object, field)
 	namespace := utils.GetNamespaceFromContext(localcontext)
 	object = utils.ConvertReferenceToObjectName(object)
 	catalog, err := m.ApiClient.GetCatalog(ctx, object, namespace, m.Config.User, m.Config.Password)
@@ -147,7 +147,7 @@ func (m *CatalogConfigProvider) ReadObject(ctx context.Context, object string, l
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
-	clog.DebugCtx(ctx, " M (Catalog): ReadObject, object: %s", object)
+	clog.DebugfCtx(ctx, " M (Catalog): ReadObject, object: %s", object)
 	namespace := utils.GetNamespaceFromContext(localcontext)
 	object = utils.ConvertReferenceToObjectName(object)
 
@@ -239,7 +239,7 @@ func (m *CatalogConfigProvider) Set(ctx context.Context, object string, field st
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
-	clog.DebugCtx(ctx, " M (Catalog): Set, object: %s, field: %s", object, field)
+	clog.DebugfCtx(ctx, " M (Catalog): Set, object: %s, field: %s", object, field)
 	catalog, err := m.getCatalogInDefaultNamespace(ctx, object)
 	if err != nil {
 		return err
@@ -256,7 +256,7 @@ func (m *CatalogConfigProvider) SetObject(ctx context.Context, object string, va
 	defer observ_utils.CloseSpanWithError(span, &err)
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
 
-	clog.DebugCtx(ctx, " M (Catalog): SetObject, object: %s", object)
+	clog.DebugfCtx(ctx, " M (Catalog): SetObject, object: %s", object)
 	catalog, err := m.getCatalogInDefaultNamespace(ctx, object)
 	if err != nil {
 		return err
@@ -276,7 +276,7 @@ func (m *CatalogConfigProvider) Remove(ctx context.Context, object string, field
 	defer observ_utils.CloseSpanWithError(span, &err)
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
 
-	clog.DebugCtx(ctx, " M (Catalog): Remove, object: %s, field: %s", object, field)
+	clog.DebugfCtx(ctx, " M (Catalog): Remove, object: %s, field: %s", object, field)
 	catlog, err := m.getCatalogInDefaultNamespace(ctx, object)
 	if err != nil {
 		return err
@@ -297,7 +297,7 @@ func (m *CatalogConfigProvider) RemoveObject(ctx context.Context, object string)
 	defer observ_utils.CloseSpanWithError(span, &err)
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
 
-	clog.DebugCtx(ctx, " M (Catalog): RemoveObject, object: %s", object)
+	clog.DebugfCtx(ctx, " M (Catalog): RemoveObject, object: %s", object)
 	object = utils.ConvertReferenceToObjectName(object)
 	return m.ApiClient.DeleteCatalog(ctx, object, m.Config.User, m.Config.Password)
 }

--- a/api/pkg/apis/v1alpha1/providers/config/catalog/catalogprovider_test.go
+++ b/api/pkg/apis/v1alpha1/providers/config/catalog/catalogprovider_test.go
@@ -7,6 +7,7 @@
 package catalog
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -20,6 +21,8 @@ import (
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/utils"
 	"github.com/stretchr/testify/assert"
 )
+
+var ctx = context.Background()
 
 type AuthResponse struct {
 	AccessToken string   `json:"accessToken"`
@@ -95,7 +98,7 @@ func TestRead(t *testing.T) {
 	}
 	assert.Nil(t, err)
 
-	res, err := provider.Read("catalog1:v1", "components", nil)
+	res, err := provider.Read(ctx, "catalog1:v1", "components", nil)
 	assert.Nil(t, err)
 	data, err := json.Marshal(res)
 	assert.Nil(t, err)
@@ -104,13 +107,13 @@ func TestRead(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "name", summary[0].Name)
 
-	res, err = provider.Read("catalog1:v1", "parentAttribute", nil)
+	res, err = provider.Read(ctx, "catalog1:v1", "parentAttribute", nil)
 	assert.Nil(t, err)
 	v, ok := res.(string)
 	assert.True(t, ok)
 	assert.Equal(t, "This is father", v)
 
-	res, err = provider.Read("catalog1:v1", "notExist", nil)
+	res, err = provider.Read(ctx, "catalog1:v1", "notExist", nil)
 	coaErr := err.(v1alpha2.COAError)
 	assert.Equal(t, v1alpha2.NotFound, coaErr.State)
 	assert.Empty(t, res)
@@ -168,7 +171,7 @@ func TestReadObject(t *testing.T) {
 	}
 	assert.Nil(t, err)
 
-	res, err := provider.ReadObject("catalog1:v1", nil)
+	res, err := provider.ReadObject(ctx, "catalog1:v1", nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "name", res["Name"])
 }
@@ -220,13 +223,13 @@ func TestSetandRemove(t *testing.T) {
 	}
 	assert.Nil(t, err)
 
-	err = provider.Set("catalog1", "random", "random")
+	err = provider.Set(ctx, "catalog1", "random", "random")
 	assert.Nil(t, err)
 
-	err = provider.Remove("catalog1", "components")
+	err = provider.Remove(ctx, "catalog1", "components")
 	assert.Nil(t, err)
 
-	err = provider.Remove("catalog1", "notExist")
+	err = provider.Remove(ctx, "catalog1", "notExist")
 	coeErr := err.(v1alpha2.COAError)
 	assert.Equal(t, v1alpha2.NotFound, coeErr.State)
 }
@@ -279,9 +282,9 @@ func TestSetandRemoveObject(t *testing.T) {
 	assert.Nil(t, err)
 	var data map[string]interface{} = make(map[string]interface{})
 	data["random"] = "random"
-	err = provider.SetObject("catalog1", data)
+	err = provider.SetObject(ctx, "catalog1", data)
 	assert.Nil(t, err)
 
-	err = provider.RemoveObject("catalog1")
+	err = provider.RemoveObject(ctx, "catalog1")
 	assert.Nil(t, err)
 }

--- a/api/pkg/apis/v1alpha1/providers/secret/k8s_test.go
+++ b/api/pkg/apis/v1alpha1/providers/secret/k8s_test.go
@@ -96,7 +96,7 @@ func TestK8sSecretProvider_Get(t *testing.T) {
 	evalContext := coa_utils.EvaluationContext{
 		Namespace: "default",
 	}
-	value, err := provider.Read("test-secret", "test-field", evalContext)
+	value, err := provider.Read(context.Background(), "test-secret", "test-field", evalContext)
 	assert.Nil(t, err)
 
 	// Check the value

--- a/api/pkg/apis/v1alpha1/vendors/settings-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/settings-vendor_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+var ctx = context.Background()
+
 func createSettingsVendor() SettingsVendor {
 	provider := memory.MemoryConfigProvider{}
 	provider.Init(memory.MemoryConfigProviderConfig{})
@@ -110,7 +112,7 @@ func TestConfigGet(t *testing.T) {
 	vendor := createSettingsVendor()
 	manager := vendor.EvaluationContext.ConfigProvider.(*configs.ConfigsManager)
 	provider := manager.ConfigProviders["memory"]
-	provider.Set("test", "field", "obj::field")
+	provider.Set(ctx, "test", "field", "obj::field")
 
 	request := &v1alpha2.COARequest{
 		Method:  fasthttp.MethodGet,
@@ -131,7 +133,7 @@ func TestConfigGetField(t *testing.T) {
 	vendor := createSettingsVendor()
 	manager := vendor.EvaluationContext.ConfigProvider.(*configs.ConfigsManager)
 	provider := manager.ConfigProviders["memory"]
-	provider.Set("test", "field", "obj::field")
+	provider.Set(ctx, "test", "field", "obj::field")
 
 	request := &v1alpha2.COARequest{
 		Method:  fasthttp.MethodGet,

--- a/coa/pkg/apis/v1alpha2/providers/config/config.go
+++ b/coa/pkg/apis/v1alpha2/providers/config/config.go
@@ -7,17 +7,19 @@
 package config
 
 import (
+	"context"
+
 	providers "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
 )
 
 type IConfigProvider interface {
 	Init(config providers.IProviderConfig) error
-	Read(object string, field string, localContext interface{}) (interface{}, error)
-	ReadObject(object string, localContext interface{}) (map[string]interface{}, error)
-	Set(object string, field string, value interface{}) error
-	SetObject(object string, value map[string]interface{}) error
-	Remove(object string, field string) error
-	RemoveObject(object string) error
+	Read(ctx context.Context, object string, field string, localContext interface{}) (interface{}, error)
+	ReadObject(ctx context.Context, object string, localContext interface{}) (map[string]interface{}, error)
+	Set(ctx context.Context, object string, field string, value interface{}) error
+	SetObject(ctx context.Context, object string, value map[string]interface{}) error
+	Remove(ctx context.Context, object string, field string) error
+	RemoveObject(ctx context.Context, object string) error
 }
 
 type IExtConfigProvider interface {

--- a/coa/pkg/apis/v1alpha2/providers/config/memoryconfig/memoryconfig.go
+++ b/coa/pkg/apis/v1alpha2/providers/config/memoryconfig/memoryconfig.go
@@ -7,6 +7,7 @@
 package memory
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -73,7 +74,7 @@ func toMemoryConfigProviderConfig(config providers.IProviderConfig) (MemoryConfi
 	ret.Name = utils.ParseProperty(ret.Name)
 	return ret, err
 }
-func (m *MemoryConfigProvider) Read(object string, field string, localContext interface{}) (interface{}, error) {
+func (m *MemoryConfigProvider) Read(ctx context.Context, object string, field string, localContext interface{}) (interface{}, error) {
 	if _, ok := m.ConfigData[object]; !ok {
 		return "", v1alpha2.NewCOAError(nil, "object not found", v1alpha2.NotFound)
 	}
@@ -82,20 +83,20 @@ func (m *MemoryConfigProvider) Read(object string, field string, localContext in
 	}
 	return m.ConfigData[object][field], nil
 }
-func (m *MemoryConfigProvider) ReadObject(object string, localContext interface{}) (map[string]interface{}, error) {
+func (m *MemoryConfigProvider) ReadObject(ctx context.Context, object string, localContext interface{}) (map[string]interface{}, error) {
 	if _, ok := m.ConfigData[object]; !ok {
 		return nil, v1alpha2.NewCOAError(nil, "object not found", v1alpha2.NotFound)
 	}
 	return m.ConfigData[object], nil
 }
-func (m *MemoryConfigProvider) Set(object string, field string, value interface{}) error {
+func (m *MemoryConfigProvider) Set(ctx context.Context, object string, field string, value interface{}) error {
 	if _, ok := m.ConfigData[object]; !ok {
 		m.ConfigData[object] = make(map[string]interface{})
 	}
 	m.ConfigData[object][field] = value
 	return nil
 }
-func (m *MemoryConfigProvider) SetObject(object string, value map[string]interface{}) error {
+func (m *MemoryConfigProvider) SetObject(ctx context.Context, object string, value map[string]interface{}) error {
 	if _, ok := m.ConfigData[object]; !ok {
 		m.ConfigData[object] = make(map[string]interface{})
 	}
@@ -104,7 +105,7 @@ func (m *MemoryConfigProvider) SetObject(object string, value map[string]interfa
 	}
 	return nil
 }
-func (m *MemoryConfigProvider) Remove(object string, field string) error {
+func (m *MemoryConfigProvider) Remove(ctx context.Context, object string, field string) error {
 	if _, ok := m.ConfigData[object]; !ok {
 		return v1alpha2.NewCOAError(nil, "object not found", v1alpha2.NotFound)
 	}
@@ -114,7 +115,7 @@ func (m *MemoryConfigProvider) Remove(object string, field string) error {
 	delete(m.ConfigData[object], field)
 	return nil
 }
-func (m *MemoryConfigProvider) RemoveObject(object string) error {
+func (m *MemoryConfigProvider) RemoveObject(ctx context.Context, object string) error {
 	if _, ok := m.ConfigData[object]; !ok {
 		return v1alpha2.NewCOAError(nil, "object not found", v1alpha2.NotFound)
 	}

--- a/coa/pkg/apis/v1alpha2/providers/config/memoryconfig/memoryconfig_test.go
+++ b/coa/pkg/apis/v1alpha2/providers/config/memoryconfig/memoryconfig_test.go
@@ -7,10 +7,13 @@
 package memory
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+var ctx = context.Background()
 
 func TestInit(t *testing.T) {
 	provider := MemoryConfigProvider{}
@@ -21,15 +24,15 @@ func TestGetEmpty(t *testing.T) {
 	provider := MemoryConfigProvider{}
 	err := provider.Init(MemoryConfigProviderConfig{})
 	assert.Nil(t, err)
-	_, err = provider.Read("obj", "field", nil)
+	_, err = provider.Read(ctx, "obj", "field", nil)
 	assert.NotNil(t, err)
 }
 func TestGet(t *testing.T) {
 	provider := MemoryConfigProvider{}
 	err := provider.Init(MemoryConfigProviderConfig{})
 	assert.Nil(t, err)
-	provider.Set("obj", "field", "obj::field")
-	val, err := provider.Read("obj", "field", nil)
+	provider.Set(ctx, "obj", "field", "obj::field")
+	val, err := provider.Read(ctx, "obj", "field", nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "obj::field", val)
 }
@@ -37,8 +40,8 @@ func TestGetObject(t *testing.T) {
 	provider := MemoryConfigProvider{}
 	err := provider.Init(MemoryConfigProviderConfig{})
 	assert.Nil(t, err)
-	provider.SetObject("obj", map[string]interface{}{"field": "obj::field"})
-	val, err := provider.ReadObject("obj", nil)
+	provider.SetObject(ctx, "obj", map[string]interface{}{"field": "obj::field"})
+	val, err := provider.ReadObject(ctx, "obj", nil)
 	assert.Nil(t, err)
 	assert.Equal(t, map[string]interface{}{"field": "obj::field"}, val)
 }
@@ -46,19 +49,19 @@ func TestDelete(t *testing.T) {
 	provider := MemoryConfigProvider{}
 	err := provider.Init(MemoryConfigProviderConfig{})
 	assert.Nil(t, err)
-	provider.Set("obj", "field", "obj::field")
-	err = provider.Remove("obj", "field")
+	provider.Set(ctx, "obj", "field", "obj::field")
+	err = provider.Remove(ctx, "obj", "field")
 	assert.Nil(t, err)
-	_, err = provider.Read("obj", "field", nil)
+	_, err = provider.Read(ctx, "obj", "field", nil)
 	assert.NotNil(t, err)
 }
 func TestDeleteObject(t *testing.T) {
 	provider := MemoryConfigProvider{}
 	err := provider.Init(MemoryConfigProviderConfig{})
 	assert.Nil(t, err)
-	provider.SetObject("obj", map[string]interface{}{"field": "obj::field"})
-	err = provider.RemoveObject("obj")
+	provider.SetObject(ctx, "obj", map[string]interface{}{"field": "obj::field"})
+	err = provider.RemoveObject(ctx, "obj")
 	assert.Nil(t, err)
-	_, err = provider.ReadObject("obj", nil)
+	_, err = provider.ReadObject(ctx, "obj", nil)
 	assert.NotNil(t, err)
 }

--- a/coa/pkg/apis/v1alpha2/providers/secret/conformance/secret_conformance.go
+++ b/coa/pkg/apis/v1alpha2/providers/secret/conformance/secret_conformance.go
@@ -7,6 +7,7 @@
 package conformance
 
 import (
+	"context"
 	"testing"
 
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/secret"
@@ -17,7 +18,7 @@ func GetSecretNotFound[P secret.ISecretProvider](t *testing.T, p P) {
 	// TODO: this case should fail. This is a prototype of conformance test suite
 	// but unfortunately the mock secret provider doesn't confirm with reasonable
 	// expected behavior
-	_, err := p.Read("fake_object", "fake_key", nil)
+	_, err := p.Read(context.TODO(), "fake_object", "fake_key", nil)
 	assert.Nil(t, err)
 }
 func ConformanceSuite[P secret.ISecretProvider](t *testing.T, p P) {

--- a/coa/pkg/apis/v1alpha2/providers/secret/mock/mockprovider.go
+++ b/coa/pkg/apis/v1alpha2/providers/secret/mock/mockprovider.go
@@ -7,6 +7,7 @@
 package mock
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
@@ -68,7 +69,7 @@ func toMockSecretProviderConfig(config providers.IProviderConfig) (MockSecretPro
 	ret.Name = utils.ParseProperty(ret.Name)
 	return ret, err
 }
-func (m *MockSecretProvider) Read(object string, field string, localContext interface{}) (string, error) {
+func (m *MockSecretProvider) Read(ctx context.Context, object string, field string, localContext interface{}) (string, error) {
 	return object + ">>" + field, nil
 }
 func (m *MockSecretProvider) Get(object string, field string, localContext interface{}) (string, error) {

--- a/coa/pkg/apis/v1alpha2/providers/secret/mock/mockprovider_test.go
+++ b/coa/pkg/apis/v1alpha2/providers/secret/mock/mockprovider_test.go
@@ -7,6 +7,7 @@
 package mock
 
 import (
+	"context"
 	"testing"
 
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
@@ -51,7 +52,7 @@ func TestGet(t *testing.T) {
 	provider := MockSecretProvider{}
 	err := provider.Init(MockSecretProviderConfig{})
 	assert.Nil(t, err)
-	val, err := provider.Read("obj", "field", nil)
+	val, err := provider.Read(context.Background(), "obj", "field", nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "obj>>field", val)
 }

--- a/coa/pkg/apis/v1alpha2/providers/secret/secret.go
+++ b/coa/pkg/apis/v1alpha2/providers/secret/secret.go
@@ -7,12 +7,14 @@
 package secret
 
 import (
+	"context"
+
 	providers "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
 )
 
 type ISecretProvider interface {
 	Init(config providers.IProviderConfig) error
-	Read(name string, field string, localContext interface{}) (string, error)
+	Read(ctx context.Context, name string, field string, localContext interface{}) (string, error)
 }
 
 type IExtSecretProvider interface {


### PR DESCRIPTION
Since jiawei's tracing PR, config secret manager and provider should follow the same way.

If we want to pass context to manager level, evaluationContext needs to add a context field. We shall make sure evaluationContext clone using the same evaluationContext's context and pass down and make sure it never reused. Change maybe a little bit heavy.