### PR TITLE
fix readme command to run symphony via docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ maestro up
 ### Using Helm
 You can also install Symphony using Helm by running the following command:
 ```Bash
-helm install symphony oci://ghcr.io/eclipse-symphony/helm/symphony --version '0.47.2'
+helm install symphony oci://ghcr.io/eclipse-symphony/helm/symphony --version '0.48.28'
 ```
 After Symphony is installed, you can use maestro to try out sample scenarios.
 
 ### Using Docker
-You can also install Symphony using Docker by running the following command:
+You can also install Symphony using Docker with the bundled `symphony-api.json` or volume mounting your own & injecting its reference via `CONFIG` env:
 ```Bash
-docker run -d --name symphony-api -p 8080:8080 ghcr.io/eclipse-symphony/symphony-api:0.47.1
+docker run -d --name symphony-api -p 8080:8080 -e CONFIG=/symphony-api.json ghcr.io/eclipse-symphony/symphony-api:0.48.28
 ```
 ### Using symphony-api binary
 You can also run Symphony in standalone mode as a single process by running the following command:


### PR DESCRIPTION
fix readme command to run symphony via docker. bumped the recommended version to 0.48.28.

container comes up as expected:
<img width="1585" alt="Screenshot 2024-08-21 at 11 34 43 PM" src="https://github.com/user-attachments/assets/47137d5e-5b87-4fad-9851-c98ffe74a53d">

without the readme fix:
<img width="896" alt="Screenshot 2024-08-21 at 11 35 44 PM" src="https://github.com/user-attachments/assets/dc990a83-743f-433d-941f-dfa61ad7f8b7">

validated the helm deploy also works with the new version (just in case):
<img width="851" alt="Screenshot 2024-08-21 at 11 48 41 PM" src="https://github.com/user-attachments/assets/3fad5f0f-b78d-4036-bd21-8fb16dfea9f7">