### PR TITLE
Turn off validation in standalone mode for cross type check

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/activations/activations-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/activations/activations-manager.go
@@ -52,7 +52,9 @@ func (s *ActivationsManager) Init(context *contexts.VendorContext, config manage
 	}
 	s.needValidate = managers.NeedObjectValidate(config, providers)
 	if s.needValidate {
-		s.Validator = validation.NewActivationValidator(s.CampaignLookup)
+		// Turn off validation of differnt types: https://github.com/eclipse-symphony/symphony/issues/445
+		// s.Validator = validation.NewActivationValidator(s.CampaignLookup)
+		s.Validator = validation.NewActivationValidator(nil)
 	}
 	return nil
 }

--- a/api/pkg/apis/v1alpha1/managers/activations/activations-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/activations/activations-manager.go
@@ -124,7 +124,9 @@ func (m *ActivationsManager) UpsertState(ctx context.Context, name string, state
 		if state.ObjectMeta.Labels == nil {
 			state.ObjectMeta.Labels = make(map[string]string)
 		}
-		state.ObjectMeta.Labels[constants.Campaign] = state.Spec.Campaign
+		if state.Spec != nil {
+			state.ObjectMeta.Labels[constants.Campaign] = state.Spec.Campaign
+		}
 		if err = m.ValidateCreateOrUpdate(ctx, state); err != nil {
 			return err
 		}

--- a/api/pkg/apis/v1alpha1/managers/activations/activations-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/activations/activations-manager_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
-	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
 	"github.com/stretchr/testify/assert"
 )
@@ -172,6 +171,8 @@ func TestUpdateStageStatusRemote(t *testing.T) {
 	assert.Equal(t, v1alpha2.Done.String(), state.Status.StageHistory[0].Outputs["child2.__status"])
 	assert.Nil(t, err)
 }
+
+/*
 func TestCreateActivationWithMissingCampaign(t *testing.T) {
 	stateProvider := &memorystate.MemoryStateProvider{}
 	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
@@ -275,3 +276,4 @@ func TestUpdateActivationWithRunningStatus(t *testing.T) {
 	})
 	assert.Contains(t, err.Error(), "spec is immutable: stage doesn't match")
 }
+*/

--- a/api/pkg/apis/v1alpha1/managers/campaigns/campaigns-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/campaigns/campaigns-manager.go
@@ -43,7 +43,9 @@ func (s *CampaignsManager) Init(context *contexts.VendorContext, config managers
 	}
 	s.needValidate = managers.NeedObjectValidate(config, providers)
 	if s.needValidate {
-		s.CampaignValidator = validation.NewCampaignValidator(s.CampaignContainerLookup, s.CampaignActivationsLookup)
+		// Turn off validation of differnt types: https://github.com/eclipse-symphony/symphony/issues/445
+		//s.CampaignValidator = validation.NewCampaignValidator(s.CampaignContainerLookup, s.CampaignActivationsLookup)
+		s.CampaignValidator = validation.NewCampaignValidator(nil, nil)
 	}
 	return nil
 }

--- a/api/pkg/apis/v1alpha1/managers/campaigns/campaigns-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/campaigns/campaigns-manager_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
-	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
 	"github.com/stretchr/testify/assert"
 )
@@ -36,6 +35,7 @@ func TestCreateGetDeleteCampaignSpec(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+/*
 func TestCreateCampaignWithMissingContainer(t *testing.T) {
 	stateProvider := &memorystate.MemoryStateProvider{}
 	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
@@ -218,3 +218,4 @@ func TestCreateCampaignWithWrongFirstStage(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "firstStage must be one of the stages in the stages list")
 }
+*/

--- a/api/pkg/apis/v1alpha1/managers/catalogs/catalogs-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/catalogs/catalogs-manager.go
@@ -54,7 +54,9 @@ func (s *CatalogsManager) Init(context *contexts.VendorContext, config managers.
 	}
 	s.needValidate = managers.NeedObjectValidate(config, providers)
 	if s.needValidate {
-		s.CatalogValidator = validation.NewCatalogValidator(s.CatalogLookup, s.CatalogContainerLookup, s.ChildCatalogLookup)
+		// Turn off validation of differnt types: https://github.com/eclipse-symphony/symphony/issues/445
+		// s.CatalogValidator = validation.NewCatalogValidator(s.CatalogLookup, s.CatalogContainerLookup, s.ChildCatalogLookup)
+		s.CatalogValidator = validation.NewCatalogValidator(s.CatalogLookup, nil, s.ChildCatalogLookup)
 	}
 	return nil
 }

--- a/api/pkg/apis/v1alpha1/managers/catalogs/catalogs-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/catalogs/catalogs-manager_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/pubsub/memory"
-	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
 	"github.com/stretchr/testify/assert"
 )
@@ -359,6 +358,7 @@ func TestParentCatalog(t *testing.T) {
 	assert.Contains(t, err.Error(), "Catalog has one or more child catalogs. Update or Deletion is not allowed")
 }
 
+/*
 func TestCatalogContainer(t *testing.T) {
 	err := initalizeManager()
 	assert.Nil(t, err)
@@ -407,3 +407,4 @@ func TestCatalogContainer(t *testing.T) {
 	})
 	assert.Nil(t, err)
 }
+*/

--- a/api/pkg/apis/v1alpha1/managers/instances/instances-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/instances/instances-manager.go
@@ -90,9 +90,11 @@ func (t *InstancesManager) UpsertState(ctx context.Context, name string, state m
 		if state.ObjectMeta.Labels == nil {
 			state.ObjectMeta.Labels = make(map[string]string)
 		}
-		state.ObjectMeta.Labels[constants.DisplayName] = utils.ConvertStringToValidLabel(state.Spec.DisplayName)
-		state.ObjectMeta.Labels[constants.Solution] = state.Spec.Solution
-		state.ObjectMeta.Labels[constants.Target] = state.Spec.Target.Name
+		if state.Spec != nil {
+			state.ObjectMeta.Labels[constants.DisplayName] = utils.ConvertStringToValidLabel(state.Spec.DisplayName)
+			state.ObjectMeta.Labels[constants.Solution] = state.Spec.Solution
+			state.ObjectMeta.Labels[constants.Target] = state.Spec.Target.Name
+		}
 		if err = t.ValidateCreateOrUpdate(ctx, state); err != nil {
 			return err
 		}

--- a/api/pkg/apis/v1alpha1/managers/instances/instances-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/instances/instances-manager.go
@@ -45,7 +45,9 @@ func (s *InstancesManager) Init(context *contexts.VendorContext, config managers
 	}
 	s.needValidate = managers.NeedObjectValidate(config, providers)
 	if s.needValidate {
-		s.InstanceValidator = validation.NewInstanceValidator(s.instanceUniqueNameLookup, s.solutionLookup, s.targetLookup)
+		// Turn off validation of differnt types: https://github.com/eclipse-symphony/symphony/issues/445
+		//s.InstanceValidator = validation.NewInstanceValidator(s.instanceUniqueNameLookup, s.solutionLookup, s.targetLookup)
+		s.InstanceValidator = validation.NewInstanceValidator(s.instanceUniqueNameLookup, nil, nil)
 	}
 	return nil
 }

--- a/api/pkg/apis/v1alpha1/managers/solutions/solutions-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/solutions/solutions-manager.go
@@ -45,7 +45,9 @@ func (s *SolutionsManager) Init(context *contexts.VendorContext, config managers
 	}
 	s.needValidate = managers.NeedObjectValidate(config, providers)
 	if s.needValidate {
-		s.SolutionValidator = validation.NewSolutionValidator(s.solutionInstanceLookup, s.solutionContainerLookup, s.uniqueNameSolutionLookup)
+		// Turn off validation of differnt types: https://github.com/eclipse-symphony/symphony/issues/445
+		// s.SolutionValidator = validation.NewSolutionValidator(s.solutionInstanceLookup, s.solutionContainerLookup, s.uniqueNameSolutionLookup)
+		s.SolutionValidator = validation.NewSolutionValidator(nil, nil, s.uniqueNameSolutionLookup)
 	}
 	return nil
 }

--- a/api/pkg/apis/v1alpha1/managers/solutions/solutions-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/solutions/solutions-manager.go
@@ -96,8 +96,10 @@ func (t *SolutionsManager) UpsertState(ctx context.Context, name string, state m
 		if state.ObjectMeta.Labels == nil {
 			state.ObjectMeta.Labels = make(map[string]string)
 		}
-		state.ObjectMeta.Labels[constants.DisplayName] = utils.ConvertStringToValidLabel(state.Spec.DisplayName)
-		state.ObjectMeta.Labels[constants.RootResource] = state.Spec.RootResource
+		if state.Spec != nil {
+			state.ObjectMeta.Labels[constants.DisplayName] = utils.ConvertStringToValidLabel(state.Spec.DisplayName)
+			state.ObjectMeta.Labels[constants.RootResource] = state.Spec.RootResource
+		}
 		if err = t.ValidateCreateOrUpdate(ctx, state); err != nil {
 			return err
 		}

--- a/api/pkg/apis/v1alpha1/managers/solutions/solutions-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/solutions/solutions-manager_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/validation"
-	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
 	"github.com/stretchr/testify/assert"
 )
@@ -61,50 +60,51 @@ func TestCreateSolutionWithMissingContainer(t *testing.T) {
 	assert.Contains(t, err.Error(), "rootResource must be a valid container")
 }
 
-func TestCreateSolutionWithContainer(t *testing.T) {
-	stateProvider := &memorystate.MemoryStateProvider{}
-	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
-	manager := SolutionsManager{
-		StateProvider: stateProvider,
-		needValidate:  true,
-	}
-	manager.SolutionValidator = validation.NewSolutionValidator(nil, manager.solutionContainerLookup, nil)
-	stateProvider.Upsert(context.Background(), states.UpsertRequest{
-		Value: states.StateEntry{
-			ID: "test",
-			Body: map[string]interface{}{
-				"apiVersion": model.SolutionGroup + "/v1",
-				"kind":       "SolutionContainer",
-				"metadata": model.ObjectMeta{
-					Name:      "test",
-					Namespace: "default",
+/*
+	func TestCreateSolutionWithContainer(t *testing.T) {
+		stateProvider := &memorystate.MemoryStateProvider{}
+		stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+		manager := SolutionsManager{
+			StateProvider: stateProvider,
+			needValidate:  true,
+		}
+		manager.SolutionValidator = validation.NewSolutionValidator(nil, manager.solutionContainerLookup, nil)
+		stateProvider.Upsert(context.Background(), states.UpsertRequest{
+			Value: states.StateEntry{
+				ID: "test",
+				Body: map[string]interface{}{
+					"apiVersion": model.SolutionGroup + "/v1",
+					"kind":       "SolutionContainer",
+					"metadata": model.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					"spec": model.SolutionContainerSpec{},
 				},
-				"spec": model.SolutionContainerSpec{},
+				ETag: "1",
 			},
-			ETag: "1",
-		},
-		Metadata: map[string]interface{}{
-			"namespace": "default",
-			"group":     model.SolutionGroup,
-			"version":   "v1",
-			"resource":  "solutioncontainers",
-			"kind":      "SolutionContainer",
-		},
-	})
+			Metadata: map[string]interface{}{
+				"namespace": "default",
+				"group":     model.SolutionGroup,
+				"version":   "v1",
+				"resource":  "solutioncontainers",
+				"kind":      "SolutionContainer",
+			},
+		})
 
-	err := manager.UpsertState(context.Background(), "test-v-v1", model.SolutionState{
-		ObjectMeta: model.ObjectMeta{
-			Name:      "test-v-v1",
-			Namespace: "default",
-		},
-		Spec: &model.SolutionSpec{
-			DisplayName:  "test-v-v1",
-			RootResource: "test",
-		},
-	})
-	assert.Nil(t, err)
-}
-
+		err := manager.UpsertState(context.Background(), "test-v-v1", model.SolutionState{
+			ObjectMeta: model.ObjectMeta{
+				Name:      "test-v-v1",
+				Namespace: "default",
+			},
+			Spec: &model.SolutionSpec{
+				DisplayName:  "test-v-v1",
+				RootResource: "test",
+			},
+		})
+		assert.Nil(t, err)
+	}
+*/
 func TestCreateSolutionWithSameDisplayName(t *testing.T) {
 	stateProvider := &memorystate.MemoryStateProvider{}
 	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
@@ -139,6 +139,7 @@ func TestCreateSolutionWithSameDisplayName(t *testing.T) {
 	assert.Contains(t, err.Error(), "solution displayName must be unique")
 }
 
+/*
 func TestDeleteSolutionWithInstance(t *testing.T) {
 	stateProvider := &memorystate.MemoryStateProvider{}
 	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
@@ -191,3 +192,4 @@ func TestDeleteSolutionWithInstance(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "Solution has one or more associated instances")
 }
+*/

--- a/api/pkg/apis/v1alpha1/managers/targets/targets-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/targets/targets-manager.go
@@ -98,7 +98,9 @@ func (t *TargetsManager) UpsertState(ctx context.Context, name string, state mod
 		if state.ObjectMeta.Labels == nil {
 			state.ObjectMeta.Labels = make(map[string]string)
 		}
-		state.ObjectMeta.Labels[constants.DisplayName] = utils.ConvertStringToValidLabel(state.Spec.DisplayName)
+		if state.Spec != nil {
+			state.ObjectMeta.Labels[constants.DisplayName] = utils.ConvertStringToValidLabel(state.Spec.DisplayName)
+		}
 		if err = t.ValidateCreateOrUpdate(ctx, state); err != nil {
 			return err
 		}

--- a/api/pkg/apis/v1alpha1/managers/targets/targets-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/targets/targets-manager.go
@@ -47,7 +47,9 @@ func (s *TargetsManager) Init(context *contexts.VendorContext, config managers.M
 	}
 	s.needValidate = managers.NeedObjectValidate(config, providers)
 	if s.needValidate {
-		s.TargetValidator = validation.NewTargetValidator(s.targetInstanceLookup, s.targetUniqueNameLookup)
+		// Turn off validation of differnt types: https://github.com/eclipse-symphony/symphony/issues/445
+		// s.TargetValidator = validation.NewTargetValidator(s.targetInstanceLookup, s.targetUniqueNameLookup)
+		s.TargetValidator = validation.NewTargetValidator(nil, s.targetUniqueNameLookup)
 	}
 	return nil
 }

--- a/api/pkg/apis/v1alpha1/managers/targets/targets-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/targets/targets-manager_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/validation"
-	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
 	"github.com/stretchr/testify/assert"
 )
@@ -105,6 +104,7 @@ func TestCreateTargetWithSameDisplayName(t *testing.T) {
 	assert.Contains(t, err.Error(), "target displayName must be unique")
 }
 
+/*
 func TestDeleteTargetWithInstance(t *testing.T) {
 	stateProvider := &memorystate.MemoryStateProvider{}
 	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
@@ -158,3 +158,4 @@ func TestDeleteTargetWithInstance(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "Target has one or more associated instances")
 }
+*/


### PR DESCRIPTION
There are some issues for object validation in standalone mode. Details can be found in https://github.com/eclipse-symphony/symphony/issues/445.

Turn off the validation temporarily to unblock object creation.