### PR TITLE
Use keyLock in activation manager

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/activations/activations-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/activations/activations-manager.go
@@ -218,8 +218,8 @@ func (t *ActivationsManager) ReportStatus(ctx context.Context, name string, name
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
-	t.KeyLockProvider.Lock(name + namespace)
-	defer t.KeyLockProvider.UnLock(name + namespace)
+	t.KeyLockProvider.Lock(utils.GenerateUniqueKey(name, namespace))
+	defer t.KeyLockProvider.UnLock(utils.GenerateUniqueKey(name, namespace))
 
 	var activationState model.ActivationState
 	activationState, err = t.GetState(ctx, name, namespace)
@@ -262,8 +262,8 @@ func (t *ActivationsManager) ReportStageStatus(ctx context.Context, name string,
 	})
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
-	t.KeyLockProvider.Lock(name + namespace)
-	defer t.KeyLockProvider.UnLock(name + namespace)
+	t.KeyLockProvider.Lock(utils.GenerateUniqueKey(name, namespace))
+	defer t.KeyLockProvider.UnLock(utils.GenerateUniqueKey(name, namespace))
 
 	var activationState model.ActivationState
 	activationState, err = t.GetState(ctx, name, namespace)

--- a/api/pkg/apis/v1alpha1/managers/activations/activations-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/activations/activations-manager_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	memorykeylock "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/keylock/memory"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
 	"github.com/stretchr/testify/assert"
@@ -35,9 +36,12 @@ func TestCreateGetDeleteActivationSpec(t *testing.T) {
 func TestCleanupOldActivationSpec(t *testing.T) {
 	stateProvider := &memorystate.MemoryStateProvider{}
 	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	keyLockProvider := &memorykeylock.MemoryKeyLockProvider{}
+	keyLockProvider.Init(memorykeylock.MemoryKeyLockProviderConfig{})
 
 	manager := ActivationsManager{
-		StateProvider: stateProvider,
+		StateProvider:   stateProvider,
+		KeyLockProvider: keyLockProvider,
 	}
 	cleanupmanager := ActivationsCleanupManager{
 		ActivationsManager: manager,
@@ -63,8 +67,11 @@ func TestCleanupOldActivationSpec(t *testing.T) {
 func TestUpdateStageStatus(t *testing.T) {
 	stateProvider := &memorystate.MemoryStateProvider{}
 	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	keyLockProvider := &memorykeylock.MemoryKeyLockProvider{}
+	keyLockProvider.Init(memorykeylock.MemoryKeyLockProviderConfig{})
 	manager := ActivationsManager{
-		StateProvider: stateProvider,
+		StateProvider:   stateProvider,
+		KeyLockProvider: keyLockProvider,
 	}
 	err := manager.UpsertState(context.Background(), "test", model.ActivationState{Spec: &model.ActivationSpec{}})
 	assert.Nil(t, err)
@@ -113,8 +120,11 @@ func TestUpdateStageStatus(t *testing.T) {
 func TestUpdateStageStatusRemote(t *testing.T) {
 	stateProvider := &memorystate.MemoryStateProvider{}
 	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	keyLockProvider := &memorykeylock.MemoryKeyLockProvider{}
+	keyLockProvider.Init(memorykeylock.MemoryKeyLockProviderConfig{})
 	manager := ActivationsManager{
-		StateProvider: stateProvider,
+		StateProvider:   stateProvider,
+		KeyLockProvider: keyLockProvider,
 	}
 	err := manager.UpsertState(context.Background(), "test", model.ActivationState{Spec: &model.ActivationSpec{}})
 	assert.Nil(t, err)

--- a/api/pkg/apis/v1alpha1/providers/providerfactory.go
+++ b/api/pkg/apis/v1alpha1/providers/providerfactory.go
@@ -45,6 +45,7 @@ import (
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	cp "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
 	mockconfig "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/config/mock"
+	memorykeylock "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/keylock/memory"
 	mockledger "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/ledger/mock"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/probe/rtsp"
 	mempubsub "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/pubsub/memory"
@@ -365,6 +366,12 @@ func (s SymphonyProviderFactory) CreateProvider(providerType string, config cp.I
 		}
 	case "providers.graph.memory":
 		mProvider := &memorygraph.MemoryGraphProvider{}
+		err = mProvider.Init(config)
+		if err == nil {
+			return mProvider, nil
+		}
+	case "providers.keylock.memory":
+		mProvider := &memorykeylock.MemoryKeyLockProvider{}
 		err = mProvider.Init(config)
 		if err == nil {
 			return mProvider, nil

--- a/api/pkg/apis/v1alpha1/providers/providerfactory_test.go
+++ b/api/pkg/apis/v1alpha1/providers/providerfactory_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/staging"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/win10/sideload"
 	mockconfig "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/config/mock"
+	memorykeylock "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/keylock/memory"
 	mockledger "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/ledger/mock"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/probe/rtsp"
 	mempubsub "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/pubsub/memory"
@@ -273,6 +274,10 @@ func TestCreateProvider(t *testing.T) {
 	provider, err = providerfactory.CreateProvider("providers.graph.memory", memorygraph.MemoryGraphProviderConfig{})
 	assert.Nil(t, err)
 	assert.NotNil(t, *provider.(*memorygraph.MemoryGraphProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.keylock.memory", memorykeylock.MemoryKeyLockProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*memorykeylock.MemoryKeyLockProvider))
 }
 
 func TestCreateProviderForTargetRole(t *testing.T) {

--- a/api/pkg/apis/v1alpha1/vendors/activations-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/activations-vendor_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
+	memorykeylock "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/keylock/memory"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/pubsub/memory"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states/memorystate"
 	"github.com/stretchr/testify/assert"
@@ -24,8 +25,11 @@ import (
 func createActivationsVendor() ActivationsVendor {
 	stateProvider := &memorystate.MemoryStateProvider{}
 	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	keyLockProvider := &memorykeylock.MemoryKeyLockProvider{}
+	keyLockProvider.Init(memorykeylock.MemoryKeyLockProviderConfig{})
 	manager := activations.ActivationsManager{
-		StateProvider: stateProvider,
+		StateProvider:   stateProvider,
+		KeyLockProvider: keyLockProvider,
 	}
 	vendor := ActivationsVendor{
 		ActivationsManager: &manager,

--- a/api/symphony-api-no-k8s-munchen.json
+++ b/api/symphony-api-no-k8s-munchen.json
@@ -94,11 +94,16 @@
             "type": "managers.symphony.activations",
             "properties": {
               "providers.persistentstate": "k8s-state",
+              "providers.keylock": "memory-keylock",
               "singleton": "true"
             },
             "providers": {
               "k8s-state": {
                 "type": "providers.state.memory",
+                "config": {}
+              },
+              "memory-keylock": {
+                "type": "providers.keylock.memory",
                 "config": {}
               }
             }
@@ -121,11 +126,16 @@
             "type": "managers.symphony.activations",
             "properties": {
               "providers.persistentstate": "k8s-state",
+              "providers.keylock": "memory-keylock",
               "singleton": "true"
             },
             "providers": {
               "k8s-state": {
                 "type": "providers.state.memory",
+                "config": {}
+              },
+              "memory-keylock": {
+                "type": "providers.keylock.memory",
                 "config": {}
               }
             }

--- a/api/symphony-api-no-k8s-new-york.json
+++ b/api/symphony-api-no-k8s-new-york.json
@@ -94,11 +94,16 @@
             "type": "managers.symphony.activations",
             "properties": {
               "providers.persistentstate": "k8s-state",
+              "providers.keylock": "memory-keylock",
               "singleton": "true"
             },
             "providers": {
               "k8s-state": {
                 "type": "providers.state.memory",
+                "config": {}
+              },
+              "memory-keylock": {
+                "type": "providers.keylock.memory",
                 "config": {}
               }
             }
@@ -120,11 +125,17 @@
             "name": "activations-manager",
             "type": "managers.symphony.activations",
             "properties": {
-              "providers.persistentstate": "k8s-state"
+              "providers.persistentstate": "k8s-state",
+              "providers.keylock": "memory-keylock",
+              "singleton": "true"
             },
             "providers": {
               "k8s-state": {
                 "type": "providers.state.memory",
+                "config": {}
+              },
+              "memory-keylock": {
+                "type": "providers.keylock.memory",
                 "config": {}
               }
             }

--- a/api/symphony-api-no-k8s-tokyo.json
+++ b/api/symphony-api-no-k8s-tokyo.json
@@ -94,11 +94,16 @@
             "type": "managers.symphony.activations",
             "properties": {
               "providers.persistentstate": "k8s-state",
+              "providers.keylock": "memory-keylock",
               "singleton": "true"
             },
             "providers": {
               "k8s-state": {
                 "type": "providers.state.memory",
+                "config": {}
+              },
+              "memory-keylock": {
+                "type": "providers.keylock.memory",
                 "config": {}
               }
             }
@@ -120,11 +125,17 @@
             "name": "activations-manager",
             "type": "managers.symphony.activations",
             "properties": {
-              "providers.persistentstate": "k8s-state"
+              "providers.persistentstate": "k8s-state",
+              "providers.keylock": "memory-keylock",
+              "singleton": "true"
             },
             "providers": {
               "k8s-state": {
                 "type": "providers.state.memory",
+                "config": {}
+              },
+              "memory-keylock": {
+                "type": "providers.keylock.memory",
                 "config": {}
               }
             }

--- a/api/symphony-api-no-k8s.json
+++ b/api/symphony-api-no-k8s.json
@@ -85,11 +85,16 @@
             "type": "managers.symphony.activations",
             "properties": {
               "providers.persistentstate": "k8s-state",
+              "providers.keylock": "memory-keylock",
               "singleton": "true"
             },
             "providers": {
               "k8s-state": {
                 "type": "providers.state.memory",
+                "config": {}
+              },
+              "memory-keylock": {
+                "type": "providers.keylock.memory",
                 "config": {}
               }
             }
@@ -111,11 +116,16 @@
             "type": "managers.symphony.activations",
             "properties": {
               "providers.persistentstate": "k8s-state",
+              "providers.keylock": "memory-keylock",
               "singleton": "true"
             },
             "providers": {
               "k8s-state": {
                 "type": "providers.state.memory",
+                "config": {}
+              },
+              "memory-keylock": {
+                "type": "providers.keylock.memory",
                 "config": {}
               }
             }
@@ -132,12 +142,17 @@
             "type": "managers.symphony.activationscleanup",
             "properties": {
               "providers.persistentstate": "k8s-state",
+              "providers.keylock": "memory-keylock",
               "singleton": "true",
               "RetentionDuration": "4320h"
             },
             "providers": {
               "k8s-state": {
                 "type": "providers.state.memory",
+                "config": {}
+              },
+              "memory-keylock": {
+                "type": "providers.keylock.memory",
                 "config": {}
               }
             }

--- a/api/symphony-api-production.json
+++ b/api/symphony-api-production.json
@@ -95,6 +95,7 @@
             "type": "managers.symphony.activations",
             "properties": {
               "providers.persistentstate": "k8s-state",
+              "providers.keylock": "memory-keylock",
               "singleton": "true"
             },
             "providers": {
@@ -103,6 +104,10 @@
                 "config": {
                   "inCluster": true
                 }
+              },
+              "memory-keylock": {
+                "type": "providers.keylock.memory",
+                "config": {}
               }
             }
           }
@@ -123,7 +128,9 @@
             "name": "activations-manager",
             "type": "managers.symphony.activations",
             "properties": {
-              "providers.persistentstate": "k8s-state"
+              "providers.persistentstate": "k8s-state",
+              "providers.keylock": "memory-keylock",
+              "singleton": "true"
             },
             "providers": {
               "k8s-state": {
@@ -131,6 +138,10 @@
                 "config": {
                   "inCluster": true
                 }
+              },
+              "memory-keylock": {
+                "type": "providers.keylock.memory",
+                "config": {}
               }
             }
           }
@@ -146,6 +157,7 @@
             "type": "managers.symphony.activationscleanup",
             "properties": {
               "providers.persistentstate": "k8s-state",
+              "providers.keylock": "memory-keylock",
               "singleton": "true",
               "RetentionDuration": "4320h"
             },
@@ -155,6 +167,10 @@
                 "config": {
                   "inCluster": true
                 }
+              },
+              "memory-keylock": {
+                "type": "providers.keylock.memory",
+                "config": {}
               }
             }
           }

--- a/api/symphony-api.json
+++ b/api/symphony-api.json
@@ -87,6 +87,7 @@
             "type": "managers.symphony.activations",
             "properties": {
               "providers.persistentstate": "k8s-state",
+              "providers.keylock": "memory-keylock",
               "singleton": "true"
             },
             "providers": {
@@ -108,7 +109,9 @@
             "name": "activations-manager",
             "type": "managers.symphony.activations",
             "properties": {
-              "providers.persistentstate": "k8s-state"
+              "providers.persistentstate": "k8s-state",
+              "providers.keylock": "memory-keylock",
+              "singleton": "true"
             },
             "providers": {
               "k8s-state": {
@@ -131,6 +134,7 @@
             "type": "managers.symphony.activationscleanup",
             "properties": {
               "providers.persistentstate": "k8s-state",
+              "providers.keylock": "memory-keylock",
               "singleton": "true",
               "RetentionDuration": "4320h"
             },

--- a/coa/pkg/apis/v1alpha2/managers/managers.go
+++ b/coa/pkg/apis/v1alpha2/managers/managers.go
@@ -14,6 +14,7 @@ import (
 	contexts "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
 	providers "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/config"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/keylock"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/ledger"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/probe"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/queue"
@@ -243,6 +244,21 @@ func GetReporter(config ManagerConfig, providers map[string]providers.IProvider)
 		return nil, v1alpha2.NewCOAError(nil, "supplied provider is not a reporter provider", v1alpha2.BadConfig)
 	}
 	return reporterProvider, nil
+}
+func GetKeyLockProvider(config ManagerConfig, providers map[string]providers.IProvider) (keylock.IKeyLockProvider, error) {
+	reporterName, ok := config.Properties[v1alpha2.ProviderKeyLock]
+	if !ok {
+		return nil, v1alpha2.NewCOAError(nil, "keyLock provider is not configured", v1alpha2.MissingConfig)
+	}
+	provider, ok := providers[reporterName]
+	if !ok {
+		return nil, v1alpha2.NewCOAError(nil, "keyLock provider is not supplied", v1alpha2.MissingConfig)
+	}
+	keyLockProvider, ok := provider.(keylock.IKeyLockProvider)
+	if !ok {
+		return nil, v1alpha2.NewCOAError(nil, "supplied provider is not a keyLock provider", v1alpha2.BadConfig)
+	}
+	return keyLockProvider, nil
 }
 
 func NeedObjectValidate(config ManagerConfig, providers map[string]providers.IProvider) bool {

--- a/coa/pkg/apis/v1alpha2/types.go
+++ b/coa/pkg/apis/v1alpha2/types.go
@@ -349,6 +349,7 @@ const (
 	ProvidersReporter        = "providers.reporter"
 	ProviderQueue            = "providers.queue"
 	ProviderLedger           = "providers.ledger"
+	ProviderKeyLock          = "providers.keylock"
 	StatusOutput             = "__status"
 	ErrorOutput              = "__error"
 	StateOutput              = "__state"

--- a/coa/pkg/apis/v1alpha2/utils/utils.go
+++ b/coa/pkg/apis/v1alpha2/utils/utils.go
@@ -195,3 +195,7 @@ func FormatAsString(val interface{}) string {
 func ConvertStringToValidLabel(s string) string {
 	return strings.ReplaceAll(s, " ", "")
 }
+
+func GenerateUniqueKey(name string, namespace string) string {
+	return fmt.Sprintf("%s/%s", namespace, name)
+}

--- a/packages/helm/symphony/files/symphony-api.json
+++ b/packages/helm/symphony/files/symphony-api.json
@@ -125,6 +125,7 @@
             "type": "managers.symphony.activations",
             "properties": {
               "providers.persistentstate": "k8s-state",
+              "providers.keylock": "memory-keylock",
               "singleton": "true"
             },
             "providers": {
@@ -133,6 +134,10 @@
                 "config": {
                   "inCluster": true
                 }
+              },
+              "memory-keylock": {
+                "type": "providers.keylock.memory",
+                "config": {}
               }
             }
           }
@@ -152,7 +157,9 @@
             "name": "activations-manager",
             "type": "managers.symphony.activations",
             "properties": {
-              "providers.persistentstate": "k8s-state"
+              "providers.persistentstate": "k8s-state",
+              "providers.keylock": "memory-keylock",
+              "singleton": "true"
             },
             "providers": {
               "k8s-state": {
@@ -160,6 +167,10 @@
                 "config": {
                   "inCluster": true
                 }
+              },
+              "memory-keylock": {
+                "type": "providers.keylock.memory",
+                "config": {}
               }
             }
           }
@@ -176,6 +187,7 @@
             "type": "managers.symphony.activationscleanup",
             "properties": {
               "providers.persistentstate": "k8s-state",
+              "providers.keylock": "memory-keylock",
               "singleton": "true",
               "RetentionDuration": "{{ .Values.ActivationCleanup.retentionDuration }}"
             },
@@ -185,6 +197,10 @@
                 "config": {
                   "inCluster": true
                 }
+              },
+              "memory-keylock": {
+                "type": "providers.keylock.memory",
+                "config": {}
               }
             }
           }


### PR DESCRIPTION
We are using a global lock for all activations when updating status. Change the global lock to one for each activation.