### PR TITLE
Block campaign update and delete with running activation

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/campaigns/campaigns-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/campaigns/campaigns-manager.go
@@ -219,7 +219,7 @@ func (t *CampaignsManager) CampaignContainerLookup(ctx context.Context, name str
 }
 
 func (t *CampaignsManager) CampaignActivationsLookup(ctx context.Context, name string, namespace string) (bool, error) {
-	activationList, err := states.ListObjectStateWithLabels(ctx, t.StateProvider, validation.Activation, namespace, map[string]string{constants.Campaign: name}, 1)
+	activationList, err := states.ListObjectStateWithLabels(ctx, t.StateProvider, validation.Activation, namespace, map[string]string{constants.Campaign: name, constants.StatusMessage: v1alpha2.Running.String()}, 1)
 	if err != nil {
 		return false, err
 	}

--- a/k8s/apis/workflow/v1/campaign_webhook.go
+++ b/k8s/apis/workflow/v1/campaign_webhook.go
@@ -64,7 +64,7 @@ func (r *Campaign) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		},
 		// Look up running activation
 		func(ctx context.Context, campaign string, namespace string) (bool, error) {
-			activationList, err := dynamicclient.ListWithLabels(ctx, validation.Activation, namespace, map[string]string{"campaign": campaign}, 1)
+			activationList, err := dynamicclient.ListWithLabels(ctx, validation.Activation, namespace, map[string]string{"campaign": campaign, api_constants.StatusMessage: v1alpha2.Running.String()}, 1)
 			if err != nil {
 				return false, err
 			}

--- a/test/integration/scenarios/08.webhook/manifest/campaignLongRunning.yaml
+++ b/test/integration/scenarios/08.webhook/manifest/campaignLongRunning.yaml
@@ -10,5 +10,5 @@ spec:
       name: wait
       provider: providers.stage.delay
       inputs:
-        delay: "3m"
+        delay: "10s"
   selfDriving: true

--- a/test/integration/scenarios/08.webhook/verify/webhook_test.go
+++ b/test/integration/scenarios/08.webhook/verify/webhook_test.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/princjef/mageutil/shellcmd"
 	"github.com/stretchr/testify/assert"
@@ -144,9 +145,11 @@ func TestDeleteCampaignWithRunningActivation(t *testing.T) {
 	output, err := exec.Command("kubectl", "delete", "campaigns.workflow.symphony", "04campaign-v-v3").CombinedOutput()
 	assert.Contains(t, string(output), "Campaign has one or more running activations. Update or Deletion is not allowed")
 	assert.NotNil(t, err, "campaign deletion with running activation should fail")
-	err = shellcmd.Command("kubectl delete activations.workflow.symphony activationlongrunning").Run()
-	assert.Nil(t, err)
+	time.Sleep(15 * time.Second)
+	// Campaign can be deleted once the activation is DONE
 	err = shellcmd.Command("kubectl delete campaigns.workflow.symphony 04campaign-v-v3").Run()
+	assert.Nil(t, err)
+	err = shellcmd.Command("kubectl delete activations.workflow.symphony activationlongrunning").Run()
 	assert.Nil(t, err)
 	err = shellcmd.Command("kubectl delete campaigncontainers.workflow.symphony 04campaign").Run()
 	assert.Nil(t, err)


### PR DESCRIPTION
Campaign update and delete will be only block when there is any running activation on it. If activation enters termination state like DONE, Internal error or bad request, it will not block campaign update and delete anymore.