### PR TITLE
Use existing storageclass if not specified

### DIFF
--- a/packages/helm/symphony/templates/redis.yaml
+++ b/packages/helm/symphony/templates/redis.yaml
@@ -5,7 +5,7 @@ metadata:
   name: redis-pvc
   namespace: {{ .Release.Namespace }}
 spec:
-  storageClassName: {{ .Values.redis.persistentVolume.storageclass }}
+  storageClassName: {{ include "RedisPVCStorageClassName" . }}
   accessModes:
   - {{ .Values.redis.persistentVolume.accessMode }}
   resources:

--- a/packages/helm/symphony/templates/symphony-core/_helpers.tpl
+++ b/packages/helm/symphony/templates/symphony-core/_helpers.tpl
@@ -212,3 +212,15 @@ Symphony full url Endpoint
 {{- define "symphony.emitTimeFieldInUserLogs" -}}
 {{- default "false" .Values.observability.log.emitTimeFieldInUserLogs | quote }}
 {{- end }}
+
+{{- define "RedisPVCStorageClassName" -}}
+{{- $pvcName := "redis-pvc" -}}
+{{- $existingPVC := (lookup "v1" "PersistentVolumeClaim" .Release.Namespace $pvcName) -}}
+{{- if .Values.redis.persistentVolume.storageclass }}
+{{- .Values.redis.persistentVolume.storageclass -}}
+{{- else if $existingPVC  }}
+{{- $existingPVC.spec.storageClassName -}}
+{{- else }}
+{{- .Values.redis.persistentVolume.storageclass -}}
+{{- end -}}
+{{- end -}}

--- a/packages/helm/symphony/templates/symphony-core/_helpers.tpl
+++ b/packages/helm/symphony/templates/symphony-core/_helpers.tpl
@@ -216,11 +216,11 @@ Symphony full url Endpoint
 {{- define "RedisPVCStorageClassName" -}}
 {{- $pvcName := "redis-pvc" -}}
 {{- $existingPVC := (lookup "v1" "PersistentVolumeClaim" .Release.Namespace $pvcName) -}}
-{{- if .Values.redis.persistentVolume.storageclass }}
-{{- .Values.redis.persistentVolume.storageclass -}}
+{{- if .Values.redis.persistentVolume.storageClass }}
+{{- .Values.redis.persistentVolume.storageClass -}}
 {{- else if $existingPVC  }}
 {{- $existingPVC.spec.storageClassName -}}
 {{- else }}
-{{- .Values.redis.persistentVolume.storageclass -}}
+{{- .Values.redis.persistentVolume.storageClass -}}
 {{- end -}}
 {{- end -}}

--- a/packages/helm/symphony/values.yaml
+++ b/packages/helm/symphony/values.yaml
@@ -43,7 +43,7 @@ redis:
   port: 6379
   persistentVolume:
     enabled: false
-    storageclass: 
+    storageclass:
     accessMode: ReadWriteOnce
     size: 1Gi
 kubeRbacProxy:

--- a/packages/helm/symphony/values.yaml
+++ b/packages/helm/symphony/values.yaml
@@ -43,7 +43,7 @@ redis:
   port: 6379
   persistentVolume:
     enabled: false
-    storageclass:
+    storageClass:
     accessMode: ReadWriteOnce
     size: 1Gi
 kubeRbacProxy:


### PR DESCRIPTION
Kubernetes uses default storage class when creating PVCs if it doesn't specify storage class name explicitly. However, things are different when updating PVCs with empty storage class name and kubernetes will complain the PVC spec is immutable. 

This PR is to provide better user experience to allow user to enter empty storage class name in both create and update case. In helper function RedisPVCStorageClassName, we will use input if storage class is explicitly specified. Otherwise, it will check if PVC already exist and use the storage class of existing PVC. 

Manually test update scenario for storage class name
empty -> empty
empty -> specified
specified -> empty
specified -> specified