### PR TITLE
Rewrite Redis pubsub

### DIFF
--- a/api/pkg/apis/v1alpha1/contexts/manager-context_test.go
+++ b/api/pkg/apis/v1alpha1/contexts/manager-context_test.go
@@ -52,10 +52,12 @@ func TestManagerContextPublishSubscribe(t *testing.T) {
 	sig := make(chan int)
 	msg := ""
 
-	err = m.Subscribe("test", func(topic string, event v1alpha2.Event) error {
-		msg = event.Body.(string)
-		sig <- 1
-		return nil
+	err = m.Subscribe("test", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			msg = event.Body.(string)
+			sig <- 1
+			return nil
+		},
 	})
 	assert.Nil(t, err)
 	err = m.Publish("test", v1alpha2.Event{
@@ -73,8 +75,10 @@ func TestManagerContextPublishSubscribeWithoutPubSub(t *testing.T) {
 	assert.NotNil(t, m.Logger)
 	assert.Nil(t, m.PubsubProvider)
 
-	err = m.Subscribe("test", func(topic string, event v1alpha2.Event) error {
-		return nil
+	err = m.Subscribe("test", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			return nil
+		},
 	})
 	assert.Nil(t, err)
 	err = m.Publish("test", v1alpha2.Event{

--- a/api/pkg/apis/v1alpha1/contexts/vendor-context_test.go
+++ b/api/pkg/apis/v1alpha1/contexts/vendor-context_test.go
@@ -51,10 +51,12 @@ func TestVendorContextPublishSubscribe(t *testing.T) {
 	sig := make(chan int)
 	msg := ""
 
-	err := v.Subscribe("test", func(topic string, event v1alpha2.Event) error {
-		msg = event.Body.(string)
-		sig <- 1
-		return nil
+	err := v.Subscribe("test", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			msg = event.Body.(string)
+			sig <- 1
+			return nil
+		},
 	})
 	assert.Nil(t, err)
 	err = v.Publish("test", v1alpha2.Event{
@@ -68,8 +70,10 @@ func TestVendorContextPublishSubscribe(t *testing.T) {
 
 func TestVendorContextPublishSubscribeWithoutPubSub(t *testing.T) {
 	v := createVendorContextWithoutPubSub()
-	err := v.Subscribe("test", func(topic string, event v1alpha2.Event) error {
-		return nil
+	err := v.Subscribe("test", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			return nil
+		},
 	})
 	assert.Nil(t, err)
 	err = v.Publish("test", v1alpha2.Event{
@@ -83,10 +87,12 @@ func TestVendorContextPublishSubscribeBadRequest(t *testing.T) {
 	ch := make(chan struct{})
 	count := 0
 
-	err := v.Subscribe("test", func(topic string, event v1alpha2.Event) error {
-		count += 1
-		ch <- struct{}{}
-		return v1alpha2.NewCOAError(nil, "insert bad request", v1alpha2.BadRequest)
+	err := v.Subscribe("test", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			count += 1
+			ch <- struct{}{}
+			return v1alpha2.NewCOAError(nil, "insert bad request", v1alpha2.BadRequest)
+		},
 	})
 	assert.Nil(t, err)
 	err = v.Publish("test", v1alpha2.Event{
@@ -114,10 +120,12 @@ func TestVendorContextPublishSubscribeInternalError(t *testing.T) {
 	ch := make(chan struct{})
 	count := 0
 
-	err := v.Subscribe("test", func(topic string, event v1alpha2.Event) error {
-		count += 1
-		ch <- struct{}{}
-		return v1alpha2.NewCOAError(nil, "insert internal error", v1alpha2.InternalError)
+	err := v.Subscribe("test", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			count += 1
+			ch <- struct{}{}
+			return v1alpha2.NewCOAError(nil, "insert internal error", v1alpha2.InternalError)
+		},
 	})
 	assert.Nil(t, err)
 	err = v.Publish("test", v1alpha2.Event{

--- a/api/pkg/apis/v1alpha1/managers/catalogs/catalogs-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/catalogs/catalogs-manager_test.go
@@ -152,15 +152,17 @@ func TestUpsertAndGet(t *testing.T) {
 
 	err = manager.UpsertState(context.Background(), catalogState.ObjectMeta.Name, catalogState)
 	assert.Nil(t, err)
-	manager.Context.Subscribe("catalog", func(topic string, event v1alpha2.Event) error {
-		var job v1alpha2.JobData
-		jData, _ := json.Marshal(event.Body)
-		err := json.Unmarshal(jData, &job)
-		assert.Nil(t, err)
-		assert.Equal(t, "catalog", event.Metadata["objectType"])
-		assert.Equal(t, "name1", job.Id)
-		assert.Equal(t, true, job.Action == v1alpha2.JobUpdate || job.Action == v1alpha2.JobDelete)
-		return nil
+	manager.Context.Subscribe("catalog", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			var job v1alpha2.JobData
+			jData, _ := json.Marshal(event.Body)
+			err := json.Unmarshal(jData, &job)
+			assert.Nil(t, err)
+			assert.Equal(t, "catalog", event.Metadata["objectType"])
+			assert.Equal(t, "name1", job.Id)
+			assert.Equal(t, true, job.Action == v1alpha2.JobUpdate || job.Action == v1alpha2.JobDelete)
+			return nil
+		},
 	})
 	val, err := manager.GetState(context.Background(), catalogState.ObjectMeta.Name, catalogState.ObjectMeta.Namespace)
 	assert.Nil(t, err)
@@ -178,15 +180,17 @@ func TestList(t *testing.T) {
 
 	err = manager.UpsertState(context.Background(), catalogState.ObjectMeta.Name, catalogState)
 	assert.Nil(t, err)
-	manager.Context.Subscribe("catalog", func(topic string, event v1alpha2.Event) error {
-		var job v1alpha2.JobData
-		jData, _ := json.Marshal(event.Body)
-		err := json.Unmarshal(jData, &job)
-		assert.Nil(t, err)
-		assert.Equal(t, "catalog", event.Metadata["objectType"])
-		assert.Equal(t, "name1", job.Id)
-		assert.Equal(t, true, job.Action == v1alpha2.JobUpdate || job.Action == v1alpha2.JobDelete)
-		return nil
+	manager.Context.Subscribe("catalog", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			var job v1alpha2.JobData
+			jData, _ := json.Marshal(event.Body)
+			err := json.Unmarshal(jData, &job)
+			assert.Nil(t, err)
+			assert.Equal(t, "catalog", event.Metadata["objectType"])
+			assert.Equal(t, "name1", job.Id)
+			assert.Equal(t, true, job.Action == v1alpha2.JobUpdate || job.Action == v1alpha2.JobDelete)
+			return nil
+		},
 	})
 	val, err := manager.ListState(context.Background(), catalogState.ObjectMeta.Namespace, "", "")
 	assert.Nil(t, err)
@@ -206,15 +210,17 @@ func TestDelete(t *testing.T) {
 
 	err = manager.UpsertState(context.Background(), catalogState.ObjectMeta.Name, catalogState)
 	assert.Nil(t, err)
-	manager.Context.Subscribe("catalog", func(topic string, event v1alpha2.Event) error {
-		var job v1alpha2.JobData
-		jData, _ := json.Marshal(event.Body)
-		err := json.Unmarshal(jData, &job)
-		assert.Nil(t, err)
-		assert.Equal(t, "catalog", event.Metadata["objectType"])
-		assert.Equal(t, "name1", job.Id)
-		assert.Equal(t, true, job.Action == v1alpha2.JobUpdate || job.Action == v1alpha2.JobDelete)
-		return nil
+	manager.Context.Subscribe("catalog", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			var job v1alpha2.JobData
+			jData, _ := json.Marshal(event.Body)
+			err := json.Unmarshal(jData, &job)
+			assert.Nil(t, err)
+			assert.Equal(t, "catalog", event.Metadata["objectType"])
+			assert.Equal(t, "name1", job.Id)
+			assert.Equal(t, true, job.Action == v1alpha2.JobUpdate || job.Action == v1alpha2.JobDelete)
+			return nil
+		},
 	})
 	val, err := manager.GetState(context.Background(), catalogState.ObjectMeta.Name, catalogState.ObjectMeta.Namespace)
 	assert.Nil(t, err)

--- a/api/pkg/apis/v1alpha1/managers/sync/sync-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/sync/sync-manager_test.go
@@ -176,19 +176,23 @@ func TestPoll(t *testing.T) {
 	job1 := v1alpha2.JobData{}
 	// validate that the sync package was published
 	catalogCnt := 0
-	vendorContext.Subscribe("catalog-sync", func(topic string, event v1alpha2.Event) error {
-		catalogCnt++
-		jobData := event.Body.(v1alpha2.JobData)
-		catalog1 = jobData.Body.(model.CatalogState)
-		sig1 <- 1
-		return nil
+	vendorContext.Subscribe("catalog-sync", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			catalogCnt++
+			jobData := event.Body.(v1alpha2.JobData)
+			catalog1 = jobData.Body.(model.CatalogState)
+			sig1 <- 1
+			return nil
+		},
 	})
 	jobCount := 0
-	vendorContext.Subscribe("remote-job", func(topic string, event v1alpha2.Event) error {
-		jobCount++
-		job1 = event.Body.(v1alpha2.JobData)
-		sig2 <- 1
-		return nil
+	vendorContext.Subscribe("remote-job", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			jobCount++
+			job1 = event.Body.(v1alpha2.JobData)
+			sig2 <- 1
+			return nil
+		},
 	})
 
 	errs := manager.Poll()

--- a/api/pkg/apis/v1alpha1/providers/stage/remote/remote_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/remote/remote_test.go
@@ -38,17 +38,19 @@ func TestRemoteProcess(t *testing.T) {
 	provider.SetContext(&ctx)
 	sig := make(chan bool)
 	succeededCount := 0
-	ctx.Subscribe("remote", func(topic string, event v1alpha2.Event) error {
-		var job v1alpha2.JobData
-		jData, _ := json.Marshal(event.Body)
-		err := json.Unmarshal(jData, &job)
-		assert.Nil(t, err)
-		assert.Equal(t, "child", event.Metadata["site"])
-		assert.Equal(t, "task", event.Metadata["objectType"])
-		assert.Equal(t, v1alpha2.JobRun, job.Action)
-		succeededCount += 1
-		sig <- true
-		return nil
+	ctx.Subscribe("remote", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			var job v1alpha2.JobData
+			jData, _ := json.Marshal(event.Body)
+			err := json.Unmarshal(jData, &job)
+			assert.Nil(t, err)
+			assert.Equal(t, "child", event.Metadata["site"])
+			assert.Equal(t, "task", event.Metadata["objectType"])
+			assert.Equal(t, v1alpha2.JobRun, job.Action)
+			succeededCount += 1
+			sig <- true
+			return nil
+		},
 	})
 	_, _, err = provider.Process(context.Background(), ctx, map[string]interface{}{
 		"__site": "child",

--- a/api/pkg/apis/v1alpha1/vendors/activations-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/activations-vendor_test.go
@@ -81,16 +81,18 @@ func TestActivationsOnActivations(t *testing.T) {
 	campaignName := "campaign1"
 	succeededCount := 0
 	sigs := make(chan bool)
-	vendor.Context.Subscribe("activation", func(topic string, event v1alpha2.Event) error {
-		var activation v1alpha2.ActivationData
-		jData, _ := json.Marshal(event.Body)
-		err := json.Unmarshal(jData, &activation)
-		assert.Nil(t, err)
-		assert.Equal(t, campaignName, activation.Campaign)
-		assert.Equal(t, activationName, activation.Activation)
-		succeededCount += 1
-		sigs <- true
-		return nil
+	vendor.Context.Subscribe("activation", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			var activation v1alpha2.ActivationData
+			jData, _ := json.Marshal(event.Body)
+			err := json.Unmarshal(jData, &activation)
+			assert.Nil(t, err)
+			assert.Equal(t, campaignName, activation.Campaign)
+			assert.Equal(t, activationName, activation.Activation)
+			succeededCount += 1
+			sigs <- true
+			return nil
+		},
 	})
 	resp := vendor.onActivations(v1alpha2.COARequest{
 		Method: fasthttp.MethodGet,

--- a/api/pkg/apis/v1alpha1/vendors/echovendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/echovendor.go
@@ -43,15 +43,18 @@ func (e *EchoVendor) GetMessages() []string {
 func (e *EchoVendor) Init(config vendors.VendorConfig, factories []managers.IManagerFactroy, providers map[string]map[string]providers.IProvider, pubsubProvider pubsub.IPubSubProvider) error {
 	err := e.Vendor.Init(config, factories, providers, pubsubProvider)
 	e.myMessages = make([]string, 0)
-	e.Vendor.Context.Subscribe("trace", func(topic string, event v1alpha2.Event) error {
-		e.lock.Lock()
-		defer e.lock.Unlock()
-		msg := utils.FormatAsString(event.Body)
-		e.myMessages = append(e.myMessages, msg)
-		if len(e.myMessages) > 20 {
-			e.myMessages = e.myMessages[1:]
-		}
-		return nil
+	e.Vendor.Context.Subscribe("trace", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			e.lock.Lock()
+			defer e.lock.Unlock()
+			msg := utils.FormatAsString(event.Body)
+			e.myMessages = append(e.myMessages, msg)
+			if len(e.myMessages) > 20 {
+				e.myMessages = e.myMessages[1:]
+			}
+			return nil
+		},
+		Group: "echo",
 	})
 	if err != nil {
 		return err

--- a/api/pkg/apis/v1alpha1/vendors/federation-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/federation-vendor_test.go
@@ -273,13 +273,15 @@ func TestFederationOnSyncPost(t *testing.T) {
 	}
 	response := vendor.onSync(*requestPost)
 	assert.Equal(t, v1alpha2.OK, response.State)
-	vendor.Context.PubsubProvider.Subscribe("job-report", func(topic string, event v1alpha2.Event) error {
-		jData, _ := json.Marshal(event.Body)
-		var status model.StageStatus
-		err := json.Unmarshal(jData, &status)
-		assert.Nil(t, err)
-		assert.Equal(t, stageStatus.Stage, status.Stage)
-		return nil
+	vendor.Context.PubsubProvider.Subscribe("job-report", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			jData, _ := json.Marshal(event.Body)
+			var status model.StageStatus
+			err := json.Unmarshal(jData, &status)
+			assert.Nil(t, err)
+			assert.Equal(t, stageStatus.Stage, status.Stage)
+			return nil
+		},
 	})
 
 	requestPatch := &v1alpha2.COARequest{

--- a/api/pkg/apis/v1alpha1/vendors/instances-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/instances-vendor_test.go
@@ -83,17 +83,19 @@ func TestInstancesOnInstances(t *testing.T) {
 	}
 	succeededCount := 0
 	sig := make(chan bool)
-	vendor.Context.Subscribe("job", func(topic string, event v1alpha2.Event) error {
-		var job v1alpha2.JobData
-		jData, _ := json.Marshal(event.Body)
-		err := json.Unmarshal(jData, &job)
-		assert.Nil(t, err)
-		assert.Equal(t, "instance", event.Metadata["objectType"])
-		assert.Equal(t, "instance1-v1", job.Id)
-		assert.Equal(t, true, job.Action == v1alpha2.JobUpdate || job.Action == v1alpha2.JobDelete)
-		succeededCount += 1
-		sig <- true
-		return nil
+	vendor.Context.Subscribe("job", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			var job v1alpha2.JobData
+			jData, _ := json.Marshal(event.Body)
+			err := json.Unmarshal(jData, &job)
+			assert.Nil(t, err)
+			assert.Equal(t, "instance", event.Metadata["objectType"])
+			assert.Equal(t, "instance1-v1", job.Id)
+			assert.Equal(t, true, job.Action == v1alpha2.JobUpdate || job.Action == v1alpha2.JobDelete)
+			succeededCount += 1
+			sig <- true
+			return nil
+		},
 	})
 	instanceSpec := model.InstanceSpec{}
 	data, _ := json.Marshal(instanceSpec)

--- a/api/pkg/apis/v1alpha1/vendors/job-vendor_test.go
+++ b/api/pkg/apis/v1alpha1/vendors/job-vendor_test.go
@@ -94,16 +94,18 @@ func TestJobsonHello(t *testing.T) {
 	vendor.Context.Init(&pubSubProvider)
 	succeededCount := 0
 	sig := make(chan bool)
-	vendor.Context.Subscribe("activation", func(topic string, event v1alpha2.Event) error {
-		var activation v1alpha2.ActivationData
-		jData, _ := json.Marshal(event.Body)
-		err := json.Unmarshal(jData, &activation)
-		assert.Nil(t, err)
-		assert.Equal(t, "activation1", activation.Activation)
-		assert.Equal(t, "campaign1", activation.Campaign)
-		succeededCount += 1
-		sig <- true
-		return nil
+	vendor.Context.Subscribe("activation", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			var activation v1alpha2.ActivationData
+			jData, _ := json.Marshal(event.Body)
+			err := json.Unmarshal(jData, &activation)
+			assert.Nil(t, err)
+			assert.Equal(t, "activation1", activation.Activation)
+			assert.Equal(t, "campaign1", activation.Campaign)
+			succeededCount += 1
+			sig <- true
+			return nil
+		},
 	})
 	activation := v1alpha2.ActivationData{
 		Activation: "activation1",

--- a/api/pkg/apis/v1alpha1/vendors/stage-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/stage-vendor.go
@@ -74,265 +74,274 @@ func (s *StageVendor) Init(config vendors.VendorConfig, factories []managers.IMa
 	if s.ActivationsManager == nil {
 		return v1alpha2.NewCOAError(nil, "activations manager is not supplied", v1alpha2.MissingConfig)
 	}
-	s.Vendor.Context.Subscribe("activation", func(topic string, event v1alpha2.Event) error {
-		ctx := context.TODO()
-		if event.Context != nil {
-			ctx = event.Context
-		}
+	s.Vendor.Context.Subscribe("activation", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			ctx := context.TODO()
+			if event.Context != nil {
+				ctx = event.Context
+			}
 
-		var actData v1alpha2.ActivationData
-		jData, _ := json.Marshal(event.Body)
-		err := json.Unmarshal(jData, &actData)
-		if err != nil {
-			log.ErrorCtx(ctx, "V (Stage): event body of activation event is not ActivationData ")
-			return v1alpha2.NewCOAError(nil, "event body is not an activation job", v1alpha2.BadRequest)
-		}
-		log.InfofCtx(ctx, "V (Stage): handling activation event for activation %s in namespace %s", actData.Activation, actData.Namespace)
-		campaignName := api_utils.ConvertReferenceToObjectName(actData.Campaign)
-
-		campaign, err := s.CampaignsManager.GetState(ctx, campaignName, actData.Namespace)
-		if err != nil {
-			log.ErrorfCtx(ctx, "V (Stage): unable to find campaign %s with error: %+v", campaignName, err)
-			err = s.reportActivationStatusWithBadRequest(actData.Activation, actData.Namespace, err)
-			// If report status succeeded, return an empty err so the subscribe function will not be retried
-			// The actual error will be stored in Activation cr
-			return err
-		}
-		activation, err := s.ActivationsManager.GetState(ctx, actData.Activation, actData.Namespace)
-		if err != nil {
-			log.ErrorfCtx(ctx, "V (Stage): unable to find activation: %+v", err)
-			return nil
-		}
-
-		evt, err := s.StageManager.HandleActivationEvent(ctx, actData, *campaign.Spec, activation)
-		if err != nil {
-			err = s.reportActivationStatusWithBadRequest(actData.Activation, actData.Namespace, err)
-			// If report status succeeded, return an empty err so the subscribe function will not be retried
-			// The actual error will be stored in Activation cr
-			return err
-		}
-
-		if evt != nil {
-			s.Vendor.Context.Publish("trigger", v1alpha2.Event{
-				Body:    *evt,
-				Context: ctx,
-			})
-		}
-		return nil
-	})
-	s.Vendor.Context.Subscribe("trigger", func(topic string, event v1alpha2.Event) error {
-		ctx := context.TODO()
-		if event.Context != nil {
-			ctx = event.Context
-		}
-
-		status := model.StageStatus{
-			Stage:         "",
-			NextStage:     "",
-			Outputs:       map[string]interface{}{},
-			Status:        v1alpha2.Untouched,
-			StatusMessage: v1alpha2.Untouched.String(),
-			ErrorMessage:  "",
-			IsActive:      true,
-		}
-		triggerData := v1alpha2.ActivationData{}
-		jData, _ := json.Marshal(event.Body)
-		err := json.Unmarshal(jData, &triggerData)
-		if err != nil {
-			err = v1alpha2.NewCOAError(nil, "event body is not an activation job", v1alpha2.BadRequest)
-			sLog.ErrorfCtx(ctx, "V (Stage): failed to deserialize activation data: %v", err)
-			err = s.reportActivationStatusWithBadRequest(triggerData.Activation, triggerData.Namespace, err)
-			// If report status succeeded, return an empty err so the subscribe function will not be retried
-			// The actual error will be stored in Activation cr
-			return err
-		}
-		log.InfoCtx(ctx, "V (Stage): handling trigger event for activation %s stage %s in namespace %s",
-			triggerData.Activation, triggerData.Stage, triggerData.Namespace)
-
-		status.Outputs["__namespace"] = triggerData.Namespace
-		_, err = s.ActivationsManager.GetState(ctx, triggerData.Activation, triggerData.Namespace)
-		if err != nil {
-			sLog.ErrorfCtx(ctx, "V (Stage): unable to find activation: %+v", err)
-			return nil
-		}
-		campaignName := api_utils.ConvertReferenceToObjectName(triggerData.Campaign)
-		campaign, err := s.CampaignsManager.GetState(ctx, campaignName, triggerData.Namespace)
-		if err != nil {
-			sLog.ErrorfCtx(ctx, "V (Stage): failed to get campaign spec: %v", err)
-			err = s.reportActivationStatusWithBadRequest(triggerData.Activation, triggerData.Namespace, err)
-			// If report status succeeded, return an empty err so the subscribe function will not be retried
-			// The actual error will be stored in Activation cr
-			return err
-		}
-		status.Stage = triggerData.Stage
-		status.ErrorMessage = ""
-		status.Status = v1alpha2.Running
-		status.StatusMessage = v1alpha2.Running.String()
-		if triggerData.NeedsReport {
-			sLog.DebugfCtx(ctx, "V (Stage): activation %s, stage %s in namespace %s reporting status: %v", triggerData.Activation, triggerData.Stage, triggerData.Namespace, status)
-			s.Vendor.Context.Publish("report", v1alpha2.Event{
-				Body:    status,
-				Context: ctx,
-			})
-		} else {
-			err = s.ActivationsManager.ReportStageStatus(ctx, triggerData.Activation, triggerData.Namespace, status)
+			var actData v1alpha2.ActivationData
+			jData, _ := json.Marshal(event.Body)
+			err := json.Unmarshal(jData, &actData)
 			if err != nil {
-				sLog.Errorf("V (Stage): failed to report accepted status: %v (%v)", status.ErrorMessage, err)
+				log.ErrorCtx(ctx, "V (Stage): event body of activation event is not ActivationData ")
+				return v1alpha2.NewCOAError(nil, "event body is not an activation job", v1alpha2.BadRequest)
+			}
+			log.InfofCtx(ctx, "V (Stage): handling activation event for activation %s in namespace %s", actData.Activation, actData.Namespace)
+			campaignName := api_utils.ConvertReferenceToObjectName(actData.Campaign)
+
+			campaign, err := s.CampaignsManager.GetState(ctx, campaignName, actData.Namespace)
+			if err != nil {
+				log.ErrorfCtx(ctx, "V (Stage): unable to find campaign %s with error: %+v", campaignName, err)
+				err = s.reportActivationStatusWithBadRequest(actData.Activation, actData.Namespace, err)
+				// If report status succeeded, return an empty err so the subscribe function will not be retried
+				// The actual error will be stored in Activation cr
 				return err
 			}
-		}
-
-		status, activation := s.StageManager.HandleTriggerEvent(ctx, *campaign.Spec, triggerData)
-
-		if triggerData.NeedsReport {
-			sLog.DebugfCtx(ctx, "V (Stage): reporting status: %v", status)
-			s.Vendor.Context.Publish("report", v1alpha2.Event{
-				Body:    status,
-				Context: ctx,
-			})
-
-		} else {
-			err = s.ActivationsManager.ReportStageStatus(ctx, triggerData.Activation, triggerData.Namespace, status)
+			activation, err := s.ActivationsManager.GetState(ctx, actData.Activation, actData.Namespace)
 			if err != nil {
-				sLog.ErrorfCtx(ctx, "V (Stage): failed to report status: %v (%v)", status.ErrorMessage, err)
+				log.ErrorfCtx(ctx, "V (Stage): unable to find activation: %+v", err)
+				return nil
+			}
+
+			evt, err := s.StageManager.HandleActivationEvent(ctx, actData, *campaign.Spec, activation)
+			if err != nil {
+				err = s.reportActivationStatusWithBadRequest(actData.Activation, actData.Namespace, err)
+				// If report status succeeded, return an empty err so the subscribe function will not be retried
+				// The actual error will be stored in Activation cr
 				return err
 			}
-			if activation != nil && status.NextStage != "" && status.Status != v1alpha2.Paused {
+
+			if evt != nil {
 				s.Vendor.Context.Publish("trigger", v1alpha2.Event{
-					Body:    *activation,
+					Body:    *evt,
 					Context: ctx,
 				})
 			}
-		}
-		log.InfoCtx(ctx, "V (Stage): Finished handling trigger event")
-		return nil
+			return nil
+		},
+		Group: "0",
 	})
-	s.Vendor.Context.Subscribe("job-report", func(topic string, event v1alpha2.Event) error {
-		ctx := context.TODO()
-		if event.Context != nil {
-			ctx = event.Context
-		}
-		sLog.DebugfCtx(ctx, "V (Stage): handling job report event: %v", event)
-		jData, _ := json.Marshal(event.Body)
-		var status model.StageStatus
-		json.Unmarshal(jData, &status)
-		campaign, ok := status.Outputs["__campaign"].(string)
-		if !ok {
-			sLog.ErrorfCtx(ctx, "V (Stage): failed to get campaign name from job report")
-			return v1alpha2.NewCOAError(nil, "job-report: campaign is not valid", v1alpha2.BadRequest)
-		}
-		namespace, ok := status.Outputs["__namespace"].(string)
-		if !ok {
-			sLog.ErrorfCtx(ctx, "V (Stage): failed to get namespace from job report, use default instead")
-			namespace = "default"
-		}
-		activation, ok := status.Outputs["__activation"].(string)
-		if !ok {
-			sLog.ErrorfCtx(ctx, "V (Stage): failed to get activation name from job report")
-			return v1alpha2.NewCOAError(nil, "job-report: activation is not valid", v1alpha2.BadRequest)
-		}
+	s.Vendor.Context.Subscribe("trigger", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			ctx := context.TODO()
+			if event.Context != nil {
+				ctx = event.Context
+			}
 
-		err = s.ActivationsManager.ReportStageStatus(ctx, activation, namespace, status)
-		if err != nil {
-			sLog.ErrorfCtx(ctx, "V (Stage): failed to report status: %v (%v)", status.ErrorMessage, err)
-			return err
-		}
-
-		if status.Status == v1alpha2.Done || status.Status == v1alpha2.OK {
-			campaignName := api_utils.ConvertReferenceToObjectName(campaign)
-			campaign, err := s.CampaignsManager.GetState(ctx, campaignName, namespace)
+			status := model.StageStatus{
+				Stage:         "",
+				NextStage:     "",
+				Outputs:       map[string]interface{}{},
+				Status:        v1alpha2.Untouched,
+				StatusMessage: v1alpha2.Untouched.String(),
+				ErrorMessage:  "",
+				IsActive:      true,
+			}
+			triggerData := v1alpha2.ActivationData{}
+			jData, _ := json.Marshal(event.Body)
+			err := json.Unmarshal(jData, &triggerData)
 			if err != nil {
-				sLog.ErrorfCtx(ctx, "V (Stage): failed to get campaign spec '%s': %v", campaign, err)
+				err = v1alpha2.NewCOAError(nil, "event body is not an activation job", v1alpha2.BadRequest)
+				sLog.ErrorfCtx(ctx, "V (Stage): failed to deserialize activation data: %v", err)
+				err = s.reportActivationStatusWithBadRequest(triggerData.Activation, triggerData.Namespace, err)
+				// If report status succeeded, return an empty err so the subscribe function will not be retried
+				// The actual error will be stored in Activation cr
 				return err
 			}
-			if campaign.Spec.SelfDriving {
-				activation, err := s.StageManager.ResumeStage(ctx, status, *campaign.Spec)
+			log.InfoCtx(ctx, "V (Stage): handling trigger event for activation %s stage %s in namespace %s",
+				triggerData.Activation, triggerData.Stage, triggerData.Namespace)
+
+			status.Outputs["__namespace"] = triggerData.Namespace
+			_, err = s.ActivationsManager.GetState(ctx, triggerData.Activation, triggerData.Namespace)
+			if err != nil {
+				sLog.ErrorfCtx(ctx, "V (Stage): unable to find activation: %+v", err)
+				return nil
+			}
+			campaignName := api_utils.ConvertReferenceToObjectName(triggerData.Campaign)
+			campaign, err := s.CampaignsManager.GetState(ctx, campaignName, triggerData.Namespace)
+			if err != nil {
+				sLog.ErrorfCtx(ctx, "V (Stage): failed to get campaign spec: %v", err)
+				err = s.reportActivationStatusWithBadRequest(triggerData.Activation, triggerData.Namespace, err)
+				// If report status succeeded, return an empty err so the subscribe function will not be retried
+				// The actual error will be stored in Activation cr
+				return err
+			}
+			status.Stage = triggerData.Stage
+			status.ErrorMessage = ""
+			status.Status = v1alpha2.Running
+			status.StatusMessage = v1alpha2.Running.String()
+			if triggerData.NeedsReport {
+				sLog.DebugfCtx(ctx, "V (Stage): activation %s, stage %s in namespace %s reporting status: %v", triggerData.Activation, triggerData.Stage, triggerData.Namespace, status)
+				s.Vendor.Context.Publish("report", v1alpha2.Event{
+					Body:    status,
+					Context: ctx,
+				})
+			} else {
+				err = s.ActivationsManager.ReportStageStatus(ctx, triggerData.Activation, triggerData.Namespace, status)
 				if err != nil {
-					status.Status = v1alpha2.InternalError
-					status.StatusMessage = v1alpha2.InternalError.String()
-					status.IsActive = false
-					status.ErrorMessage = fmt.Sprintf("failed to resume stage: %v", err)
-					sLog.ErrorfCtx(ctx, "V (Stage): failed to resume stage: %v", err)
+					sLog.Errorf("V (Stage): failed to report accepted status: %v (%v)", status.ErrorMessage, err)
+					return err
 				}
-				if activation != nil {
+			}
+
+			status, activation := s.StageManager.HandleTriggerEvent(ctx, *campaign.Spec, triggerData)
+
+			if triggerData.NeedsReport {
+				sLog.DebugfCtx(ctx, "V (Stage): reporting status: %v", status)
+				s.Vendor.Context.Publish("report", v1alpha2.Event{
+					Body:    status,
+					Context: ctx,
+				})
+
+			} else {
+				err = s.ActivationsManager.ReportStageStatus(ctx, triggerData.Activation, triggerData.Namespace, status)
+				if err != nil {
+					sLog.ErrorfCtx(ctx, "V (Stage): failed to report status: %v (%v)", status.ErrorMessage, err)
+					return err
+				}
+				if activation != nil && status.NextStage != "" && status.Status != v1alpha2.Paused {
 					s.Vendor.Context.Publish("trigger", v1alpha2.Event{
 						Body:    *activation,
 						Context: ctx,
 					})
 				}
 			}
-		}
-
-		return nil
+			log.InfoCtx(ctx, "V (Stage): Finished handling trigger event")
+			return nil
+		},
 	})
-	s.Vendor.Context.Subscribe("remote-job", func(topic string, event v1alpha2.Event) error {
-		ctx := context.TODO()
-		if event.Context != nil {
-			ctx = event.Context
-		}
-		// Unwrap data package from event body
-		jData, _ := json.Marshal(event.Body)
-		var job v1alpha2.JobData
-		json.Unmarshal(jData, &job)
-		jData, _ = json.Marshal(job.Body)
-		var dataPackage v1alpha2.InputOutputData
-		err := json.Unmarshal(jData, &dataPackage)
-		if err != nil {
-			return err
-		}
+	s.Vendor.Context.Subscribe("job-report", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			ctx := context.TODO()
+			if event.Context != nil {
+				ctx = event.Context
+			}
+			sLog.DebugfCtx(ctx, "V (Stage): handling job report event: %v", event)
+			jData, _ := json.Marshal(event.Body)
+			var status model.StageStatus
+			json.Unmarshal(jData, &status)
+			campaign, ok := status.Outputs["__campaign"].(string)
+			if !ok {
+				sLog.ErrorfCtx(ctx, "V (Stage): failed to get campaign name from job report")
+				return v1alpha2.NewCOAError(nil, "job-report: campaign is not valid", v1alpha2.BadRequest)
+			}
+			namespace, ok := status.Outputs["__namespace"].(string)
+			if !ok {
+				sLog.ErrorfCtx(ctx, "V (Stage): failed to get namespace from job report, use default instead")
+				namespace = "default"
+			}
+			activation, ok := status.Outputs["__activation"].(string)
+			if !ok {
+				sLog.ErrorfCtx(ctx, "V (Stage): failed to get activation name from job report")
+				return v1alpha2.NewCOAError(nil, "job-report: activation is not valid", v1alpha2.BadRequest)
+			}
 
-		// restore schedule
-		var schedule = ""
-		if v, ok := dataPackage.Inputs["__schedule"]; ok {
-			schedule = utils.FormatAsString(v)
-		}
+			err = s.ActivationsManager.ReportStageStatus(ctx, activation, namespace, status)
+			if err != nil {
+				sLog.ErrorfCtx(ctx, "V (Stage): failed to report status: %v (%v)", status.ErrorMessage, err)
+				return err
+			}
 
-		triggerData := v1alpha2.ActivationData{
-			Activation:           utils.FormatAsString(dataPackage.Inputs["__activation"]),
-			ActivationGeneration: utils.FormatAsString(dataPackage.Inputs["__activationGeneration"]),
-			Campaign:             utils.FormatAsString(dataPackage.Inputs["__campaign"]),
-			Stage:                utils.FormatAsString(dataPackage.Inputs["__stage"]),
-			Inputs:               dataPackage.Inputs,
-			Outputs:              dataPackage.Outputs,
-			Schedule:             schedule,
-			NeedsReport:          true,
-			Namespace:            utils.FormatAsString(dataPackage.Inputs["__namespace"]),
-		}
+			if status.Status == v1alpha2.Done || status.Status == v1alpha2.OK {
+				campaignName := api_utils.ConvertReferenceToObjectName(campaign)
+				campaign, err := s.CampaignsManager.GetState(ctx, campaignName, namespace)
+				if err != nil {
+					sLog.ErrorfCtx(ctx, "V (Stage): failed to get campaign spec '%s': %v", campaign, err)
+					return err
+				}
+				if campaign.Spec.SelfDriving {
+					activation, err := s.StageManager.ResumeStage(ctx, status, *campaign.Spec)
+					if err != nil {
+						status.Status = v1alpha2.InternalError
+						status.StatusMessage = v1alpha2.InternalError.String()
+						status.IsActive = false
+						status.ErrorMessage = fmt.Sprintf("failed to resume stage: %v", err)
+						sLog.ErrorfCtx(ctx, "V (Stage): failed to resume stage: %v", err)
+					}
+					if activation != nil {
+						s.Vendor.Context.Publish("trigger", v1alpha2.Event{
+							Body:    *activation,
+							Context: ctx,
+						})
+					}
+				}
+			}
 
-		triggerData.Inputs["__origin"] = event.Metadata["origin"]
-
-		switch dataPackage.Inputs["operation"] {
-		case "wait":
-			triggerData.Provider = "providers.stage.wait"
-			config, err := wait.WaitStageProviderConfigFromVendorMap(s.Vendor.Config.Properties)
+			return nil
+		},
+	})
+	s.Vendor.Context.Subscribe("remote-job", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			ctx := context.TODO()
+			if event.Context != nil {
+				ctx = event.Context
+			}
+			// Unwrap data package from event body
+			jData, _ := json.Marshal(event.Body)
+			var job v1alpha2.JobData
+			json.Unmarshal(jData, &job)
+			jData, _ = json.Marshal(job.Body)
+			var dataPackage v1alpha2.InputOutputData
+			err := json.Unmarshal(jData, &dataPackage)
 			if err != nil {
 				return err
 			}
-			triggerData.Config = config
-		case "materialize":
-			triggerData.Provider = "providers.stage.materialize"
-			config, err := materialize.MaterializeStageProviderConfigFromVendorMap(s.Vendor.Config.Properties)
-			if err != nil {
-				return err
+
+			// restore schedule
+			var schedule = ""
+			if v, ok := dataPackage.Inputs["__schedule"]; ok {
+				schedule = utils.FormatAsString(v)
 			}
-			triggerData.Config = config
-		case "mock":
-			triggerData.Provider = "providers.stage.mock"
-			config, err := mock.MockStageProviderConfigFromMap(s.Vendor.Config.Properties)
-			if err != nil {
-				return err
+
+			triggerData := v1alpha2.ActivationData{
+				Activation:           utils.FormatAsString(dataPackage.Inputs["__activation"]),
+				ActivationGeneration: utils.FormatAsString(dataPackage.Inputs["__activationGeneration"]),
+				Campaign:             utils.FormatAsString(dataPackage.Inputs["__campaign"]),
+				Stage:                utils.FormatAsString(dataPackage.Inputs["__stage"]),
+				Inputs:               dataPackage.Inputs,
+				Outputs:              dataPackage.Outputs,
+				Schedule:             schedule,
+				NeedsReport:          true,
+				Namespace:            utils.FormatAsString(dataPackage.Inputs["__namespace"]),
 			}
-			triggerData.Config = config
-		default:
-			return v1alpha2.NewCOAError(nil, fmt.Sprintf("operation %v is not supported", dataPackage.Inputs["operation"]), v1alpha2.BadRequest)
-		}
-		status := s.StageManager.HandleDirectTriggerEvent(ctx, triggerData)
-		sLog.DebugfCtx(ctx, "V (Stage): reporting status: %v", status)
-		s.Vendor.Context.Publish("report", v1alpha2.Event{
-			Body:    status,
-			Context: ctx,
-		})
-		return nil
+
+			triggerData.Inputs["__origin"] = event.Metadata["origin"]
+
+			switch dataPackage.Inputs["operation"] {
+			case "wait":
+				triggerData.Provider = "providers.stage.wait"
+				config, err := wait.WaitStageProviderConfigFromVendorMap(s.Vendor.Config.Properties)
+				if err != nil {
+					return err
+				}
+				triggerData.Config = config
+			case "materialize":
+				triggerData.Provider = "providers.stage.materialize"
+				config, err := materialize.MaterializeStageProviderConfigFromVendorMap(s.Vendor.Config.Properties)
+				if err != nil {
+					return err
+				}
+				triggerData.Config = config
+			case "mock":
+				triggerData.Provider = "providers.stage.mock"
+				config, err := mock.MockStageProviderConfigFromMap(s.Vendor.Config.Properties)
+				if err != nil {
+					return err
+				}
+				triggerData.Config = config
+			default:
+				return v1alpha2.NewCOAError(nil, fmt.Sprintf("operation %v is not supported", dataPackage.Inputs["operation"]), v1alpha2.BadRequest)
+			}
+			status := s.StageManager.HandleDirectTriggerEvent(ctx, triggerData)
+			sLog.DebugfCtx(ctx, "V (Stage): reporting status: %v", status)
+			s.Vendor.Context.Publish("report", v1alpha2.Event{
+				Body:    status,
+				Context: ctx,
+			})
+			return nil
+		},
 	})
 	return nil
 }

--- a/api/symphony-api-production.json
+++ b/api/symphony-api-production.json
@@ -27,7 +27,7 @@
           "host": "localhost:6379",
           "requireTLS": false,
           "password": "",
-          "numberOfWorkers": 1
+          "numberOfWorkers": 10
         }
       }
     },

--- a/api/symphony-api-production.json
+++ b/api/symphony-api-production.json
@@ -27,7 +27,7 @@
           "host": "localhost:6379",
           "requireTLS": false,
           "password": "",
-          "numberOfWorkers": 10
+          "numberOfWorkers": 20
         }
       }
     },

--- a/api/symphony-api-production.json
+++ b/api/symphony-api-production.json
@@ -27,7 +27,7 @@
           "host": "localhost:6379",
           "requireTLS": false,
           "password": "",
-          "numberOfWorkers": 20
+          "numberOfWorkers": 1
         }
       }
     },

--- a/coa/pkg/apis/v1alpha2/contexts/manager-context_test.go
+++ b/coa/pkg/apis/v1alpha2/contexts/manager-context_test.go
@@ -68,10 +68,12 @@ func TestManagerContextPublishSubscribe(t *testing.T) {
 
 	called := false
 	sig := make(chan bool)
-	m.Subscribe("test", func(topic string, event v1alpha2.Event) error {
-		called = true
-		sig <- true
-		return nil
+	m.Subscribe("test", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			called = true
+			sig <- true
+			return nil
+		},
 	})
 
 	m.Publish("test", v1alpha2.Event{})
@@ -87,9 +89,11 @@ func TestManagerContextPublishSubscribeWithoutPubSub(t *testing.T) {
 	assert.Nil(t, m.PubsubProvider)
 
 	called := false
-	m.Subscribe("test", func(topic string, event v1alpha2.Event) error {
-		called = true
-		return nil
+	m.Subscribe("test", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			called = true
+			return nil
+		},
 	})
 
 	m.Publish("test", v1alpha2.Event{})

--- a/coa/pkg/apis/v1alpha2/contexts/vendor-context_test.go
+++ b/coa/pkg/apis/v1alpha2/contexts/vendor-context_test.go
@@ -28,7 +28,7 @@ func (t *TestPubSubProvider) Publish(topic string, event v1alpha2.Event) error {
 	if ok && arr != nil {
 		for _, s := range arr {
 			go func(handler v1alpha2.EventHandler, topic string, event v1alpha2.Event) {
-				handler(topic, event)
+				handler.Handler(topic, event)
 			}(s, topic, event)
 		}
 	}
@@ -76,10 +76,13 @@ func TestVendorContextPublishSubscribe(t *testing.T) {
 
 	called := false
 	sig := make(chan bool)
-	v.Subscribe("test", func(topic string, event v1alpha2.Event) error {
-		called = true
-		sig <- true
-		return nil
+	v.Subscribe("test", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			called = true
+			sig <- true
+			return nil
+		},
+		Group: "0",
 	})
 
 	v.Publish("test", v1alpha2.Event{})
@@ -95,9 +98,12 @@ func TestVendorContextPublishSubscribeWithoutPubSub(t *testing.T) {
 	assert.Nil(t, v.PubsubProvider)
 
 	called := false
-	v.Subscribe("test", func(topic string, event v1alpha2.Event) error {
-		called = true
-		return nil
+	v.Subscribe("test", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			called = true
+			return nil
+		},
+		Group: "0",
 	})
 
 	v.Publish("test", v1alpha2.Event{})

--- a/coa/pkg/apis/v1alpha2/events.go
+++ b/coa/pkg/apis/v1alpha2/events.go
@@ -186,10 +186,15 @@ func (e Event) MarshalBinary() (data []byte, err error) {
 	return json.Marshal(e)
 }
 
-type EventHandler func(topic string, message Event) error
+type EventHandler struct {
+	Handler func(topic string, message Event) error
+	// Group is used to distinguish different handlers for the same topic
+	// Important: The Group name of an existing handler should NOT be modified.
+	Group string
+}
 
 func EventShouldRetryWrapper(handler EventHandler, topic string, message Event) bool {
-	err := handler(topic, message)
+	err := handler.Handler(topic, message)
 	if err != nil {
 		return IsRetriableErr(err)
 	}

--- a/coa/pkg/apis/v1alpha2/providers/pubsub/memory/memory_test.go
+++ b/coa/pkg/apis/v1alpha2/providers/pubsub/memory/memory_test.go
@@ -19,10 +19,12 @@ func TestBasicPubSub(t *testing.T) {
 	msg := ""
 	provider := InMemoryPubSubProvider{}
 	provider.Init(InMemoryPubSubConfig{Name: "test"})
-	provider.Subscribe("test", func(topic string, event v1alpha2.Event) error {
-		msg = event.Body.(string)
-		sig <- 1
-		return nil
+	provider.Subscribe("test", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			msg = event.Body.(string)
+			sig <- 1
+			return nil
+		},
 	})
 	provider.Publish("test", v1alpha2.Event{Body: "TEST"})
 	<-sig
@@ -36,15 +38,19 @@ func TestMultipleSubscriber(t *testing.T) {
 	msg2 := ""
 	provider := InMemoryPubSubProvider{}
 	provider.Init(InMemoryPubSubConfig{Name: "test"})
-	provider.Subscribe("test", func(topic string, event v1alpha2.Event) error {
-		msg1 = event.Body.(string)
-		sig1 <- 1
-		return nil
+	provider.Subscribe("test", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			msg1 = event.Body.(string)
+			sig1 <- 1
+			return nil
+		},
 	})
-	provider.Subscribe("test", func(topic string, event v1alpha2.Event) error {
-		msg2 = event.Body.(string)
-		sig2 <- 1
-		return nil
+	provider.Subscribe("test", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			msg2 = event.Body.(string)
+			sig2 <- 1
+			return nil
+		},
 	})
 	provider.Publish("test", v1alpha2.Event{Body: "TEST"})
 	<-sig1
@@ -60,15 +66,19 @@ func TestMultipleTopics(t *testing.T) {
 	msg2 := ""
 	provider := InMemoryPubSubProvider{}
 	provider.Init(InMemoryPubSubConfig{Name: "test"})
-	provider.Subscribe("test1", func(topic string, event v1alpha2.Event) error {
-		msg1 = event.Body.(string)
-		sig1 <- 1
-		return nil
+	provider.Subscribe("test1", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			msg1 = event.Body.(string)
+			sig1 <- 1
+			return nil
+		},
 	})
-	provider.Subscribe("test2", func(topic string, event v1alpha2.Event) error {
-		msg2 = event.Body.(string)
-		sig2 <- 1
-		return nil
+	provider.Subscribe("test2", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			msg2 = event.Body.(string)
+			sig2 <- 1
+			return nil
+		},
 	})
 	provider.Publish("test1", v1alpha2.Event{Body: "TEST1"})
 	provider.Publish("test2", v1alpha2.Event{Body: "TEST2"})
@@ -147,10 +157,12 @@ func TestMemoryPubsubProviderBadRequest(t *testing.T) {
 	ch := make(chan struct{})
 	count := 0
 
-	err := provider.Subscribe("test", func(topic string, event v1alpha2.Event) error {
-		count += 1
-		ch <- struct{}{}
-		return v1alpha2.NewCOAError(nil, "insert bad request", v1alpha2.BadRequest)
+	err := provider.Subscribe("test", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			count += 1
+			ch <- struct{}{}
+			return v1alpha2.NewCOAError(nil, "insert bad request", v1alpha2.BadRequest)
+		},
 	})
 	assert.Nil(t, err)
 	err = provider.Publish("test", v1alpha2.Event{
@@ -184,10 +196,12 @@ func TestMemoryPubsubProviderInternalError(t *testing.T) {
 	ch := make(chan struct{})
 	count := 0
 
-	err := provider.Subscribe("test", func(topic string, event v1alpha2.Event) error {
-		count += 1
-		ch <- struct{}{}
-		return v1alpha2.NewCOAError(nil, "insert internal error", v1alpha2.InternalError)
+	err := provider.Subscribe("test", v1alpha2.EventHandler{
+		Handler: func(topic string, event v1alpha2.Event) error {
+			count += 1
+			ch <- struct{}{}
+			return v1alpha2.NewCOAError(nil, "insert internal error", v1alpha2.InternalError)
+		},
 	})
 	assert.Nil(t, err)
 	err = provider.Publish("test", v1alpha2.Event{

--- a/coa/pkg/apis/v1alpha2/providers/pubsub/redis/redis_test.go
+++ b/coa/pkg/apis/v1alpha2/providers/pubsub/redis/redis_test.go
@@ -54,7 +54,7 @@ func TestWithZeroWorkerCount(t *testing.T) {
 	assert.True(t, ok)
 	// NumberOfWorkers should be set to 1, but initializtion should fail because of invalid host name
 	assert.Equal(t, v1alpha2.InternalError, coaErr.State)
-	assert.Equal(t, 1, provider.Config.NumberOfWorkers)
+	assert.Equal(t, 20, provider.Config.NumberOfWorkers)
 }
 
 func TestInit(t *testing.T) {

--- a/packages/helm/symphony/files/symphony-api.json
+++ b/packages/helm/symphony/files/symphony-api.json
@@ -37,8 +37,7 @@
           "host": "{{ include "symphony.redisHost" . }}",
           "requireTLS": false,
           "password": "",
-          "numberOfWorkers": 1,
-          "multiInstance": false
+          "numberOfWorkers": 1
         }
       }
       {{- else }}

--- a/packages/helm/symphony/files/symphony-api.json
+++ b/packages/helm/symphony/files/symphony-api.json
@@ -37,7 +37,7 @@
           "host": "{{ include "symphony.redisHost" . }}",
           "requireTLS": false,
           "password": "",
-          "numberOfWorkers": 1
+          "numberOfWorkers": 20
         }
       }
       {{- else }}


### PR DESCRIPTION
Previous design of redis pubsub maintain an in-memory Queue which contains pending message. However, it requires extra effects to maintain the queue. For example, we need to dedup pending messages if they are already in the queue and we need to be very careful about the locks.
To remove this queue and simplify the logic of redis pubsub, changes are made below
1. We maintain a number of idle workers. Each time when new messages or pending messages are ready, we will try to decrement the number of idle workers so that we can launch a new thread to process the message. And the worker is released back to pool once the thread is done.
2. When a message is being processed, another heartbeat thread will reclaim this message frequently which reset the idleTime of the message and prevent it being claimed by other threads.

Besides, also fixed #358 by adding Group field in the handler. If there is a new subscriber for a topic, subscriber can enter a brand new "Group" name so that all the messages for the topic will be distributed to it.