### PR TITLE
Add Triggers field for activation input

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/stage/stage-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/stage/stage-manager.go
@@ -203,10 +203,10 @@ func (s *StageManager) ResumeStage(ctx context.Context, status model.StageStatus
 				nextStage := ""
 				if currentStage, ok := cam.Stages[stage]; ok {
 					parser := utils.NewParser(currentStage.StageSelector)
-
 					eCtx := s.VendorContext.EvaluationContext.Clone()
 					eCtx.Context = ctx
 					eCtx.Namespace = namespace
+					eCtx.Triggers = currentStage.Inputs
 					eCtx.Inputs = status.Inputs
 					log.DebugfCtx(ctx, " M (Stage): ResumeStage evaluation inputs: %v", eCtx.Inputs)
 					if eCtx.Inputs != nil {
@@ -433,7 +433,8 @@ func (s *StageManager) HandleTriggerEvent(ctx context.Context, campaign model.Ca
 			eCtx := s.VendorContext.EvaluationContext.Clone()
 			eCtx.Context = ctx
 			eCtx.Namespace = triggerData.Namespace
-			eCtx.Inputs = triggerData.Inputs
+			eCtx.Inputs = currentStage.Inputs
+			eCtx.Triggers = triggerData.Inputs
 			if eCtx.Inputs != nil {
 				if v, ok := eCtx.Inputs["context"]; ok {
 					eCtx.Value = v
@@ -471,15 +472,13 @@ func (s *StageManager) HandleTriggerEvent(ctx context.Context, campaign model.Ca
 			sites = append(sites, s.VendorContext.SiteInfo.SiteId)
 		}
 
-		inputs := triggerData.Inputs
+		triggers := triggerData.Inputs
+		if triggers == nil {
+			triggers = make(map[string]interface{})
+		}
+		inputs := currentStage.Inputs
 		if inputs == nil {
 			inputs = make(map[string]interface{})
-		}
-
-		if currentStage.Inputs != nil {
-			for k, v := range currentStage.Inputs {
-				inputs[k] = v
-			}
 		}
 
 		// inject default inputs
@@ -496,7 +495,7 @@ func (s *StageManager) HandleTriggerEvent(ctx context.Context, campaign model.Ca
 
 		for k, v := range inputs {
 			var val interface{}
-			val, err = s.traceValue(ctx, v, triggerData.Namespace, inputs, triggerData.Outputs)
+			val, err = s.traceValue(ctx, v, triggerData.Namespace, inputs, triggers, triggerData.Outputs)
 			if err != nil {
 				status.Status = v1alpha2.InternalError
 				status.StatusMessage = v1alpha2.InternalError.String()
@@ -565,7 +564,7 @@ func (s *StageManager) HandleTriggerEvent(ctx context.Context, campaign model.Ca
 
 				for k, v := range inputCopy {
 					var val interface{}
-					val, err = s.traceValue(ctx, v, triggerData.Namespace, inputCopy, triggerData.Outputs)
+					val, err = s.traceValue(ctx, v, triggerData.Namespace, inputCopy, triggers, triggerData.Outputs)
 					if err != nil {
 						status.Status = v1alpha2.InternalError
 						status.StatusMessage = v1alpha2.InternalError.String()
@@ -698,7 +697,8 @@ func (s *StageManager) HandleTriggerEvent(ctx context.Context, campaign model.Ca
 			eCtx := s.VendorContext.EvaluationContext.Clone()
 			eCtx.Context = ctx
 			eCtx.Namespace = triggerData.Namespace
-			eCtx.Inputs = triggerData.Inputs
+			eCtx.Triggers = triggerData.Inputs
+			eCtx.Inputs = currentStage.Inputs
 			if eCtx.Inputs != nil {
 				if v, ok := eCtx.Inputs["context"]; ok {
 					eCtx.Value = v
@@ -782,7 +782,7 @@ func (s *StageManager) HandleTriggerEvent(ctx context.Context, campaign model.Ca
 	return status, activationData
 }
 
-func (s *StageManager) traceValue(ctx context.Context, v interface{}, namespace string, inputs map[string]interface{}, outputs map[string]map[string]interface{}) (interface{}, error) {
+func (s *StageManager) traceValue(ctx context.Context, v interface{}, namespace string, inputs map[string]interface{}, triggers map[string]interface{}, outputs map[string]map[string]interface{}) (interface{}, error) {
 	switch val := v.(type) {
 	case string:
 		parser := utils.NewParser(val)
@@ -791,6 +791,7 @@ func (s *StageManager) traceValue(ctx context.Context, v interface{}, namespace 
 		context.DeploymentSpec = s.Context.VencorContext.EvaluationContext.DeploymentSpec
 		context.Namespace = namespace
 		context.Inputs = inputs
+		context.Triggers = triggers
 		context.Outputs = outputs
 		if context.Inputs != nil {
 			if v, ok := context.Inputs["context"]; ok {
@@ -805,12 +806,12 @@ func (s *StageManager) traceValue(ctx context.Context, v interface{}, namespace 
 		case string:
 			return vt, nil
 		default:
-			return s.traceValue(ctx, v, namespace, inputs, outputs)
+			return s.traceValue(ctx, v, namespace, inputs, triggers, outputs)
 		}
 	case []interface{}:
 		ret := []interface{}{}
 		for _, v := range val {
-			tv, err := s.traceValue(ctx, v, namespace, inputs, outputs)
+			tv, err := s.traceValue(ctx, v, namespace, inputs, triggers, outputs)
 			if err != nil {
 				return "", err
 			}
@@ -820,7 +821,7 @@ func (s *StageManager) traceValue(ctx context.Context, v interface{}, namespace 
 	case map[string]interface{}:
 		ret := map[string]interface{}{}
 		for k, v := range val {
-			tv, err := s.traceValue(ctx, v, namespace, inputs, outputs)
+			tv, err := s.traceValue(ctx, v, namespace, inputs, triggers, outputs)
 			if err != nil {
 				return "", err
 			}

--- a/api/pkg/apis/v1alpha1/utils/parser.go
+++ b/api/pkg/apis/v1alpha1/utils/parser.go
@@ -559,6 +559,26 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 			return property, nil
 		}
 		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$output() expects 2 argument, found %d", len(n.Args)), v1alpha2.BadConfig)
+	case "trigger":
+		if len(n.Args) == 2 {
+			if context.Triggers == nil {
+				return nil, errors.New("a trigger collection is needed to evaluate $trigger")
+			}
+			key, err := n.Args[0].Eval(context)
+			if err != nil {
+				return nil, err
+			}
+			defaultVal, err := n.Args[1].Eval(context)
+			if err != nil {
+				return nil, err
+			}
+			property, err := readPropertyInterface(context.Triggers, FormatAsString(key))
+			if err != nil {
+				return defaultVal, nil
+			}
+			return property, nil
+		}
+		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$trigger() expects 2 arguments, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "equal":
 		if len(n.Args) == 2 {
 			v1, err := n.Args[0].Eval(context)

--- a/api/pkg/apis/v1alpha1/utils/parser.go
+++ b/api/pkg/apis/v1alpha1/utils/parser.go
@@ -561,9 +561,6 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$output() expects 2 argument, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "trigger":
 		if len(n.Args) == 2 {
-			if context.Triggers == nil {
-				return nil, errors.New("a trigger collection is needed to evaluate $trigger")
-			}
 			key, err := n.Args[0].Eval(context)
 			if err != nil {
 				return nil, err
@@ -571,6 +568,9 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 			defaultVal, err := n.Args[1].Eval(context)
 			if err != nil {
 				return nil, err
+			}
+			if context.Triggers == nil {
+				return defaultVal, nil
 			}
 			property, err := readPropertyInterface(context.Triggers, FormatAsString(key))
 			if err != nil {

--- a/api/pkg/apis/v1alpha1/utils/parser_test.go
+++ b/api/pkg/apis/v1alpha1/utils/parser_test.go
@@ -2695,6 +2695,68 @@ func TestLeadingUnderScore(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "a__b", val)
 }
+func TestTriggerGetValue(t *testing.T) {
+	ctx := utils.EvaluationContext{
+		Triggers: map[string]interface{}{
+			"foo":  "bar",
+			"bar":  24,
+			"bazz": true,
+		},
+	}
+	parser1 := NewParser("${{$trigger(foo, -1)}}")
+	val, err := parser1.Eval(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, "bar", val)
+	parser2 := NewParser("${{$trigger(bar, -1)}}")
+	val, err = parser2.Eval(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, int(24), val)
+	parser3 := NewParser("${{$trigger(bazz, false)}}")
+	val, err = parser3.Eval(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, true, val)
+}
+
+func TestTriggerOutputGetValue(t *testing.T) {
+	ctx := utils.EvaluationContext{
+		Triggers: map[string]interface{}{
+			"foo": "bar",
+		},
+		Outputs: map[string]map[string]interface{}{
+			"test": {
+				"foo": 0,
+			},
+		},
+	}
+	parser1 := NewParser("${{$if($equal($output(test,foo), 0), $trigger(foo, 0), $output(test,foo))}}")
+	val, err := parser1.Eval(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, "bar", val)
+}
+
+func TestTriggerGetDefault(t *testing.T) {
+	parser := NewParser("${{$trigger(foo, -1)}}")
+	val, err := parser.Eval(utils.EvaluationContext{
+		Triggers: map[string]interface{}{},
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(-1), val)
+}
+func TestTriggerMissingTriggers(t *testing.T) {
+	parser := NewParser("${{$trigger(foo, -1)}}")
+	_, err := parser.Eval(utils.EvaluationContext{})
+	assert.NotNil(t, err)
+}
+func TestTriggerMissingTriggersWithDefault(t *testing.T) {
+	parser := NewParser("${{$trigger(foo)}}")
+	_, err := parser.Eval(utils.EvaluationContext{
+		Triggers: map[string]interface{}{
+			"foo": "bar",
+			"bar": 24,
+		},
+	})
+	assert.NotNil(t, err)
+}
 func TestEvaulateValueRange(t *testing.T) {
 	parser := NewParser("${{$and($gt($val(),5), $lt($val(),10))}}")
 	val, err := parser.Eval(utils.EvaluationContext{

--- a/api/pkg/apis/v1alpha1/utils/parser_test.go
+++ b/api/pkg/apis/v1alpha1/utils/parser_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/config/mock"
 	secretmock "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/secret/mock"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/utils"
@@ -2744,8 +2745,9 @@ func TestTriggerGetDefault(t *testing.T) {
 }
 func TestTriggerMissingTriggers(t *testing.T) {
 	parser := NewParser("${{$trigger(foo, -1)}}")
-	_, err := parser.Eval(utils.EvaluationContext{})
-	assert.NotNil(t, err)
+	val, err := parser.Eval(utils.EvaluationContext{})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(-1), val)
 }
 func TestTriggerMissingTriggersWithDefault(t *testing.T) {
 	parser := NewParser("${{$trigger(foo)}}")
@@ -2756,6 +2758,9 @@ func TestTriggerMissingTriggersWithDefault(t *testing.T) {
 		},
 	})
 	assert.NotNil(t, err)
+	cErr, ok := err.(v1alpha2.COAError)
+	assert.True(t, ok)
+	assert.Equal(t, v1alpha2.BadConfig, cErr.State)
 }
 func TestEvaulateValueRange(t *testing.T) {
 	parser := NewParser("${{$and($gt($val(),5), $lt($val(),10))}}")

--- a/coa/pkg/apis/v1alpha2/utils/utils.go
+++ b/coa/pkg/apis/v1alpha2/utils/utils.go
@@ -56,6 +56,7 @@ type EvaluationContext struct {
 	Properties     map[string]string
 	Inputs         map[string]interface{}
 	Outputs        map[string]map[string]interface{}
+	Triggers       map[string]interface{}
 	Component      string
 	Value          interface{}
 	Namespace      string

--- a/docs/samples/campaigns/counter/campaign.yaml
+++ b/docs/samples/campaigns/counter/campaign.yaml
@@ -17,3 +17,6 @@ spec:
       name: "counter"
       provider: "providers.stage.counter"      
       stageSelector: "${{$if($lt($output(counter,val), 20), counter, '')}}"
+      inputs:
+        val: "${{$trigger(val, 0)}}"
+        val.init: "${{$trigger(val.init, 0)}}"

--- a/docs/samples/campaigns/hello-world/campaign.yaml
+++ b/docs/samples/campaigns/hello-world/campaign.yaml
@@ -15,4 +15,6 @@ spec:
   stages:
     mock:
       name: "mock"
-      provider: "providers.stage.mock"  
+      provider: "providers.stage.mock"
+      inputs:
+        foo: "${{$trigger(foo, 0)}}"

--- a/docs/samples/campaigns/mock/activation.yaml
+++ b/docs/samples/campaigns/mock/activation.yaml
@@ -5,3 +5,5 @@ metadata:
 spec:
   campaign: "mock-campaign:v1"
   stage: ""
+  inputs:
+    foo: 0

--- a/docs/samples/campaigns/mock/activation.yaml
+++ b/docs/samples/campaigns/mock/activation.yaml
@@ -5,5 +5,3 @@ metadata:
 spec:
   campaign: "mock-campaign:v1"
   stage: ""
-  inputs:
-    foo: 0

--- a/docs/symphony-book/concepts/unified-object-model/property-expressions.md
+++ b/docs/symphony-book/concepts/unified-object-model/property-expressions.md
@@ -61,7 +61,8 @@ When these functions are used, a valid `EvaluationContext` is required, which in
 |----------|---------|
 |`$config(<config object>, <config key>, [<overrides>])` | Reads a configuration from a config provider |
 |`$context([<JsonPath>])` | Reads the evaluation context value. If a JsonPath is specified, it applies the path to the context value (same as `$val()`) |
-|`$input(<field>)` | Reads campaign activation input `<field>` |
+|`$input(<field>)` | Reads campaign input `<field>` |
+|`$trigger(<field>, <default value>)` | Reads activation input `<field>`, if not exist, use the `<default value>` |
 |`$instance()`| Gets instance name of the current deployment |
 |`$json(<value>)`| Arranges `<value>` into a JSON string |
 |`$output(<stage>, <field>)` | Reads the output `<field>` value from a campaign `<stage>` outputs|
@@ -88,7 +89,7 @@ Symphony also supports common logical operators:
 
 ## Evaluation context
 
-Functions like `$input()`, `$output()`, `instance()`, `property()` and  `$val()` etc. can be only evaluated in an appropriate evaluation context, to which Symphony automatically injects contextual information, such as Campaign activation inputs. When you use Symphony API, the evaluation context is automatically managed so you can use these functions in appropriate contexts without concerns. However, using these functions outside of an appropriate context leads to an error.
+Functions like `$input()`, `$output()`, `trigger()`, `instance()`, `property()` and  `$val()` etc. can be only evaluated in an appropriate evaluation context, to which Symphony automatically injects contextual information, such as Campaign activation inputs. When you use Symphony API, the evaluation context is automatically managed so you can use these functions in appropriate contexts without concerns. However, using these functions outside of an appropriate context leads to an error.
 
 ## Use operators as characters
 

--- a/test/integration/scenarios/04.workflow/manifest/activation-stage.yaml
+++ b/test/integration/scenarios/04.workflow/manifest/activation-stage.yaml
@@ -5,4 +5,6 @@ metadata:
 spec:
   campaign: "04campaign:v1"
   stage: "deploy"
+  inputs:
+    namesOnly: true
   

--- a/test/integration/scenarios/04.workflow/manifest/activation.yaml
+++ b/test/integration/scenarios/04.workflow/manifest/activation.yaml
@@ -4,4 +4,5 @@ metadata:
   name: 04workflow
 spec:
   campaign: "04campaign:v1"
-  
+  inputs:
+    namesOnly: true

--- a/test/integration/scenarios/04.workflow/manifest/campaign.yaml
+++ b/test/integration/scenarios/04.workflow/manifest/campaign.yaml
@@ -32,7 +32,7 @@ spec:
         password: ""
       inputs:
         objectType: catalogs
-        namesOnly: true
+        namesOnly: "${{$trigger(namesOnly,false)}}"
     deploy:
       name: deploy
       provider: providers.stage.materialize


### PR DESCRIPTION
Fix https://github.com/eclipse-symphony/symphony/issues/183
Previous discussion: https://github.com/eclipse-symphony/symphony/pull/352

### Enhancements to `StageManager`:

* Added an `apiClient` field to `StageManager` and initialized it in the `Init` function. (`api/pkg/apis/v1alpha1/managers/stage/stage-manager.go`)
* Integrated API client calls in `ResumeStage` to fetch activation state and update evaluation context triggers. (`api/pkg/apis/v1alpha1/managers/stage/stage-manager.go`)
* Modified `HandleTriggerEvent` to differentiate between `triggers` and `inputs`, ensuring proper handling of trigger data. (`api/pkg/apis/v1alpha1/managers/stage/stage-manager.go`)
* Updated the `traceValue` function to include `triggers` in the context for evaluation. (`api/pkg/apis/v1alpha1/managers/stage/stage-manager.go`)

### Test Case Updates:

* Added new imports and mock server setup for testing API client integration. (`api/pkg/apis/v1alpha1/managers/stage/stage-manager_test.go`)
* Updated test cases to reflect changes in input handling and API client integration:
  * Modified `TestCampaignWithSingleMockStageLoop` to use new trigger syntax.
  * Adjusted input initialization in `TestCampaignWithSingleCounterStageLoop` and `TestCampaignWithSingleNegativeCounterStageLoop`.
  * Added a new test case `TestCampaignWithTriggersCounterStageLoop` to validate trigger handling.
  * Enhanced `TestResumeStage` and `TestResumeStageFailed` to include API client setup and validation.