### PR TITLE
Add logs for catalog

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/configs/configs-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/configs/configs-manager.go
@@ -19,7 +19,6 @@ import (
 	observ_utils "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/observability/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/config"
-	coa_utils "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/logger"
 )
 
@@ -72,11 +71,7 @@ func (s *ConfigsManager) Init(vendorCtx *contexts.VendorContext, cfg managers.Ma
 	return nil
 }
 
-func (s *ConfigsManager) Get(object string, field string, overlays []string, localContext interface{}) (interface{}, error) {
-	ctx := context.TODO()
-	if localContext, ok := localContext.(coa_utils.EvaluationContext); ok {
-		ctx = localContext.Context
-	}
+func (s *ConfigsManager) Get(ctx context.Context, object string, field string, overlays []string, localContext interface{}) (interface{}, error) {
 	ctx, span := observability.StartSpan("Config Manager", ctx, &map[string]string{
 		"method": "Get",
 	})
@@ -154,11 +149,7 @@ func (s *ConfigsManager) getWithOverlay(ctx context.Context, provider config.ICo
 	return provider.Read(ctx, object, field, localContext)
 }
 
-func (s *ConfigsManager) GetObject(object string, overlays []string, localContext interface{}) (map[string]interface{}, error) {
-	ctx := context.TODO()
-	if localContext, ok := localContext.(coa_utils.EvaluationContext); ok {
-		ctx = localContext.Context
-	}
+func (s *ConfigsManager) GetObject(ctx context.Context, object string, overlays []string, localContext interface{}) (map[string]interface{}, error) {
 	ctx, span := observability.StartSpan("Config Manager", ctx, &map[string]string{
 		"method": "GetObject",
 	})
@@ -212,8 +203,8 @@ func (s *ConfigsManager) getObjectWithOverlay(ctx context.Context, provider conf
 	return provider.ReadObject(ctx, object, localContext)
 }
 
-func (s *ConfigsManager) Set(object string, field string, value interface{}) error {
-	ctx, span := observability.StartSpan("Config Manager", context.TODO(), &map[string]string{
+func (s *ConfigsManager) Set(ctx context.Context, object string, field string, value interface{}) error {
+	ctx, span := observability.StartSpan("Config Manager", ctx, &map[string]string{
 		"method": "Set",
 	})
 	var err error = nil
@@ -252,8 +243,8 @@ func (s *ConfigsManager) Set(object string, field string, value interface{}) err
 	return err
 }
 
-func (s *ConfigsManager) SetObject(object string, values map[string]interface{}) error {
-	ctx, span := observability.StartSpan("Config Manager", context.TODO(), &map[string]string{
+func (s *ConfigsManager) SetObject(ctx context.Context, object string, values map[string]interface{}) error {
+	ctx, span := observability.StartSpan("Config Manager", ctx, &map[string]string{
 		"method": "SetObject",
 	})
 	var err error = nil
@@ -292,8 +283,8 @@ func (s *ConfigsManager) SetObject(object string, values map[string]interface{})
 	return err
 }
 
-func (s *ConfigsManager) Delete(object string, field string) error {
-	ctx, span := observability.StartSpan("Config Manager", context.TODO(), &map[string]string{
+func (s *ConfigsManager) Delete(ctx context.Context, object string, field string) error {
+	ctx, span := observability.StartSpan("Config Manager", ctx, &map[string]string{
 		"method": "Delete",
 	})
 	var err error = nil
@@ -332,8 +323,8 @@ func (s *ConfigsManager) Delete(object string, field string) error {
 	return err
 }
 
-func (s *ConfigsManager) DeleteObject(object string) error {
-	ctx, span := observability.StartSpan("Config Manager", context.TODO(), &map[string]string{
+func (s *ConfigsManager) DeleteObject(ctx context.Context, object string) error {
+	ctx, span := observability.StartSpan("Config Manager", ctx, &map[string]string{
 		"method": "DeleteObject",
 	})
 	var err error = nil

--- a/api/pkg/apis/v1alpha1/managers/configs/configs-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/configs/configs-manager.go
@@ -30,14 +30,9 @@ type ConfigsManager struct {
 	Precedence      []string
 }
 
-func (s *ConfigsManager) Init(vendorCtx *contexts.VendorContext, cfg managers.ManagerConfig, providers map[string]providers.IProvider) error {
-	ctx := context.TODO()
-	if vendorCtx != nil && vendorCtx.EvaluationContext != nil && vendorCtx.EvaluationContext.Context != nil {
-		ctx = vendorCtx.EvaluationContext.Context
-	}
-
-	log.DebugCtx(ctx, " M (Config): Init")
-	err := s.Manager.Init(vendorCtx, cfg, providers)
+func (s *ConfigsManager) Init(context *contexts.VendorContext, cfg managers.ManagerConfig, providers map[string]providers.IProvider) error {
+	log.Debug(" M (Config): Init")
+	err := s.Manager.Init(context, cfg, providers)
 	if err != nil {
 		return err
 	}
@@ -51,11 +46,11 @@ func (s *ConfigsManager) Init(vendorCtx *contexts.VendorContext, cfg managers.Ma
 		s.Precedence = strings.Split(val, ",")
 	}
 	if len(s.ConfigProviders) == 0 {
-		log.ErrorCtx(ctx, " M (Config): No config providers found")
+		log.Error(" M (Config): No config providers found")
 		return v1alpha2.NewCOAError(nil, "No config providers found", v1alpha2.BadConfig)
 	}
 	if len(s.Precedence) < len(s.ConfigProviders) && len(s.ConfigProviders) > 1 {
-		log.ErrorCtx(ctx, " M (Config): Not enough precedence values")
+		log.Error(" M (Config): Not enough precedence values")
 		return v1alpha2.NewCOAError(nil, "Not enough precedence values", v1alpha2.BadConfig)
 	}
 	if len(s.ConfigProviders) > 1 {
@@ -64,7 +59,7 @@ func (s *ConfigsManager) Init(vendorCtx *contexts.VendorContext, cfg managers.Ma
 			provderKeys = append(provderKeys, key)
 		}
 		if !utils.AreSlicesEqual(provderKeys, s.Precedence) {
-			log.ErrorCtx(ctx, " M (Config): Precedence does not match with config providers")
+			log.Error(" M (Config): Precedence does not match with config providers")
 			return v1alpha2.NewCOAError(nil, "Precedence does not match with config providers", v1alpha2.BadConfig)
 		}
 	}

--- a/api/pkg/apis/v1alpha1/managers/configs/configs-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/configs/configs-manager_test.go
@@ -58,8 +58,8 @@ func TestObjectFieldGetWithProviderSpecified(t *testing.T) {
 		},
 	}
 	assert.Nil(t, err)
-	manager.Set("memory:obj", "field", "obj::field")
-	val, err := manager.Get("memory:obj", "field", nil, nil)
+	manager.Set(ctx, "memory:obj", "field", "obj::field")
+	val, err := manager.Get(ctx, "memory:obj", "field", nil, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "obj::field", val)
 }
@@ -79,15 +79,15 @@ func TestObjectGetWithProviderSpecified(t *testing.T) {
 		"key3": true,
 	}
 
-	manager.SetObject("memory:obj", object)
+	manager.SetObject(ctx, "memory:obj", object)
 
 	// GetObject
-	val, err := manager.GetObject("memory:obj", nil, nil)
+	val, err := manager.GetObject(ctx, "memory:obj", nil, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, object, val)
 
 	// Get
-	val2, err2 := manager.Get("memory:obj", "", nil, nil)
+	val2, err2 := manager.Get(ctx, "memory:obj", "", nil, nil)
 	assert.Nil(t, err2)
 	assert.Equal(t, object, val2)
 }
@@ -101,8 +101,8 @@ func TestObjectFieldGetWithOneProvider(t *testing.T) {
 		},
 	}
 	assert.Nil(t, err)
-	manager.Set("obj", "field", "obj::field")
-	val, err := manager.Get("obj", "field", nil, nil)
+	manager.Set(ctx, "obj", "field", "obj::field")
+	val, err := manager.Get(ctx, "obj", "field", nil, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "obj::field", val)
 }
@@ -122,15 +122,15 @@ func TestObjectGetWithOneProvider(t *testing.T) {
 		"key3": true,
 	}
 
-	manager.SetObject("obj", object)
+	manager.SetObject(ctx, "obj", object)
 
 	// GetObject
-	val, err := manager.GetObject("obj", nil, nil)
+	val, err := manager.GetObject(ctx, "obj", nil, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, object, val)
 
 	// Get
-	val2, err2 := manager.Get("obj", "", nil, nil)
+	val2, err2 := manager.Get(ctx, "obj", "", nil, nil)
 	assert.Nil(t, err2)
 	assert.Equal(t, object, val2)
 }
@@ -150,8 +150,8 @@ func TestObjectFieldGetWithMoreProviders(t *testing.T) {
 		Precedence: []string{"memory1", "memory2"},
 	}
 	assert.Nil(t, err)
-	manager.Set("obj", "field", "obj::field")
-	val, err := manager.Get("obj", "field", nil, nil)
+	manager.Set(ctx, "obj", "field", "obj::field")
+	val, err := manager.Get(ctx, "obj", "field", nil, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "obj::field", val)
 }
@@ -177,15 +177,15 @@ func TestObjectGetWithMoreProviders(t *testing.T) {
 		"key3": true,
 	}
 
-	manager.SetObject("obj", object)
+	manager.SetObject(ctx, "obj", object)
 
 	// GetObject
-	val, err := manager.GetObject("obj", nil, nil)
+	val, err := manager.GetObject(ctx, "obj", nil, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, object, val)
 
 	// Get
-	val2, err2 := manager.Get("obj", "", nil, nil)
+	val2, err2 := manager.Get(ctx, "obj", "", nil, nil)
 	assert.Nil(t, err2)
 	assert.Equal(t, object, val2)
 }
@@ -200,21 +200,21 @@ func TestWithOverlay(t *testing.T) {
 	}
 	assert.Nil(t, err)
 
-	manager.Set("obj", "field", "obj::field")
-	manager.Set("obj-overlay", "field", "overlay::field")
-	val, err := manager.Get("obj", "field", []string{"obj-overlay"}, nil)
+	manager.Set(ctx, "obj", "field", "obj::field")
+	manager.Set(ctx, "obj-overlay", "field", "overlay::field")
+	val, err := manager.Get(ctx, "obj", "field", []string{"obj-overlay"}, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "overlay::field", val)
 
 	object := map[string]interface{}{
 		"key1": "value1",
 	}
-	manager.SetObject("obj2", object)
+	manager.SetObject(ctx, "obj2", object)
 	object2 := map[string]interface{}{
 		"key1": "overlay",
 	}
-	manager.SetObject("obj2-overlay", object2)
-	val2, err2 := manager.GetObject("obj2", []string{"obj2-overlay"}, nil)
+	manager.SetObject(ctx, "obj2-overlay", object2)
+	val2, err2 := manager.GetObject(ctx, "obj2", []string{"obj2-overlay"}, nil)
 	assert.Nil(t, err2)
 	assert.Equal(t, object2, val2)
 
@@ -236,19 +236,19 @@ func TestOverlayWithMultipleProviders(t *testing.T) {
 	assert.Nil(t, err)
 	provider1.Set(ctx, "obj", "field", "obj::field")
 	provider2.Set(ctx, "obj-overlay", "field", "overlay::field")
-	val, err := manager.Get("obj", "field", []string{"obj-overlay"}, nil)
+	val, err := manager.Get(ctx, "obj", "field", []string{"obj-overlay"}, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "overlay::field", val)
 
 	object := map[string]interface{}{
 		"key1": "value1",
 	}
-	manager.SetObject("obj2", object)
+	manager.SetObject(ctx, "obj2", object)
 	object2 := map[string]interface{}{
 		"key1": "overlay",
 	}
-	manager.SetObject("obj2-overlay", object2)
-	val2, err2 := manager.GetObject("obj2", []string{"obj2-overlay"}, nil)
+	manager.SetObject(ctx, "obj2-overlay", object2)
+	val2, err2 := manager.GetObject(ctx, "obj2", []string{"obj2-overlay"}, nil)
 	assert.Nil(t, err2)
 	assert.Equal(t, object2, val2)
 }
@@ -268,19 +268,19 @@ func TestOverlayMissWithMultipleProviders(t *testing.T) {
 	}
 	assert.Nil(t, err)
 	provider1.Set(ctx, "obj", "field", "obj::field")
-	val, err := manager.Get("obj", "field", []string{"obj-overlay"}, nil)
+	val, err := manager.Get(ctx, "obj", "field", []string{"obj-overlay"}, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "obj::field", val)
 
 	object := map[string]interface{}{
 		"key1": "value1",
 	}
-	manager.SetObject("obj2", object)
+	manager.SetObject(ctx, "obj2", object)
 	object2 := map[string]interface{}{
 		"key1": "overlay",
 	}
-	manager.SetObject("obj2-overlay", object2)
-	val2, err2 := manager.GetObject("obj2", []string{"obj2-overlay"}, nil)
+	manager.SetObject(ctx, "obj2-overlay", object2)
+	val2, err2 := manager.GetObject(ctx, "obj2", []string{"obj2-overlay"}, nil)
 	assert.Nil(t, err2)
 	assert.Equal(t, object2, val2)
 }
@@ -301,19 +301,19 @@ func TestOverlayWithMultipleProvidersReversedPrecedence(t *testing.T) {
 	assert.Nil(t, err)
 	provider1.Set(ctx, "obj", "field", "obj::field")
 	provider2.Set(ctx, "obj-overlay", "field", "overlay::field")
-	val, err := manager.Get("obj", "field", []string{"obj-overlay"}, nil)
+	val, err := manager.Get(ctx, "obj", "field", []string{"obj-overlay"}, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "obj::field", val)
 
 	object := map[string]interface{}{
 		"key1": "value1",
 	}
-	manager.SetObject("obj2", object)
+	manager.SetObject(ctx, "obj2", object)
 	object2 := map[string]interface{}{
 		"key1": "overlay",
 	}
-	manager.SetObject("obj2-overlay", object2)
-	val2, err2 := manager.GetObject("obj2", []string{"obj2-overlay"}, nil)
+	manager.SetObject(ctx, "obj2-overlay", object2)
+	val2, err2 := manager.GetObject(ctx, "obj2", []string{"obj2-overlay"}, nil)
 	assert.Nil(t, err2)
 	assert.Equal(t, object2, val2)
 }
@@ -335,7 +335,7 @@ func TestMultipleProvidersSameKey(t *testing.T) {
 	assert.Nil(t, err)
 	provider1.Set(ctx, "obj", "field", "obj::field1")
 	provider2.Set(ctx, "obj", "field", "obj::field2")
-	val, err := manager.Get("obj", "field", nil, nil)
+	val, err := manager.Get(ctx, "obj", "field", nil, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "obj::field2", val)
 }
@@ -355,19 +355,19 @@ func TestObjectDeleteWithProviderSpecified(t *testing.T) {
 		"key2": 42,
 		"key3": true,
 	}
-	manager.SetObject("memory::obj", object)
+	manager.SetObject(ctx, "memory::obj", object)
 
 	// Delete field
-	err = manager.Delete("memory::obj", "key1")
+	err = manager.Delete(ctx, "memory::obj", "key1")
 	assert.Nil(t, err)
-	val, err := manager.Get("memory::obj", "key1", nil, nil)
+	val, err := manager.Get(ctx, "memory::obj", "key1", nil, nil)
 	assert.NotNil(t, err)
 	assert.Empty(t, val)
 
 	// Delete object
-	err2 := manager.DeleteObject("memory::obj")
+	err2 := manager.DeleteObject(ctx, "memory::obj")
 	assert.Nil(t, err2)
-	val2, err2 := manager.GetObject("memory::obj", nil, nil)
+	val2, err2 := manager.GetObject(ctx, "memory::obj", nil, nil)
 	assert.NotNil(t, err2)
 	assert.Empty(t, val2)
 }
@@ -387,19 +387,19 @@ func TestObjectDeleteWithOneProvider(t *testing.T) {
 		"key2": 42,
 		"key3": true,
 	}
-	manager.SetObject("obj", object)
+	manager.SetObject(ctx, "obj", object)
 
 	// Delete field
-	err = manager.Delete("obj", "key1")
+	err = manager.Delete(ctx, "obj", "key1")
 	assert.Nil(t, err)
-	val, err := manager.Get("obj", "key1", nil, nil)
+	val, err := manager.Get(ctx, "obj", "key1", nil, nil)
 	assert.NotNil(t, err)
 	assert.Empty(t, val)
 
 	// Delete object
-	err2 := manager.DeleteObject("obj")
+	err2 := manager.DeleteObject(ctx, "obj")
 	assert.Nil(t, err2)
-	val2, err2 := manager.GetObject("obj", nil, nil)
+	val2, err2 := manager.GetObject(ctx, "obj", nil, nil)
 	assert.NotNil(t, err2)
 	assert.Empty(t, val2)
 }
@@ -425,19 +425,19 @@ func TestObjectDeleteWithMoreProviders(t *testing.T) {
 		"key2": 42,
 		"key3": true,
 	}
-	manager.SetObject("obj", object)
+	manager.SetObject(ctx, "obj", object)
 
 	// Delete field
-	err = manager.Delete("obj", "key1")
+	err = manager.Delete(ctx, "obj", "key1")
 	assert.Nil(t, err)
-	val, err := manager.Get("obj", "key1", nil, nil)
+	val, err := manager.Get(ctx, "obj", "key1", nil, nil)
 	assert.NotNil(t, err)
 	assert.Empty(t, val)
 
 	// Delete object
-	err2 := manager.DeleteObject("obj")
+	err2 := manager.DeleteObject(ctx, "obj")
 	assert.Nil(t, err2)
-	val2, err2 := manager.GetObject("obj", nil, nil)
+	val2, err2 := manager.GetObject(ctx, "obj", nil, nil)
 	assert.NotNil(t, err2)
 	assert.Empty(t, val2)
 }
@@ -464,22 +464,22 @@ func TestObjectReference(t *testing.T) {
 		"key3": true,
 	}
 	// Get field
-	manager.SetObject("memory1::obj:v1", object)
-	val, err := manager.Get("obj:v1", "key1", nil, nil)
+	manager.SetObject(ctx, "memory1::obj:v1", object)
+	val, err := manager.Get(ctx, "obj:v1", "key1", nil, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "value1", val)
 
 	// Delete field
-	err = manager.Delete("memory1::obj:v1", "key1")
+	err = manager.Delete(ctx, "memory1::obj:v1", "key1")
 	assert.Nil(t, err)
-	val, err = manager.Get("memory1::obj:v1", "key1", nil, nil)
+	val, err = manager.Get(ctx, "memory1::obj:v1", "key1", nil, nil)
 	assert.NotNil(t, err)
 	assert.Empty(t, val)
 
 	// Delete object
-	err2 := manager.DeleteObject("memory1::obj:v1")
+	err2 := manager.DeleteObject(ctx, "memory1::obj:v1")
 	assert.Nil(t, err2)
-	val2, err2 := manager.GetObject("memory1::obj:v1", nil, nil)
+	val2, err2 := manager.GetObject(ctx, "memory1::obj:v1", nil, nil)
 	assert.NotNil(t, err2)
 	assert.Empty(t, val2)
 }
@@ -568,13 +568,13 @@ func TestCircularCatalogReferences(t *testing.T) {
 
 	evalContext.ConfigProvider = &manager
 
-	_, err = manager.Get("config1:v1", "image", nil, evalContext)
+	_, err = manager.Get(ctx, "config1:v1", "image", nil, evalContext)
 	assert.Error(t, err, "Detect circular dependency, object: config1-v-v1, field: image")
 
-	_, err = manager.Get("config1:v1", "attribute", nil, evalContext)
+	_, err = manager.Get(ctx, "config1:v1", "attribute", nil, evalContext)
 	assert.Nil(t, err, "Detect correct attribute, expect no error")
 
-	_, err = manager.Get("config2:v1", "attribute", nil, evalContext)
+	_, err = manager.Get(ctx, "config2:v1", "attribute", nil, evalContext)
 	assert.Nil(t, err, "Detect correct attribute, expect no error")
 }
 
@@ -650,10 +650,10 @@ func TestParentConfigEvaluation(t *testing.T) {
 
 	evalContext.ConfigProvider = &manager
 
-	val, err := manager.Get("config:v1", "parentAttribute", nil, evalContext)
+	val, err := manager.Get(ctx, "config:v1", "parentAttribute", nil, evalContext)
 	assert.Equal(t, "value", val)
 	assert.Nil(t, err)
 
-	_, err = manager.Get("config:v1", "parentCircular", nil, evalContext)
+	_, err = manager.Get(ctx, "config:v1", "parentCircular", nil, evalContext)
 	assert.Error(t, err, "Circular dependency in config should throw error")
 }

--- a/api/pkg/apis/v1alpha1/managers/configs/configs-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/configs/configs-manager_test.go
@@ -539,7 +539,9 @@ func TestCircularCatalogReferences(t *testing.T) {
 	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	os.Setenv(constants.UseServiceAccountTokenEnvName, "false")
 
-	evalContext := utils.EvaluationContext{}
+	evalContext := utils.EvaluationContext{
+		Context: context.TODO(),
+	}
 	vendorContext := coa_contexts.VendorContext{
 		EvaluationContext: &evalContext,
 	}
@@ -619,7 +621,9 @@ func TestParentConfigEvaluation(t *testing.T) {
 	os.Setenv(constants.SymphonyAPIUrlEnvName, ts.URL+"/")
 	os.Setenv(constants.UseServiceAccountTokenEnvName, "false")
 
-	evalContext := utils.EvaluationContext{}
+	evalContext := utils.EvaluationContext{
+		Context: context.TODO(),
+	}
 	vendorContext := coa_contexts.VendorContext{
 		EvaluationContext: &evalContext,
 	}

--- a/api/pkg/apis/v1alpha1/managers/jobs/jobs-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/jobs/jobs-manager.go
@@ -526,6 +526,7 @@ func (s *JobsManager) HandleJobEvent(ctx context.Context, event v1alpha2.Event) 
 			var deployment model.DeploymentSpec
 			deployment, err = utils.CreateSymphonyDeploymentFromTarget(ctx, target, namespace)
 			if err != nil {
+				log.ErrorfCtx(ctx, " M (Job): error reconciling target %s: %s", targetName, err.Error())
 				return err
 			}
 			switch job.Action {

--- a/api/pkg/apis/v1alpha1/managers/jobs/jobs-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/jobs/jobs-manager.go
@@ -468,7 +468,7 @@ func (s *JobsManager) HandleJobEvent(ctx context.Context, event v1alpha2.Event) 
 
 			//create deployment spec
 			var deployment model.DeploymentSpec
-			deployment, err = utils.CreateSymphonyDeployment(instance, solution, targetCandidates, nil, namespace)
+			deployment, err = utils.CreateSymphonyDeployment(ctx, instance, solution, targetCandidates, nil, namespace)
 			if err != nil {
 				log.ErrorfCtx(ctx, " M (Job): error creating deployment spec for instance %s: %s", instanceName, err.Error())
 				return err
@@ -524,7 +524,7 @@ func (s *JobsManager) HandleJobEvent(ctx context.Context, event v1alpha2.Event) 
 				return err
 			}
 			var deployment model.DeploymentSpec
-			deployment, err = utils.CreateSymphonyDeploymentFromTarget(target, namespace)
+			deployment, err = utils.CreateSymphonyDeploymentFromTarget(ctx, target, namespace)
 			if err != nil {
 				return err
 			}

--- a/api/pkg/apis/v1alpha1/managers/secrets/secrets-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/secrets/secrets-manager.go
@@ -31,7 +31,7 @@ type SecretsManager struct {
 }
 
 func (s *SecretsManager) Init(context *contexts.VendorContext, cfg managers.ManagerConfig, providers map[string]providers.IProvider) error {
-	log.Debug(" M (secret): Init")
+	log.Debug(" M (Secret): Init")
 	err := s.Manager.Init(context, cfg, providers)
 	if err != nil {
 		return err
@@ -46,11 +46,11 @@ func (s *SecretsManager) Init(context *contexts.VendorContext, cfg managers.Mana
 		s.Precedence = strings.Split(val, ",")
 	}
 	if len(s.SecretProviders) == 0 {
-		log.Error(" M (secret): No secret providers found")
+		log.Error(" M (Secret): No secret providers found")
 		return v1alpha2.NewCOAError(nil, "No secret providers found", v1alpha2.BadConfig)
 	}
 	if len(s.Precedence) < len(s.SecretProviders) && len(s.SecretProviders) > 1 {
-		log.Error(" M (secret): Not enough precedence values")
+		log.Error(" M (Secret): Not enough precedence values")
 		return v1alpha2.NewCOAError(nil, "Not enough precedence values", v1alpha2.BadConfig)
 	}
 	if len(s.SecretProviders) > 1 {
@@ -59,7 +59,7 @@ func (s *SecretsManager) Init(context *contexts.VendorContext, cfg managers.Mana
 			provderKeys = append(provderKeys, key)
 		}
 		if !utils.AreSlicesEqual(provderKeys, s.Precedence) {
-			log.Error(" M (secret): Precedence does not match with secret providers")
+			log.Error(" M (Secret): Precedence does not match with secret providers")
 			return v1alpha2.NewCOAError(nil, "Precedence does not match with secret providers", v1alpha2.BadConfig)
 		}
 	}
@@ -74,16 +74,16 @@ func (s *SecretsManager) Get(ctx context.Context, object string, field string, l
 	defer observ_utils.CloseSpanWithError(span, &err)
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
 
-	log.DebugfCtx(ctx, " M (secret): Get %v, secret provider size %d", object, len(s.SecretProviders))
+	log.DebugfCtx(ctx, " M (Secret): Get %v, secret provider size %d", object, len(s.SecretProviders))
 	if field == "" {
-		log.ErrorfCtx(ctx, " M (secret): field is empty")
+		log.ErrorfCtx(ctx, " M (Secret): field is empty")
 		err = v1alpha2.NewCOAError(nil, "Field is empty", v1alpha2.BadRequest)
 		return "", err
 	}
 	if strings.Index(object, "::") > 0 {
 		parts := strings.Split(object, "::")
 		if len(parts) != 2 {
-			log.ErrorfCtx(ctx, " M (secret): Invalid object: %s", object)
+			log.ErrorfCtx(ctx, " M (Secret): Invalid object: %s", object)
 			err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid object: %s", object), v1alpha2.BadRequest)
 			return "", err
 		}
@@ -91,7 +91,7 @@ func (s *SecretsManager) Get(ctx context.Context, object string, field string, l
 			return provider.Read(ctx, parts[1], field, localContext)
 		}
 
-		log.ErrorfCtx(ctx, " M (secret): Invalid provider: %s", parts[0])
+		log.ErrorfCtx(ctx, " M (Secret): Invalid provider: %s", parts[0])
 		err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Invalid provider: %s", parts[0]), v1alpha2.BadRequest)
 		return "", err
 	}
@@ -111,7 +111,7 @@ func (s *SecretsManager) Get(ctx context.Context, object string, field string, l
 		}
 	}
 
-	log.ErrorfCtx(ctx, " M (secret): No provider found for object: %s", object)
+	log.ErrorfCtx(ctx, " M (Secret): No provider found for object: %s", object)
 	err = v1alpha2.NewCOAError(nil, fmt.Sprintf("No provider found for object: %s", object), v1alpha2.NotFound)
 	return "", err
 }

--- a/api/pkg/apis/v1alpha1/managers/secrets/secrets-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/secrets/secrets-manager.go
@@ -19,7 +19,6 @@ import (
 	observ_utils "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/observability/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/secret"
-	coa_utils "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/logger"
 )
 
@@ -72,11 +71,7 @@ func (s *SecretsManager) Init(vendorCtx *contexts.VendorContext, cfg managers.Ma
 	return nil
 }
 
-func (s *SecretsManager) Get(object string, field string, localContext interface{}) (string, error) {
-	ctx := context.TODO()
-	if localContext, ok := localContext.(coa_utils.EvaluationContext); ok {
-		ctx = localContext.Context
-	}
+func (s *SecretsManager) Get(ctx context.Context, object string, field string, localContext interface{}) (string, error) {
 	ctx, span := observability.StartSpan("Secret Manager", ctx, &map[string]string{
 		"method": "Get",
 	})

--- a/api/pkg/apis/v1alpha1/managers/secrets/secrets-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/secrets/secrets-manager.go
@@ -30,14 +30,9 @@ type SecretsManager struct {
 	Precedence      []string
 }
 
-func (s *SecretsManager) Init(vendorCtx *contexts.VendorContext, cfg managers.ManagerConfig, providers map[string]providers.IProvider) error {
-	ctx := context.TODO()
-	if vendorCtx != nil && vendorCtx.EvaluationContext != nil && vendorCtx.EvaluationContext.Context != nil {
-		ctx = vendorCtx.EvaluationContext.Context
-	}
-
-	log.DebugCtx(ctx, " M (secret): Init")
-	err := s.Manager.Init(vendorCtx, cfg, providers)
+func (s *SecretsManager) Init(context *contexts.VendorContext, cfg managers.ManagerConfig, providers map[string]providers.IProvider) error {
+	log.Debug(" M (secret): Init")
+	err := s.Manager.Init(context, cfg, providers)
 	if err != nil {
 		return err
 	}
@@ -51,11 +46,11 @@ func (s *SecretsManager) Init(vendorCtx *contexts.VendorContext, cfg managers.Ma
 		s.Precedence = strings.Split(val, ",")
 	}
 	if len(s.SecretProviders) == 0 {
-		log.ErrorCtx(ctx, " M (secret): No secret providers found")
+		log.Error(" M (secret): No secret providers found")
 		return v1alpha2.NewCOAError(nil, "No secret providers found", v1alpha2.BadConfig)
 	}
 	if len(s.Precedence) < len(s.SecretProviders) && len(s.SecretProviders) > 1 {
-		log.ErrorCtx(ctx, " M (secret): Not enough precedence values")
+		log.Error(" M (secret): Not enough precedence values")
 		return v1alpha2.NewCOAError(nil, "Not enough precedence values", v1alpha2.BadConfig)
 	}
 	if len(s.SecretProviders) > 1 {
@@ -64,7 +59,7 @@ func (s *SecretsManager) Init(vendorCtx *contexts.VendorContext, cfg managers.Ma
 			provderKeys = append(provderKeys, key)
 		}
 		if !utils.AreSlicesEqual(provderKeys, s.Precedence) {
-			log.ErrorCtx(ctx, " M (secret): Precedence does not match with secret providers")
+			log.Error(" M (secret): Precedence does not match with secret providers")
 			return v1alpha2.NewCOAError(nil, "Precedence does not match with secret providers", v1alpha2.BadConfig)
 		}
 	}

--- a/api/pkg/apis/v1alpha1/managers/secrets/secrets-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/secrets/secrets-manager_test.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"context"
 	"testing"
 
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/managers"
@@ -9,6 +10,8 @@ import (
 	mocksecret "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/secret/mock"
 	"github.com/stretchr/testify/assert"
 )
+
+var ctx = context.Background()
 
 func TestSecretsManager_Init(t *testing.T) {
 	secretProvider := mocksecret.MockSecretProvider{}
@@ -34,7 +37,7 @@ func TestObjectFieldGetWithProviderSpecified(t *testing.T) {
 		},
 	}
 	assert.Nil(t, err)
-	val, err := manager.Get("mock::obj", "field", nil)
+	val, err := manager.Get(ctx, "mock::obj", "field", nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "obj>>field", val)
 }
@@ -42,12 +45,13 @@ func TestObjectFieldGetWithProviderSpecified(t *testing.T) {
 func TestObjectFieldGetWithOneProvider(t *testing.T) {
 	provider := mocksecret.MockSecretProvider{}
 	err := provider.Init(mocksecret.MockSecretProviderConfig{})
+	assert.Nil(t, err)
 	manager := SecretsManager{
 		SecretProviders: map[string]secret.ISecretProvider{
 			"mock": &provider,
 		},
 	}
-	val, err := manager.Get("obj", "field", nil)
+	val, err := manager.Get(ctx, "obj", "field", nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "obj>>field", val)
 }
@@ -67,7 +71,7 @@ func TestObjectFieldGetWithMoreProviders(t *testing.T) {
 		Precedence: []string{"mock1", "mock2"},
 	}
 	assert.Nil(t, err)
-	val, err := manager.Get("obj", "field", nil)
+	val, err := manager.Get(ctx, "obj", "field", nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "obj>>field", val)
 }

--- a/api/pkg/apis/v1alpha1/providers/config/catalog/catalogprovider.go
+++ b/api/pkg/apis/v1alpha1/providers/config/catalog/catalogprovider.go
@@ -95,7 +95,7 @@ func (m *CatalogConfigProvider) unwindOverrides(ctx context.Context, override st
 	override = utils.ConvertReferenceToObjectName(override)
 	catalog, err := m.ApiClient.GetCatalog(ctx, override, namespace, m.Config.User, m.Config.Password)
 	if err != nil {
-		clog.ErrorCtx(ctx, " P (Catalog): Unwind overrides error:", err)
+		clog.ErrorCtx(ctx, "  P (Catalog): Unwind overrides error:", err)
 		return "", err
 	}
 	if v, ok := utils.JsonParseProperty(catalog.Spec.Properties, field); ok {
@@ -105,7 +105,7 @@ func (m *CatalogConfigProvider) unwindOverrides(ctx context.Context, override st
 		return m.unwindOverrides(ctx, catalog.Spec.ParentName, field, namespace, localcontext, dependencyList)
 	}
 	err = v1alpha2.NewCOAError(nil, fmt.Sprintf("field '%s' is not found in configuration '%s'", field, override), v1alpha2.NotFound)
-	clog.ErrorCtx(ctx, " P (Catalog): Unwind overrides error:", err)
+	clog.ErrorCtx(ctx, "  P (Catalog): Unwind overrides error:", err)
 	return "", err
 }
 
@@ -116,12 +116,12 @@ func (m *CatalogConfigProvider) Read(ctx context.Context, object string, field s
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
-	clog.DebugfCtx(ctx, " P (Catalog): Read, object: %s, field: %s", object, field)
+	clog.DebugfCtx(ctx, "  P (Catalog): Read, object: %s, field: %s", object, field)
 	namespace := utils.GetNamespaceFromContext(localcontext)
 	object = utils.ConvertReferenceToObjectName(object)
 	catalog, err := m.ApiClient.GetCatalog(ctx, object, namespace, m.Config.User, m.Config.Password)
 	if err != nil {
-		clog.ErrorCtx(ctx, " P (Catalog): Read error:", err)
+		clog.ErrorCtx(ctx, "  P (Catalog): Read error:", err)
 		return "", err
 	}
 
@@ -130,7 +130,7 @@ func (m *CatalogConfigProvider) Read(ctx context.Context, object string, field s
 	if localcontext != nil {
 		if evalContext, ok := localcontext.(coa_utils.EvaluationContext); ok {
 			if coa_utils.HasCircularDependency(object, field, evalContext) {
-				clog.ErrorfCtx(ctx, " P (Catalog): Read detect circular dependency. Object: %s, field: %s, ", object, field)
+				clog.ErrorfCtx(ctx, "  P (Catalog): Read detect circular dependency. Object: %s, field: %s, ", object, field)
 				return "", v1alpha2.NewCOAError(nil, fmt.Sprintf("Detect circular dependency, object: %s, field: %s", object, field), v1alpha2.BadConfig)
 			}
 			dependencyList = coa_utils.DeepCopyDependencyList(evalContext.ParentConfigs)
@@ -152,7 +152,7 @@ func (m *CatalogConfigProvider) Read(ctx context.Context, object string, field s
 	}
 
 	err = v1alpha2.NewCOAError(nil, fmt.Sprintf("field '%s' is not found in configuration '%s'", field, object), v1alpha2.NotFound)
-	clog.ErrorCtx(ctx, " P (Catalog): Read error:", err)
+	clog.ErrorCtx(ctx, "  P (Catalog): Read error:", err)
 	return "", err
 }
 
@@ -163,20 +163,20 @@ func (m *CatalogConfigProvider) ReadObject(ctx context.Context, object string, l
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
-	clog.DebugfCtx(ctx, " P (Catalog): ReadObject, object: %s", object)
+	clog.DebugfCtx(ctx, "  P (Catalog): ReadObject, object: %s", object)
 	namespace := utils.GetNamespaceFromContext(localcontext)
 	object = utils.ConvertReferenceToObjectName(object)
 
 	catalog, err := m.ApiClient.GetCatalog(ctx, object, namespace, m.Config.User, m.Config.Password)
 	if err != nil {
-		clog.ErrorCtx(ctx, " P (Catalog): ReadObject error:", err)
+		clog.ErrorCtx(ctx, "  P (Catalog): ReadObject error:", err)
 		return nil, err
 	}
 	ret := map[string]interface{}{}
 	for k, v := range catalog.Spec.Properties {
 		tv, err := m.traceValue(v, localcontext, nil)
 		if err != nil {
-			clog.ErrorCtx(ctx, " P (Catalog): ReadObject error:", err)
+			clog.ErrorCtx(ctx, "  P (Catalog): ReadObject error:", err)
 			return nil, err
 		}
 		// line 189-196 extracts the returned map and merge the keys with the parent
@@ -224,7 +224,7 @@ func (m *CatalogConfigProvider) traceValue(v interface{}, localcontext interface
 		}
 		v, err := parser.Eval(*context)
 		if err != nil {
-			clog.ErrorCtx(logCtx, " P (Catalog): trace value error:", err)
+			clog.ErrorCtx(logCtx, "  P (Catalog): trace value error:", err)
 			return "", err
 		}
 		switch vt := v.(type) {
@@ -238,7 +238,7 @@ func (m *CatalogConfigProvider) traceValue(v interface{}, localcontext interface
 		for _, v := range val {
 			tv, err := m.traceValue(v, localcontext, dependencyList)
 			if err != nil {
-				clog.ErrorCtx(logCtx, " P (Catalog): trace value error:", err)
+				clog.ErrorCtx(logCtx, "  P (Catalog): trace value error:", err)
 				return "", err
 			}
 			ret = append(ret, tv)
@@ -249,7 +249,7 @@ func (m *CatalogConfigProvider) traceValue(v interface{}, localcontext interface
 		for k, v := range val {
 			tv, err := m.traceValue(v, localcontext, dependencyList)
 			if err != nil {
-				clog.ErrorCtx(logCtx, " P (Catalog): trace value error:", err)
+				clog.ErrorCtx(logCtx, "  P (Catalog): trace value error:", err)
 				return "", err
 			}
 			ret[k] = tv
@@ -269,10 +269,10 @@ func (m *CatalogConfigProvider) Set(ctx context.Context, object string, field st
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
-	clog.DebugfCtx(ctx, " P (Catalog): Set, object: %s, field: %s", object, field)
+	clog.DebugfCtx(ctx, "  P (Catalog): Set, object: %s, field: %s", object, field)
 	catalog, err := m.getCatalogInDefaultNamespace(ctx, object)
 	if err != nil {
-		clog.ErrorCtx(ctx, " P (Catalog): Set error:", err)
+		clog.ErrorCtx(ctx, "  P (Catalog): Set error:", err)
 		return err
 	}
 	catalog.Spec.Properties[field] = value
@@ -288,10 +288,10 @@ func (m *CatalogConfigProvider) SetObject(ctx context.Context, object string, va
 	defer observ_utils.CloseSpanWithError(span, &err)
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
 
-	clog.DebugfCtx(ctx, " P (Catalog): SetObject, object: %s", object)
+	clog.DebugfCtx(ctx, "  P (Catalog): SetObject, object: %s", object)
 	catalog, err := m.getCatalogInDefaultNamespace(ctx, object)
 	if err != nil {
-		clog.ErrorCtx(ctx, " P (Catalog): SetObject error:", err)
+		clog.ErrorCtx(ctx, "  P (Catalog): SetObject error:", err)
 		return err
 	}
 	catalog.Spec.Properties = map[string]interface{}{}
@@ -310,14 +310,14 @@ func (m *CatalogConfigProvider) Remove(ctx context.Context, object string, field
 	defer observ_utils.CloseSpanWithError(span, &err)
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
 
-	clog.DebugfCtx(ctx, " P (Catalog): Remove, object: %s, field: %s", object, field)
+	clog.DebugfCtx(ctx, "  P (Catalog): Remove, object: %s, field: %s", object, field)
 	catlog, err := m.getCatalogInDefaultNamespace(ctx, object)
 	if err != nil {
-		clog.ErrorCtx(ctx, " P (Catalog): Remove error:", err)
+		clog.ErrorCtx(ctx, "  P (Catalog): Remove error:", err)
 		return err
 	}
 	if _, ok := catlog.Spec.Properties[field]; !ok {
-		clog.ErrorCtx(ctx, " P (Catalog): Remove: field not found.")
+		clog.ErrorCtx(ctx, "  P (Catalog): Remove: field not found.")
 		return v1alpha2.NewCOAError(nil, "field not found", v1alpha2.NotFound)
 	}
 	delete(catlog.Spec.Properties, field)
@@ -333,7 +333,7 @@ func (m *CatalogConfigProvider) RemoveObject(ctx context.Context, object string)
 	defer observ_utils.CloseSpanWithError(span, &err)
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
 
-	clog.DebugfCtx(ctx, " P (Catalog): RemoveObject, object: %s", object)
+	clog.DebugfCtx(ctx, "  P (Catalog): RemoveObject, object: %s", object)
 	object = utils.ConvertReferenceToObjectName(object)
 	return m.ApiClient.DeleteCatalog(ctx, object, m.Config.User, m.Config.Password)
 }

--- a/api/pkg/apis/v1alpha1/providers/config/catalog/catalogprovider.go
+++ b/api/pkg/apis/v1alpha1/providers/config/catalog/catalogprovider.go
@@ -95,6 +95,7 @@ func (m *CatalogConfigProvider) unwindOverrides(ctx context.Context, override st
 	override = utils.ConvertReferenceToObjectName(override)
 	catalog, err := m.ApiClient.GetCatalog(ctx, override, namespace, m.Config.User, m.Config.Password)
 	if err != nil {
+		clog.ErrorCtx(ctx, " P (Catalog): Unwind overrides error:", err)
 		return "", err
 	}
 	if v, ok := utils.JsonParseProperty(catalog.Spec.Properties, field); ok {
@@ -103,7 +104,9 @@ func (m *CatalogConfigProvider) unwindOverrides(ctx context.Context, override st
 	if catalog.Spec.ParentName != "" {
 		return m.unwindOverrides(ctx, catalog.Spec.ParentName, field, namespace, localcontext, dependencyList)
 	}
-	return "", v1alpha2.NewCOAError(nil, fmt.Sprintf("field '%s' is not found in configuration '%s'", field, override), v1alpha2.NotFound)
+	err = v1alpha2.NewCOAError(nil, fmt.Sprintf("field '%s' is not found in configuration '%s'", field, override), v1alpha2.NotFound)
+	clog.ErrorCtx(ctx, " P (Catalog): Unwind overrides error:", err)
+	return "", err
 }
 
 func (m *CatalogConfigProvider) Read(ctx context.Context, object string, field string, localcontext interface{}) (interface{}, error) {
@@ -113,11 +116,12 @@ func (m *CatalogConfigProvider) Read(ctx context.Context, object string, field s
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
-	clog.DebugfCtx(ctx, " M (Catalog): Read, object: %s, field: %s", object, field)
+	clog.DebugfCtx(ctx, " P (Catalog): Read, object: %s, field: %s", object, field)
 	namespace := utils.GetNamespaceFromContext(localcontext)
 	object = utils.ConvertReferenceToObjectName(object)
 	catalog, err := m.ApiClient.GetCatalog(ctx, object, namespace, m.Config.User, m.Config.Password)
 	if err != nil {
+		clog.ErrorCtx(ctx, " P (Catalog): Read error:", err)
 		return "", err
 	}
 
@@ -126,7 +130,7 @@ func (m *CatalogConfigProvider) Read(ctx context.Context, object string, field s
 	if localcontext != nil {
 		if evalContext, ok := localcontext.(coa_utils.EvaluationContext); ok {
 			if coa_utils.HasCircularDependency(object, field, evalContext) {
-				clog.ErrorfCtx(ctx, " M (Catalog): Read detect circular dependency. Object: %s, field: %s, ", object, field)
+				clog.ErrorfCtx(ctx, " P (Catalog): Read detect circular dependency. Object: %s, field: %s, ", object, field)
 				return "", v1alpha2.NewCOAError(nil, fmt.Sprintf("Detect circular dependency, object: %s, field: %s", object, field), v1alpha2.BadConfig)
 			}
 			dependencyList = coa_utils.DeepCopyDependencyList(evalContext.ParentConfigs)
@@ -148,6 +152,7 @@ func (m *CatalogConfigProvider) Read(ctx context.Context, object string, field s
 	}
 
 	err = v1alpha2.NewCOAError(nil, fmt.Sprintf("field '%s' is not found in configuration '%s'", field, object), v1alpha2.NotFound)
+	clog.ErrorCtx(ctx, " P (Catalog): Read error:", err)
 	return "", err
 }
 
@@ -158,18 +163,20 @@ func (m *CatalogConfigProvider) ReadObject(ctx context.Context, object string, l
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
-	clog.DebugfCtx(ctx, " M (Catalog): ReadObject, object: %s", object)
+	clog.DebugfCtx(ctx, " P (Catalog): ReadObject, object: %s", object)
 	namespace := utils.GetNamespaceFromContext(localcontext)
 	object = utils.ConvertReferenceToObjectName(object)
 
 	catalog, err := m.ApiClient.GetCatalog(ctx, object, namespace, m.Config.User, m.Config.Password)
 	if err != nil {
+		clog.ErrorCtx(ctx, " P (Catalog): ReadObject error:", err)
 		return nil, err
 	}
 	ret := map[string]interface{}{}
 	for k, v := range catalog.Spec.Properties {
 		tv, err := m.traceValue(v, localcontext, nil)
 		if err != nil {
+			clog.ErrorCtx(ctx, " P (Catalog): ReadObject error:", err)
 			return nil, err
 		}
 		// line 189-196 extracts the returned map and merge the keys with the parent
@@ -188,6 +195,11 @@ func (m *CatalogConfigProvider) ReadObject(ctx context.Context, object string, l
 }
 
 func (m *CatalogConfigProvider) traceValue(v interface{}, localcontext interface{}, dependencyList map[string]map[string]bool) (interface{}, error) {
+	logCtx := context.TODO()
+	if ltx, ok := localcontext.(coa_utils.EvaluationContext); ok {
+		logCtx = ltx.Context
+	}
+
 	switch val := v.(type) {
 	case string:
 		parser := utils.NewParser(val)
@@ -201,6 +213,7 @@ func (m *CatalogConfigProvider) traceValue(v interface{}, localcontext interface
 				context.Properties = ltx.Properties
 				context.Component = ltx.Component
 				context.Namespace = ltx.Namespace
+				context.Context = ltx.Context
 				if ltx.DeploymentSpec != nil {
 					context.DeploymentSpec = ltx.DeploymentSpec
 				}
@@ -211,6 +224,7 @@ func (m *CatalogConfigProvider) traceValue(v interface{}, localcontext interface
 		}
 		v, err := parser.Eval(*context)
 		if err != nil {
+			clog.ErrorCtx(logCtx, " P (Catalog): trace value error:", err)
 			return "", err
 		}
 		switch vt := v.(type) {
@@ -224,6 +238,7 @@ func (m *CatalogConfigProvider) traceValue(v interface{}, localcontext interface
 		for _, v := range val {
 			tv, err := m.traceValue(v, localcontext, dependencyList)
 			if err != nil {
+				clog.ErrorCtx(logCtx, " P (Catalog): trace value error:", err)
 				return "", err
 			}
 			ret = append(ret, tv)
@@ -234,6 +249,7 @@ func (m *CatalogConfigProvider) traceValue(v interface{}, localcontext interface
 		for k, v := range val {
 			tv, err := m.traceValue(v, localcontext, dependencyList)
 			if err != nil {
+				clog.ErrorCtx(logCtx, " P (Catalog): trace value error:", err)
 				return "", err
 			}
 			ret[k] = tv
@@ -253,15 +269,17 @@ func (m *CatalogConfigProvider) Set(ctx context.Context, object string, field st
 	var err error = nil
 	defer observ_utils.CloseSpanWithError(span, &err)
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
-	clog.DebugfCtx(ctx, " M (Catalog): Set, object: %s, field: %s", object, field)
+	clog.DebugfCtx(ctx, " P (Catalog): Set, object: %s, field: %s", object, field)
 	catalog, err := m.getCatalogInDefaultNamespace(ctx, object)
 	if err != nil {
+		clog.ErrorCtx(ctx, " P (Catalog): Set error:", err)
 		return err
 	}
 	catalog.Spec.Properties[field] = value
 	data, _ := json.Marshal(catalog)
 	return m.ApiClient.UpsertCatalog(ctx, object, data, m.Config.User, m.Config.Password)
 }
+
 func (m *CatalogConfigProvider) SetObject(ctx context.Context, object string, value map[string]interface{}) error {
 	ctx, span := observability.StartSpan("Catalog Provider", ctx, &map[string]string{
 		"method": "SetObject",
@@ -270,9 +288,10 @@ func (m *CatalogConfigProvider) SetObject(ctx context.Context, object string, va
 	defer observ_utils.CloseSpanWithError(span, &err)
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
 
-	clog.DebugfCtx(ctx, " M (Catalog): SetObject, object: %s", object)
+	clog.DebugfCtx(ctx, " P (Catalog): SetObject, object: %s", object)
 	catalog, err := m.getCatalogInDefaultNamespace(ctx, object)
 	if err != nil {
+		clog.ErrorCtx(ctx, " P (Catalog): SetObject error:", err)
 		return err
 	}
 	catalog.Spec.Properties = map[string]interface{}{}
@@ -282,6 +301,7 @@ func (m *CatalogConfigProvider) SetObject(ctx context.Context, object string, va
 	data, _ := json.Marshal(catalog)
 	return m.ApiClient.UpsertCatalog(ctx, object, data, m.Config.User, m.Config.Password)
 }
+
 func (m *CatalogConfigProvider) Remove(ctx context.Context, object string, field string) error {
 	ctx, span := observability.StartSpan("Catalog Provider", ctx, &map[string]string{
 		"method": "Remove",
@@ -290,12 +310,14 @@ func (m *CatalogConfigProvider) Remove(ctx context.Context, object string, field
 	defer observ_utils.CloseSpanWithError(span, &err)
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
 
-	clog.DebugfCtx(ctx, " M (Catalog): Remove, object: %s, field: %s", object, field)
+	clog.DebugfCtx(ctx, " P (Catalog): Remove, object: %s, field: %s", object, field)
 	catlog, err := m.getCatalogInDefaultNamespace(ctx, object)
 	if err != nil {
+		clog.ErrorCtx(ctx, " P (Catalog): Remove error:", err)
 		return err
 	}
 	if _, ok := catlog.Spec.Properties[field]; !ok {
+		clog.ErrorCtx(ctx, " P (Catalog): Remove: field not found.")
 		return v1alpha2.NewCOAError(nil, "field not found", v1alpha2.NotFound)
 	}
 	delete(catlog.Spec.Properties, field)
@@ -311,7 +333,7 @@ func (m *CatalogConfigProvider) RemoveObject(ctx context.Context, object string)
 	defer observ_utils.CloseSpanWithError(span, &err)
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
 
-	clog.DebugfCtx(ctx, " M (Catalog): RemoveObject, object: %s", object)
+	clog.DebugfCtx(ctx, " P (Catalog): RemoveObject, object: %s", object)
 	object = utils.ConvertReferenceToObjectName(object)
 	return m.ApiClient.DeleteCatalog(ctx, object, m.Config.User, m.Config.Password)
 }

--- a/api/pkg/apis/v1alpha1/providers/config/catalog/catalogprovider.go
+++ b/api/pkg/apis/v1alpha1/providers/config/catalog/catalogprovider.go
@@ -200,6 +200,7 @@ func (m *CatalogConfigProvider) traceValue(ctx context.Context, v interface{}, l
 		parser := utils.NewParser(val)
 		context := m.Context.VencorContext.EvaluationContext.Clone()
 		context.DeploymentSpec = m.Context.VencorContext.EvaluationContext.DeploymentSpec
+		context.Context = ctx
 		if localcontext != nil {
 			if ltx, ok := localcontext.(coa_utils.EvaluationContext); ok {
 				context.Inputs = ltx.Inputs
@@ -208,7 +209,6 @@ func (m *CatalogConfigProvider) traceValue(ctx context.Context, v interface{}, l
 				context.Properties = ltx.Properties
 				context.Component = ltx.Component
 				context.Namespace = ltx.Namespace
-				context.Context = ltx.Context
 				if ltx.DeploymentSpec != nil {
 					context.DeploymentSpec = ltx.DeploymentSpec
 				}

--- a/api/pkg/apis/v1alpha1/providers/stage/http/http.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/http/http.go
@@ -428,7 +428,8 @@ func (i *HttpStageProvider) Process(ctx context.Context, mgrContext contexts.Man
 								parser := utils.NewParser(i.Config.WaitExpression)
 								var val interface{}
 								val, err = parser.Eval(coa_utils.EvaluationContext{
-									Value: obj,
+									Value:   obj,
+									Context: ctx,
 								})
 								if err != nil {
 									sLog.ErrorfCtx(ctx, "  P (Http Stage): failed to evaluate Symphony expression: %v", err)

--- a/api/pkg/apis/v1alpha1/utils/parser.go
+++ b/api/pkg/apis/v1alpha1/utils/parser.go
@@ -765,7 +765,7 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 				}
 			}
 
-			return context.ConfigProvider.Get(FormatAsString(obj), FormatAsString(field), overlays, context)
+			return context.ConfigProvider.Get(context.Context, FormatAsString(obj), FormatAsString(field), overlays, context)
 		}
 		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$config() expects 2 arguments, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "secret":
@@ -781,7 +781,7 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 			if err != nil {
 				return nil, err
 			}
-			return context.SecretProvider.Get(FormatAsString(obj), FormatAsString(field), context)
+			return context.SecretProvider.Get(context.Context, FormatAsString(obj), FormatAsString(field), context)
 		}
 		return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("$secret() expects 2 arguments, found %d", len(n.Args)), v1alpha2.BadConfig)
 	case "instance":

--- a/api/pkg/apis/v1alpha1/utils/parser.go
+++ b/api/pkg/apis/v1alpha1/utils/parser.go
@@ -1456,12 +1456,14 @@ func enumerateProperties(js interface{}, context utils.EvaluationContext) (inter
 				parser := NewParser(strVal)
 				val, err := parser.Eval(context)
 				if err != nil {
+					log.ErrorfCtx(context.Context, " (Parser): Enumerate properties failed: %v", err)
 					return nil, err
 				}
 				v[key] = val
 			} else {
 				nestedProps, err := enumerateProperties(val, context)
 				if err != nil {
+					log.ErrorfCtx(context.Context, " (Parser): Enumerate properties failed: %v", err)
 					return nil, err
 				}
 				v[key] = nestedProps
@@ -1471,6 +1473,7 @@ func enumerateProperties(js interface{}, context utils.EvaluationContext) (inter
 		for i, val := range v {
 			nestedProps, err := enumerateProperties(val, context)
 			if err != nil {
+				log.ErrorfCtx(context.Context, " (Parser): Enumerate properties failed: %v", err)
 				return nil, err
 			}
 			v[i] = nestedProps

--- a/api/pkg/apis/v1alpha1/utils/parser.go
+++ b/api/pkg/apis/v1alpha1/utils/parser.go
@@ -889,6 +889,7 @@ func (p *Parser) Eval(context utils.EvaluationContext) (interface{}, error) {
 			parser := newExpressionParser(text)
 			n, err := parser.Eval(context)
 			if err != nil {
+				log.ErrorfCtx(context.Context, " (Parser): Parser evaluate failed: %v", err)
 				return nil, err
 			}
 			results = append(results, n)

--- a/api/pkg/apis/v1alpha1/utils/parser_test.go
+++ b/api/pkg/apis/v1alpha1/utils/parser_test.go
@@ -7,6 +7,7 @@
 package utils
 
 import (
+	"context"
 	"testing"
 
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
@@ -16,70 +17,94 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var ctx = context.Background()
+
 func TestEvaluateSingleNumber(t *testing.T) {
 	parser := NewParser("1")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "1", val)
 }
 func TestEvaluateSingleNumberExpression(t *testing.T) {
 	parser := NewParser("${{1}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, int64(1), val)
 }
 func TestEvaluateNumberSpaceNumber(t *testing.T) {
 	parser := NewParser("1 2")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "1 2", val)
 }
 func TestEvaluateNumberExpressionSpaceNumberExpression(t *testing.T) {
 	parser := NewParser("${{1}} ${{2}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "1 2", val)
 }
 func TestEvaluateDoubleDigitNumber(t *testing.T) {
 	parser := NewParser("12")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "12", val)
 }
 func TestEvaluateDoubleDigitNumberExpression(t *testing.T) {
 	parser := NewParser("${{12}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, int64(12), val)
 }
 func TestEvaluateSpace(t *testing.T) {
 	parser := NewParser(" ")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, " ", val)
 }
 func TestEvaluateSpaceExpression(t *testing.T) {
 	// a null expression is evaluated to nil
 	parser := NewParser("${{ }}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, nil, val)
 }
 func TestEvaluateSurroundingSpaces(t *testing.T) {
 	parser := NewParser("  abc  ")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "  abc  ", val)
 }
 func TestEvaluateExpressionSurroundingSpaces(t *testing.T) {
 	parser := NewParser("${{  abc  }}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "abc", val)
 }
 func TestSpacesInBetween(t *testing.T) {
 	parser := NewParser("abc def")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "abc def", val)
 }
@@ -89,535 +114,711 @@ func TestExpressionSpacesInBetween(t *testing.T) {
 	// found, which is abc. This should change when we switch to a better syntax.
 	// See bug #90.
 	parser := NewParser("${{abc def}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "abc", val)
 }
 func TestEvaluateOpenSingleQuote(t *testing.T) {
 	parser := NewParser("'abc def")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "'abc def", val)
 }
 func TestEvaluateOpenSingleQuoteInExpression(t *testing.T) {
 	parser := NewParser("${{'abc def}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "'abc def", val)
 }
 func TestSingleQuotedAdExtra(t *testing.T) {
 	parser := NewParser("'abc def'hij")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "'abc def'hij", val)
 }
 func TestSingleQuotedAdExtraInExpression(t *testing.T) {
 	// TODO: see comments on TestExpressionSpacesInBetween()
 	parser := NewParser("${{'abc def'hij}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "abc def", val)
 }
 func TestNumberDotString(t *testing.T) {
 	parser := NewParser("3.abc")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "3.abc", val)
 }
 func TestNumberDotStringInExpression(t *testing.T) {
 	parser := NewParser("${{3.abc}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "3.abc", val)
 }
 func TestDot(t *testing.T) {
 	parser := NewParser(".")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, ".", val)
 }
 func TestDotInExpression(t *testing.T) {
 	parser := NewParser("${{.}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, ".", val)
 }
 func TestDotDot(t *testing.T) {
 	parser := NewParser("..")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "..", val)
 }
 func TestDotDotInExpression(t *testing.T) {
 	parser := NewParser("${{..}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "..", val)
 }
 func TestAdd(t *testing.T) {
 	parser := NewParser("+")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "+", val)
 }
 func TestAddInExpression(t *testing.T) {
 	// this is considered empty + empty, which is empty
 	parser := NewParser("${{+}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "", val)
 }
 func TestAddAdd(t *testing.T) {
 	parser := NewParser("++")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "++", val)
 }
 func TestAddAddInExpression(t *testing.T) {
 	parser := NewParser("${{++}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "", val)
 }
 func TestAddAddAdd(t *testing.T) {
 	parser := NewParser("+++")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "+++", val)
 }
 func TestAddAddAddInExpression(t *testing.T) {
 	parser := NewParser("${{+++}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "", val)
 }
 func TestAddAddAddNumber(t *testing.T) {
 	parser := NewParser("+++123")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "+++123", val)
 }
 func TestAddAddAddNumberInExpression(t *testing.T) {
 	parser := NewParser("${{+++123}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, int64(123), val)
 }
 func TestMinus(t *testing.T) {
 	parser := NewParser("-")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "-", val)
 }
 func TestMinusInExpression(t *testing.T) {
 	parser := NewParser("${{-}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "", val)
 }
 func TestMinusInQuote(t *testing.T) {
 	parser := NewParser("'-'")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "'-'", val)
 }
 func TestMinusInQuoteInExpression(t *testing.T) {
 	parser := NewParser("${{'-'}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "-", val)
 }
 func TestMinusMinus(t *testing.T) {
 	parser := NewParser("--")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "--", val)
 }
 func TestMinusMinusInExpression(t *testing.T) {
 	parser := NewParser("${{--}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "-", val)
 }
 func TestMinusMinusMinus(t *testing.T) {
 	parser := NewParser("---")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "---", val)
 }
 func TestMinusMinusMinusInExpression(t *testing.T) {
 	parser := NewParser("${{---}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "--", val)
 }
 func TestAddMinus(t *testing.T) {
 	parser := NewParser("+-")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "+-", val)
 }
 func TestAddMinusInExpression(t *testing.T) {
 	// this is "positive negative nothing"
 	parser := NewParser("${{+-}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "", val)
 }
 func TestAddMinusMinus(t *testing.T) {
 	parser := NewParser("+--")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "+--", val)
 }
 func TestAddMinusMinusInExpression(t *testing.T) {
 	// this is "positive negative dash"
 	parser := NewParser("${{+--}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "-", val)
 }
 func TestMinusAddMinus(t *testing.T) {
 	parser := NewParser("-+-")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "-+-", val)
 }
 func TestMinusAddMinusInExpression(t *testing.T) {
 	// this is nothing dash positive negative nothing
 	parser := NewParser("${{-+-}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "-", val)
 }
 func TestMinusWord(t *testing.T) {
 	parser := NewParser("-a")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "-a", val)
 }
 func TestMinusWordInExpression(t *testing.T) {
 	parser := NewParser("${{-a}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "-a", val)
 }
 func TestWordMinus(t *testing.T) {
 	parser := NewParser("a-")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "a-", val)
 }
 func TestWordMinusInExpression(t *testing.T) {
 	parser := NewParser("${{a-}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "a-", val)
 }
 func TestAddWord(t *testing.T) {
 	parser := NewParser("+a")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "+a", val)
 }
 func TestAddWordInExpression(t *testing.T) {
 	parser := NewParser("${{+a}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "a", val)
 }
 func TestWordAdd(t *testing.T) {
 	parser := NewParser("a+")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "a+", val)
 }
 func TestWordAddInExpression(t *testing.T) {
 	parser := NewParser("${{a+}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "a", val)
 }
 func TestDivideSingle(t *testing.T) {
 	parser := NewParser("/")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "/", val)
 }
 func TestDivideSingleInExpression(t *testing.T) {
 	parser := NewParser("${{/}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "/", val)
 }
 func TestDvidieDivide(t *testing.T) {
 	parser := NewParser("//")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "//", val)
 }
 func TestDvidieDivideInExpression(t *testing.T) {
 	parser := NewParser("${{//}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "//", val)
 }
 func TestDvidieDivideDivide(t *testing.T) {
 	parser := NewParser("///")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "///", val)
 }
 func TestDvidieDivideDivideInExpression(t *testing.T) {
 	parser := NewParser("${{///}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "///", val)
 }
 func TestUnderScore(t *testing.T) {
 	parser := NewParser("_")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "_", val)
 }
 func TestUnderScoreInExpression(t *testing.T) {
 	parser := NewParser("${{_}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "_", val)
 }
 func TestAmpersand(t *testing.T) {
 	parser := NewParser("&")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "&", val)
 }
 func TestAmpersandInExpression(t *testing.T) {
 	parser := NewParser("${{&}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "&", val)
 }
 func TestAmpersandAmpersand(t *testing.T) {
 	parser := NewParser("&&")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "&&", val)
 }
 func TestAmpersandAmpersandInExpression(t *testing.T) {
 	parser := NewParser("${{&&}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "&&", val)
 }
 func TestForwardSlash(t *testing.T) {
 	parser := NewParser("\\")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "\\", val)
 }
 func TestForwardSlashInExpression(t *testing.T) {
 	parser := NewParser("${{\\}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "\\", val)
 }
 func TestDivideWord(t *testing.T) {
 	parser := NewParser("/abc")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "/abc", val)
 }
 func TestDivideWordInExpression(t *testing.T) {
 	parser := NewParser("${{/abc}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "/abc", val)
 }
 func TestWordDivide(t *testing.T) {
 	parser := NewParser("abc/")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "abc/", val)
 }
 func TestWordDivideInExpression(t *testing.T) {
 	parser := NewParser("${{abc/}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "abc/", val)
 }
 func TestPath(t *testing.T) {
 	parser := NewParser("abc/def")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "abc/def", val)
 }
 func TestPathInExpression(t *testing.T) {
 	parser := NewParser("${{abc/def}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "abc/def", val)
 }
 func TestAbsolutePath(t *testing.T) {
 	parser := NewParser("/abc/def")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "/abc/def", val)
 }
 func TestAbsolutePathInExpression(t *testing.T) {
 	parser := NewParser("${{/abc/def}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "/abc/def", val)
 }
 func TestPathWithQuery(t *testing.T) {
 	parser := NewParser("/abc/def?parm=tok")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "/abc/def?parm=tok", val)
 }
 func TestPathWithQueryInExpression(t *testing.T) {
 	parser := NewParser("${{/abc/def?parm=tok}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "/abc/def?parm=tok", val)
 }
 func TestPathWithMultipleParams(t *testing.T) {
 	parser := NewParser("/abc/def?parm=tok&foo=bar")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "/abc/def?parm=tok&foo=bar", val)
 }
 func TestPathWithMultipleParamsInExpression(t *testing.T) {
 	parser := NewParser("${{/abc/def?parm=tok&foo=bar}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "/abc/def?parm=tok&foo=bar", val)
 }
 func TestUrl(t *testing.T) {
 	parser := NewParser("http://abc.com/abc/def?parm=tok&foo=bar")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "http://abc.com/abc/def?parm=tok&foo=bar", val)
 }
 func TestUrlInExpression(t *testing.T) {
 	parser := NewParser("${{http://abc.com/abc/def?parm=tok&foo=bar}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "http://abc.com/abc/def?parm=tok&foo=bar", val)
 }
 func TestUrlWithPort(t *testing.T) {
 	parser := NewParser("http://abc.com:8080/abc/def?parm=tok&foo=bar")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "http://abc.com:8080/abc/def?parm=tok&foo=bar", val)
 }
 func TestUrlWithPortInExpression(t *testing.T) {
 	parser := NewParser("${{http://abc.com:8080/abc/def?parm=tok&foo=bar}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "http://abc.com:8080/abc/def?parm=tok&foo=bar", val)
 }
 func TestUrlWithPortAddition(t *testing.T) {
 	parser := NewParser("http://abc.com:${{8080+1}}/abc/def?parm=tok&foo=bar")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "http://abc.com:8081/abc/def?parm=tok&foo=bar", val)
 }
 
 func TestEvaluateSingleNegativeNumber(t *testing.T) {
 	parser := NewParser("-1")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "-1", val)
 }
 func TestEvaluateSingleNegativeNumberInExpression(t *testing.T) {
 	parser := NewParser("${{-1}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, int64(-1), val)
 }
 func TestEvaluateSingleNegativeNumberToStrInExpression(t *testing.T) {
 	parser := NewParser("${{$str(-1)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "-1", val)
 }
 func TestEvaluateSingleDoubleNegativeNumber(t *testing.T) {
 	parser := NewParser("--1")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "--1", val)
 }
 func TestEvaluateSingleDoubleNegativeNumberInExpression(t *testing.T) {
 	parser := NewParser("${{--1}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, int64(1), val)
 }
 func TestEvaluateSinglePositiveNegativeNumber(t *testing.T) {
 	parser := NewParser("+-1")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "+-1", val)
 }
 func TestEvaluateSinglePositiveNegativeNumberInExpression(t *testing.T) {
 	parser := NewParser("${{+-1}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, int64(-1), val)
 }
 func TestEvaluateSingleDoublePositiveNumber(t *testing.T) {
 	parser := NewParser("++1")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "++1", val)
 }
 func TestEvaluateSingleDoublePositiveNumberInExpresion(t *testing.T) {
 	parser := NewParser("${{++1}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, int64(1), val)
 }
 func TestEvaluateSingleNegativePositiveNumber(t *testing.T) {
 	parser := NewParser("-+1")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "-+1", val)
 }
 func TestEvaluateSingleNegativePositiveNumberInExpression(t *testing.T) {
 	parser := NewParser("${{-+1}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, int64(-1), val)
 }
 func TestAddition(t *testing.T) {
 	parser := NewParser("1+2")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "1+2", val)
 }
 func TestAdditionInExpression(t *testing.T) {
 	parser := NewParser("${{1+2}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, int64(3), val)
 }
 func TestAdditions(t *testing.T) {
 	parser := NewParser("1+2+3")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "1+2+3", val)
 }
 func TestAdditionsInExpression(t *testing.T) {
 	parser := NewParser("${{1+2+3}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, int64(6), val)
 }
 func TestFloat(t *testing.T) {
 	parser := NewParser("6.3")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "6.3", val)
 }
@@ -625,25 +826,33 @@ func TestFloatInExpression(t *testing.T) {
 	// floats are treated as string because they are a common format for version numbers
 	// we mostly concern with configuration values instead of arithmetic calculations
 	parser := NewParser("${{6.3}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "6.3", val)
 }
 func TestFloatAdd(t *testing.T) {
 	parser := NewParser("6.3 + 3.4")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "6.3 + 3.4", val)
 }
 func TestFloatAddInExpression(t *testing.T) {
 	parser := NewParser("${{6.3 + 3.4}}") // floats are treated as string
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "6.33.4", val)
 }
 func TestFloatAddInt(t *testing.T) {
 	parser := NewParser("6.3 + 3") // floats are treated as string
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "6.3 + 3", val)
 }
@@ -651,157 +860,209 @@ func TestCreateFloatInExpression(t *testing.T) {
 	// it's possible that an expression can be evaluated into a float
 	// as the result of a calculation
 	parser := NewParser("${{1/2}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, float64(0.5), val)
 }
 func TestFloatAddIntInExpression(t *testing.T) {
 	parser := NewParser("${{6.3 + 3}}") // floats are treated as string
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "6.33", val)
 }
 func TestVersionString(t *testing.T) {
 	parser := NewParser("6.3.4")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "6.3.4", val)
 }
 func TestVersionStringInExpression(t *testing.T) {
 	parser := NewParser("${{6.3.4}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "6.3.4", val)
 }
 func TestVersionStringWithCalculation(t *testing.T) {
 	parser := NewParser("6.(1+2).(5-1)")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "6.(1+2).(5-1)", val)
 }
 func TestVersionStringWithCalculationInExpression(t *testing.T) {
 	parser := NewParser("${{6.(1+2).(5-1)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "6.3.4", val)
 }
 func TestSubtraction(t *testing.T) {
 	parser := NewParser("1-2")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "1-2", val)
 }
 func TestSubtractionInExpression(t *testing.T) {
 	parser := NewParser("${{1-2}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, int64(-1), val)
 }
 func TestDash(t *testing.T) {
 	parser := NewParser("1-a")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "1-a", val)
 }
 func TestDashInExpression(t *testing.T) {
 	parser := NewParser("${{1-a}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "1-a", val)
 }
 func TestDashFloat(t *testing.T) {
 	parser := NewParser("1-1.2.3")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "1-1.2.3", val)
 }
 func TestDashFloatInExpression(t *testing.T) {
 	parser := NewParser("${{1-1.2.3}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "1-1.2.3", val)
 }
 func TestMultiply(t *testing.T) {
 	parser := NewParser("3*4")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "3*4", val)
 }
 func TestMultiplyInExpression(t *testing.T) {
 	parser := NewParser("${{3*4}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, int64(12), val)
 }
 func TestStar(t *testing.T) {
 	parser := NewParser("*")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "*", val)
 }
 func TestStarInExpression(t *testing.T) {
 	parser := NewParser("${{*}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "*", val)
 }
 func TestStarStar(t *testing.T) {
 	parser := NewParser("**")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "**", val)
 }
 func TestStarStarInExpression(t *testing.T) {
 	parser := NewParser("${{**}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "**", val)
 }
 func TestNumberStar(t *testing.T) {
 	parser := NewParser("123*")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "123*", val)
 }
 func TestNumberStarInExpression(t *testing.T) {
 	parser := NewParser("${{123*}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "123*", val)
 }
 func TestStarNumber(t *testing.T) {
 	parser := NewParser("*123")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "*123", val)
 }
 func TestStarNumberInExpression(t *testing.T) {
 	parser := NewParser("${{*123}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "*123", val)
 }
 func TestStringStarStar(t *testing.T) {
 	parser := NewParser("abc**")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "abc**", val)
 }
 func TestStringStarStarInExpression(t *testing.T) {
 	parser := NewParser("${{abc**}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "abc**", val)
 }
 func TestDivide(t *testing.T) {
 	parser := NewParser("10/2")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "10/2", val)
 }
 func TestDivideInExpression(t *testing.T) {
 	parser := NewParser("${{10/2}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, int64(5), val)
 }
@@ -810,49 +1071,65 @@ func TestDivideStringNumberInExpression(t *testing.T) {
 	// this is no longer a division, but a string concatenation
 	// with '10', '/' and '2'
 	parser := NewParser("${{'10'/2}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "10/2", val)
 }
 func TestDivideAdd(t *testing.T) {
 	parser := NewParser("5/2+1")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "5/2+1", val)
 }
 func TestDivideAddInExpression(t *testing.T) {
 	parser := NewParser("${{5/2+1}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, float64(3.5), val)
 }
 func TestDivideAddString(t *testing.T) {
 	parser := NewParser("5/2+a")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "5/2+a", val)
 }
 func TestDivideAddStringInExpression(t *testing.T) {
 	parser := NewParser("${{5/2+a}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "2.5a", val)
 }
 func TestFloatMinus(t *testing.T) {
 	parser := NewParser("5/2-5/2")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "5/2-5/2", val)
 }
 func TestFloatMinusInExpression(t *testing.T) {
 	parser := NewParser("${{5/2-5/2}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, int64(0), val)
 }
 func TestFloatMinus2(t *testing.T) {
 	parser := NewParser("2.5-2.5")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "2.5-2.5", val)
 }
@@ -860,25 +1137,33 @@ func TestFloatMinus2InExpression(t *testing.T) {
 	// Note we treat floats as strings, as it's a common format for version numbers
 	// This differs from the above test, in which floats are the result of a calculation (5/2)
 	parser := NewParser("${{2.5-2.5}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "2.5-2.5", val)
 }
 func TestFloatMultiply(t *testing.T) {
 	parser := NewParser("5/2*5/2")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "5/2*5/2", val)
 }
 func TestFloatMultiplyInExpression(t *testing.T) {
 	parser := NewParser("${{5/2*5/2}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, float64(6.25), val)
 }
 func TestFloatMultiply2(t *testing.T) {
 	parser := NewParser("2.5*2.5")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "2.5*2.5", val)
 }
@@ -886,25 +1171,33 @@ func TestFloatMultiply2InExpression(t *testing.T) {
 	// Note we treat floats as strings, as it's a common format for version numbers
 	// This differs from the above test, in which floats are the result of a calculation (5/2)
 	parser := NewParser("${{2.5*2.5}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "2.5*2.5", val)
 }
 func TestFloatDivide(t *testing.T) {
 	parser := NewParser("(5/2)/(5/2)")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "(5/2)/(5/2)", val)
 }
 func TestFloatDivideInExpression(t *testing.T) {
 	parser := NewParser("${{(5/2)/(5/2)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, int64(1), val)
 }
 func TestFloatDivide2(t *testing.T) {
 	parser := NewParser("2.5/2.5")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "2.5/2.5", val)
 }
@@ -912,97 +1205,129 @@ func TestFloatDivide2InExpression(t *testing.T) {
 	// Note we treat floats as strings, as it's a common format for version numbers
 	// This differs from the above test, in which floats are the result of a calculation (5/2)
 	parser := NewParser("${{2.5/2.5}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "2.5/2.5", val)
 }
 func TestFloatDot(t *testing.T) {
 	parser := NewParser("5/2.")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "5/2.", val)
 }
 func TestFloatDotInExpression(t *testing.T) {
 	parser := NewParser("${{5/2.}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "2.5.", val)
 }
 func TestFloatDot2(t *testing.T) {
 	parser := NewParser("2.5.")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "2.5.", val)
 }
 func TestFloatDot2InExpression(t *testing.T) {
 	parser := NewParser("${{2.5.}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "2.5.", val)
 }
 func TestDivideNegative(t *testing.T) {
 	parser := NewParser("10/-2")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "10/-2", val)
 }
 func TestDivideNegativeInExpression(t *testing.T) {
 	parser := NewParser("${{10/-2}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, int64(-5), val)
 }
 func TestDivideZero(t *testing.T) {
 	parser := NewParser("10/0")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "10/0", val)
 }
 func TestDivideZeroInExpression(t *testing.T) {
 	parser := NewParser("${{10/0}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "10/0", val) // can't divide, original string is returned
 }
 func TestStringAddNumber(t *testing.T) {
 	parser := NewParser("dog+1")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "dog+1", val)
 }
 func TestStringAddNumberInExpression(t *testing.T) {
 	parser := NewParser("${{dog+1}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "dog1", val)
 }
 func TestNumberAddString(t *testing.T) {
 	parser := NewParser("1+cat")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "1+cat", val)
 }
 func TestNumberAddStringInExpression(t *testing.T) {
 	parser := NewParser("${{1+cat}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "1cat", val)
 }
 func TestStringAddString(t *testing.T) {
 	parser := NewParser("dog+cat")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "dog+cat", val)
 }
 func TestStringAddStringInExpression(t *testing.T) {
 	parser := NewParser("${{dog+cat}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "dogcat", val)
 }
 func TestStringMinusString(t *testing.T) {
 	parser := NewParser("crazydogs-dogs")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "crazydogs-dogs", val)
 }
@@ -1010,187 +1335,249 @@ func TestStringMinusStringInExpression(t *testing.T) {
 	// In original design, you can use string subtraction to remove a substring from another string
 	// This is no longer supported, as it's not intuitive
 	parser := NewParser("${{crazydogs-dogs}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "crazydogs-dogs", val)
 }
 func TestStringMinusStringMiss(t *testing.T) {
 	parser := NewParser("crazydogs-cats")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "crazydogs-cats", val)
 }
 func TestStringMinusStringMissInExpression(t *testing.T) {
 	parser := NewParser("${{crazydogs-cats}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "crazydogs-cats", val)
 }
 func TestParentheses(t *testing.T) {
 	parser := NewParser("3-(1+2)/(2+1)")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "3-(1+2)/(2+1)", val)
 }
 func TestParenthesesInExpression(t *testing.T) {
 	parser := NewParser("${{3-(1+2)/(2+1)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, int64(2), val)
 }
 func TestParenthesesWithString(t *testing.T) {
 	parser := NewParser("dog+(32-10/2)")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "dog+(32-10/2)", val)
 }
 func TestParenthesesWithStringInExpression(t *testing.T) {
 	parser := NewParser("${{dog+(32-10/2)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "dog27", val)
 }
 func TestStringMultiply(t *testing.T) {
 	parser := NewParser("dog*3")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "dog*3", val)
 }
 func TestStringMultiplyInExpression(t *testing.T) {
 	parser := NewParser("${{dog*3}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "dog*3", val)
 }
 func TestNumberMultiplyString(t *testing.T) {
 	parser := NewParser("3*dog")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "3*dog", val)
 }
 func TestNumberMultiplyStringInExpression(t *testing.T) {
 	parser := NewParser("${{3*dog}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "3*dog", val)
 }
 func TestStringMultiplyNegative(t *testing.T) {
 	parser := NewParser("dog*-3")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "dog*-3", val)
 }
 func TestStringMultiplyNegativeInExpression(t *testing.T) {
 	parser := NewParser("${{dog*-3}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "dog*-3", val)
 }
 func TestStringMultiplyZero(t *testing.T) {
 	parser := NewParser("dog*0")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "dog*0", val)
 }
 func TestStringMultiplyZeroInExpression(t *testing.T) {
 	parser := NewParser("${{dog*0}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "dog*0", val)
 }
 func TestStringMultiplyFraction(t *testing.T) {
 	parser := NewParser("dog*(5/2)")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "dog*(5/2)", val)
 }
 func TestStringMultiplyFractionInExpression(t *testing.T) {
 	parser := NewParser("${{dog*(5/2)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "dog*2.5", val)
 }
 func TestStringDivide(t *testing.T) {
 	parser := NewParser("dog/3")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "dog/3", val)
 }
 func TestStringDivideInExpression(t *testing.T) {
 	parser := NewParser("${{dog/3}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "dog/3", val)
 }
 func TestStringDivideDivide(t *testing.T) {
 	parser := NewParser("10/2/2")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "10/2/2", val)
 }
 func TestStringDivideDivideInExpression(t *testing.T) {
 	parser := NewParser("${{10/2/2}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, float64(2.5), val)
 }
 func TestTimeString(t *testing.T) {
 	parser := NewParser("12:24:41 3/8/2023")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "12:24:41 3/8/2023", val)
 }
 func TestTimeStringInExpression(t *testing.T) {
 	parser := NewParser("${{'12:24:41 3/8/2023'}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "12:24:41 3/8/2023", val)
 }
 func TestTimeStringNoQuote(t *testing.T) {
 	parser := NewParser("12:24:41 3/8/2023")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "12:24:41 3/8/2023", val)
 }
 func TestTimeStringNoQuoteInExpression(t *testing.T) {
 	// this becomes a bit unintuitive
 	parser := NewParser("${{12:24:41 3/8/2023}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "12:24:41/8/2023", val)
 }
 func TestUnderScores(t *testing.T) {
 	parser := NewParser("a_b_c_d")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "a_b_c_d", val)
 }
 func TestUnderScoresInExpression(t *testing.T) {
 	parser := NewParser("${{a_b_c_d}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "a_b_c_d", val)
 }
 func TestMixedExpressions(t *testing.T) {
 	parser := NewParser("dog1+3")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "dog1+3", val)
 }
 func TestMixedExpressionsInExpression(t *testing.T) {
 	parser := NewParser("${{dog1+3}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "dog13", val)
 }
 func TestSecretSingleArg(t *testing.T) {
 	parser := NewParser("${{$secret(abc)}}")
-	_, err := parser.Eval(utils.EvaluationContext{})
+	_, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.NotNil(t, err)
 }
 func TestScretNoProvider(t *testing.T) {
 	parser := NewParser("${{$secret(abc,def)}}")
-	_, err := parser.Eval(utils.EvaluationContext{})
+	_, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.NotNil(t, err)
 }
 func TestSecret(t *testing.T) {
@@ -1240,12 +1627,16 @@ func TestSecretRecursiveMixed(t *testing.T) {
 
 func TestConfigSingleArg(t *testing.T) {
 	parser := NewParser("${{$config(abc)}}")
-	_, err := parser.Eval(utils.EvaluationContext{})
+	_, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.NotNil(t, err)
 }
 func TestConfigNoProvider(t *testing.T) {
 	parser := NewParser("${{$config(abc,def)}}")
-	_, err := parser.Eval(utils.EvaluationContext{})
+	_, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.NotNil(t, err)
 }
 
@@ -1361,147 +1752,195 @@ func TestConfigWithQuotedStrings(t *testing.T) {
 func TestQuotedString(t *testing.T) {
 
 	parser := NewParser("${{'abc def'}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "abc def", val)
 }
 func TestQuotedStringAdd(t *testing.T) {
 	parser := NewParser("${{'abc def'+' ghi jkl'}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "abc def ghi jkl", val)
 }
 func TestEvaulateParamEmptySpec(t *testing.T) {
 	parser := NewParser("${{$param(abc)}}")
-	_, err := parser.Eval(utils.EvaluationContext{})
+	_, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.NotNil(t, err)
 }
 func TestString(t *testing.T) {
 	parser := NewParser("docker.io")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "docker.io", val)
 }
 func TestStringInExpression(t *testing.T) {
 	parser := NewParser("${{docker.io}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "docker.io", val)
 }
 func TestDockerImage(t *testing.T) {
 	parser := NewParser("docker.io/redis:6.0.5")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "docker.io/redis:6.0.5", val)
 }
 func TestDockerImageInExpression(t *testing.T) {
 	parser := NewParser("${{docker.io/redis:6.0.5}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "docker.io/redis:6.0.5", val)
 }
 func TestComplexExpression(t *testing.T) {
 	parser := NewParser("docker.io/redis:6.0.5 + 678-9")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "docker.io/redis:6.0.5 + 678-9", val)
 }
 func TestComplexExpressionInExpression(t *testing.T) {
 	parser := NewParser("${{docker.io/redis:6.0.5 + 678-9}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "docker.io/redis:6.0.5678-9", val)
 }
 func TestDivideToFloat(t *testing.T) {
 	parser := NewParser("9/2")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "9/2", val)
 }
 func TestDivideToFloatInExpression(t *testing.T) {
 	parser := NewParser("${{9/2}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, float64(4.5), val)
 }
 func TestDivideToFloatAddInt(t *testing.T) {
 	parser := NewParser("9/2+35")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "9/2+35", val)
 }
 func TestDivideToFloatAddIntInExpression(t *testing.T) {
 	parser := NewParser("${{9/2+35}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, float64(39.5), val)
 }
 func TestDivideToFloatAddString(t *testing.T) {
 	parser := NewParser("9/2+abc")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "9/2+abc", val)
 }
 func TestDivideToFloatAddStringInExpression(t *testing.T) {
 	parser := NewParser("${{9/2+abc}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "4.5abc", val)
 }
 func TestParenthesis(t *testing.T) {
 	parser := NewParser("(1+2)*(3+4+5)")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "(1+2)*(3+4+5)", val)
 }
 func TestParenthesisInExpression(t *testing.T) {
 	parser := NewParser("${{(1+2)*(3+4+5)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, int64(36), val)
 }
 func TestStringDivide2(t *testing.T) {
 	parser := NewParser("prom/prometheus")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "prom/prometheus", val)
 }
 func TestStringDivide2InExpression(t *testing.T) {
 	parser := NewParser("${{prom/prometheus}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "prom/prometheus", val)
 }
 func TestWindowsPath(t *testing.T) {
 	parser := NewParser("c:\\demo\\HomeHub.Package_1.0.9.0_Debug_Test\\HomeHub.Package_1.0.9.0_x64_Debug.appxbundle")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "c:\\demo\\HomeHub.Package_1.0.9.0_Debug_Test\\HomeHub.Package_1.0.9.0_x64_Debug.appxbundle", val)
 }
 func TestWindowsPathInExpression(t *testing.T) {
 	// The parser can't parse this string correctly. The '' around the string stops the parsing and returns the string as it is
 	parser := NewParser("${{'c:\\demo\\HomeHub.Package_1.0.9.0_Debug_Test\\HomeHub.Package_1.0.9.0_x64_Debug.appxbundle'}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "c:\\demo\\HomeHub.Package_1.0.9.0_Debug_Test\\HomeHub.Package_1.0.9.0_x64_Debug.appxbundle", val)
 }
 func TestComplexUrl(t *testing.T) {
 	parser := NewParser("https://manual-approval.azurewebsites.net:443/api/approval/triggers/manual/invoke?api-version=2022-05-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=<sig>")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "https://manual-approval.azurewebsites.net:443/api/approval/triggers/manual/invoke?api-version=2022-05-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=<sig>", val)
 }
 func TestComplexUrlInExpression(t *testing.T) {
 	// The parser can't parse this string correctly. The '' around the string stops the parsing and returns the string as it is
 	parser := NewParser("${{'https://manual-approval.azurewebsites.net:443/api/approval/triggers/manual/invoke?api-version=2022-05-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=<sig>'}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "https://manual-approval.azurewebsites.net:443/api/approval/triggers/manual/invoke?api-version=2022-05-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=<sig>", val)
 }
 func TestComplexUrlWithExpression(t *testing.T) {
 	// The parser can't parse this string correctly. The '' around the string stops the parsing and returns the string as it is
 	parser := NewParser("https://manual-approval.azurewebsites.net:${{442+1}}/api/approval/triggers/manual/invoke?api-version=2022-05-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=<sig>")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "https://manual-approval.azurewebsites.net:443/api/approval/triggers/manual/invoke?api-version=2022-05-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=<sig>", val)
 }
@@ -1537,43 +1976,56 @@ func TestConfigCommaConfig(t *testing.T) {
 }
 func TestJson1(t *testing.T) {
 	parser := NewParser("[{\"containerPort\":9090,\"protocol\":\"TCP\"}]")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "[{\"containerPort\":9090,\"protocol\":\"TCP\"}]", val)
 }
 func TestJson1InExpression(t *testing.T) {
 	parser := NewParser("${{[{\"containerPort\":9090,\"protocol\":\"TCP\"}]}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "[{\"containerPort\":9090,\"protocol\":\"TCP\"}]", val)
 }
 func TestJson2(t *testing.T) {
 	parser := NewParser("{\"requests\":{\"cpu\":\"100m\",\"memory\":\"100Mi\"}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "{\"requests\":{\"cpu\":\"100m\",\"memory\":\"100Mi\"}}", val)
 }
 func TestIncompletePlus(t *testing.T) {
 	parser := NewParser("${{a+}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "a", val)
 }
 func TestDashAtEnd(t *testing.T) {
 	parser := NewParser("${{a-}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "a-", val)
 }
 func TestDashFollowNumber(t *testing.T) {
 	parser := NewParser("${{10-}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "10-", val)
 }
 func TestEvaulateInstance(t *testing.T) {
 	parser := NewParser("${{$instance()}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		DeploymentSpec: model.DeploymentSpec{
 			Instance: model.InstanceState{
 				ObjectMeta: model.ObjectMeta{
@@ -1603,6 +2055,7 @@ func TestEvaulateInstance(t *testing.T) {
 func TestEvaulateParamNoComponent(t *testing.T) {
 	parser := NewParser("${{$param(abc)}}")
 	_, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		DeploymentSpec: model.DeploymentSpec{
 			SolutionName: "fake-solution",
 			Solution: model.SolutionState{
@@ -1625,6 +2078,7 @@ func TestEvaulateParamNoComponent(t *testing.T) {
 func TestEvaulateParamNoArgument(t *testing.T) {
 	parser := NewParser("${{$param(a)}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		DeploymentSpec: model.DeploymentSpec{
 			Instance: model.InstanceState{
 				Spec: &model.InstanceSpec{
@@ -1654,6 +2108,7 @@ func TestEvaulateParamNoArgument(t *testing.T) {
 func TestEvaulateParamArgumentOverride(t *testing.T) {
 	parser := NewParser("${{$param(a)}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		DeploymentSpec: model.DeploymentSpec{
 			Instance: model.InstanceState{
 				Spec: &model.InstanceSpec{
@@ -1683,6 +2138,7 @@ func TestEvaulateParamArgumentOverride(t *testing.T) {
 func TestEvaulateParamWrongComponentName(t *testing.T) {
 	parser := NewParser("${{$param(a)}}")
 	_, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		DeploymentSpec: model.DeploymentSpec{
 			Instance: model.InstanceState{
 				Spec: &model.InstanceSpec{
@@ -1711,6 +2167,7 @@ func TestEvaulateParamWrongComponentName(t *testing.T) {
 func TestEvaulateParamMissing(t *testing.T) {
 	parser := NewParser("${{$param(d)}}")
 	_, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		DeploymentSpec: model.DeploymentSpec{
 			Instance: model.InstanceState{
 				Spec: &model.InstanceSpec{
@@ -1739,6 +2196,7 @@ func TestEvaulateParamMissing(t *testing.T) {
 func TestEvaulateParamExpressionArgumentOverride(t *testing.T) {
 	parser := NewParser("${{$param(a)+$param(c)}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		DeploymentSpec: model.DeploymentSpec{
 			Instance: model.InstanceState{
 				Spec: &model.InstanceSpec{
@@ -1877,19 +2335,24 @@ func TestEvaluateDeploymentConfig(t *testing.T) {
 }
 func TestEqualNumbers(t *testing.T) {
 	parser := NewParser("${{$equal(123, 123)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, true, val)
 }
 func TestEqualNumberString(t *testing.T) {
 	parser := NewParser("${{$equal(123, '123')}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, true, val)
 }
 func TestEqualProperty(t *testing.T) {
 	parser := NewParser("${{$equal(bar, $property(foo))}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		Properties: map[string]string{
 			"foo": "bar",
 		},
@@ -1900,6 +2363,7 @@ func TestEqualProperty(t *testing.T) {
 func TestEvalProperty(t *testing.T) {
 	parser := NewParser("${{$property(foo)}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		Properties: map[string]string{
 			"foo": "bar",
 		},
@@ -1910,6 +2374,7 @@ func TestEvalProperty(t *testing.T) {
 func TestEqualPropertyExpression(t *testing.T) {
 	parser := NewParser("${{$equal(bar+2, $property(foo+1))}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		Properties: map[string]string{
 			"foo1": "bar2",
 		},
@@ -1920,6 +2385,7 @@ func TestEqualPropertyExpression(t *testing.T) {
 func TestPropertyAnd(t *testing.T) {
 	parser := NewParser("${{$and($equal($property(foo), bar), $equal($property(book), title))}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		Properties: map[string]string{
 			"foo":  "bar",
 			"book": "title",
@@ -1931,6 +2397,7 @@ func TestPropertyAnd(t *testing.T) {
 func TestPropertyOr(t *testing.T) {
 	parser := NewParser("${{$or($equal($property(foo), bar), $equal($property(foo), bar2))}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		Properties: map[string]string{
 			"foo": "bar",
 		},
@@ -1941,6 +2408,7 @@ func TestPropertyOr(t *testing.T) {
 func TestPropertyOrFalse(t *testing.T) {
 	parser := NewParser("${{$or($equal($property(foo), bar), $equal($property(foo), bar2))}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		Properties: map[string]string{
 			"foo": "bar3",
 		},
@@ -1950,110 +2418,145 @@ func TestPropertyOrFalse(t *testing.T) {
 }
 func TestNot(t *testing.T) {
 	parser := NewParser("${{$not(true)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, false, val)
 }
 func TestNotNot(t *testing.T) {
 	parser := NewParser("${{$not($not(true))}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, true, val)
 }
 func TestGt(t *testing.T) {
 	parser := NewParser("${{$gt(2, 1.0)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, true, val)
 }
 func TestGtEqual(t *testing.T) {
 	parser := NewParser("${{$gt(2, 2)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, false, val)
 }
 func TestGtNegative(t *testing.T) {
 	parser := NewParser("${{$gt(2, 3)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, false, val)
 }
 func TestGe(t *testing.T) {
 	parser := NewParser("${{$ge(2, 1.0)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, true, val)
 }
 func TestGeEqual(t *testing.T) {
 	parser := NewParser("${{$ge(2, 2)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, true, val)
 }
 func TestGeNegative(t *testing.T) {
 	parser := NewParser("${{$ge(2, 3)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, false, val)
 }
 func TestLt(t *testing.T) {
 	parser := NewParser("${{$lt(2, 3.0)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, true, val)
 }
 func TestLtEqual(t *testing.T) {
 	parser := NewParser("${{$lt(2, 2)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, false, val)
 }
 func TestLtNegative(t *testing.T) {
 	parser := NewParser("${{$lt(2, 1)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, false, val)
 }
 
 func TestLe(t *testing.T) {
 	parser := NewParser("${{$le(2, 3.0)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, true, val)
 }
 func TestLeEqual(t *testing.T) {
 	parser := NewParser("${{$le(2, 2)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, true, val)
 }
 func TestLeNegative(t *testing.T) {
 	parser := NewParser("${{$le(2, 1)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, false, val)
 }
 func TestBetween(t *testing.T) {
 	parser := NewParser("${{$between(2, 1, 3)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, true, val)
 }
 func TestBetweenNegative(t *testing.T) {
 	parser := NewParser("${{$between(2, 3, 1)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, false, val)
 }
 func TestLongVersionNumber(t *testing.T) {
 	parser := NewParser("${{0.2.0-20230627.2-develop}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "0.2.0-20230627.2-develop", val)
 }
 func TestInputAnd(t *testing.T) {
 	parser := NewParser("${{$and($equal($input(foo), bar), $equal($input(book), title))}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		Inputs: map[string]interface{}{
 			"foo":  "bar",
 			"book": "title",
@@ -2065,6 +2568,7 @@ func TestInputAnd(t *testing.T) {
 func TestInputOr(t *testing.T) {
 	parser := NewParser("${{$or($equal($input(foo), bar), $equal($input(foo), bar2))}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		Inputs: map[string]interface{}{
 			"foo": "bar",
 		},
@@ -2074,25 +2578,32 @@ func TestInputOr(t *testing.T) {
 }
 func TestStringLiteral(t *testing.T) {
 	parser := NewParser("stage-1")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "stage-1", val)
 }
 func TestStringLiteralDoubleUnderScore(t *testing.T) {
 	parser := NewParser("__status")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "__status", val)
 }
 func TestIf(t *testing.T) {
 	parser := NewParser("${{$if(true, stage-1, stage-2)}}")
-	val, err := parser.Eval(utils.EvaluationContext{})
+	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "stage-1", val)
 }
 func TestIfLess(t *testing.T) {
 	parser := NewParser("${{$if($lt($output(foo,bar),10), stage-1, stage-2)}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		Outputs: map[string]map[string]interface{}{
 			"foo": map[string]interface{}{
 				"bar": 5,
@@ -2105,6 +2616,7 @@ func TestIfLess(t *testing.T) {
 func TestIfLessNegative(t *testing.T) {
 	parser := NewParser("${{$if($lt($output(foo,bar),10), stage-1, stage-2)}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		Outputs: map[string]map[string]interface{}{
 			"foo": map[string]interface{}{
 				"bar": 11,
@@ -2117,6 +2629,7 @@ func TestIfLessNegative(t *testing.T) {
 func TestIfLessNegativeEmptyString(t *testing.T) {
 	parser := NewParser("${{$if($lt($output(foo, bar),5),stage-1, '')}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		Outputs: map[string]map[string]interface{}{
 			"foo": map[string]interface{}{
 				"bar": 11,
@@ -2129,6 +2642,7 @@ func TestIfLessNegativeEmptyString(t *testing.T) {
 func TestOutputArray(t *testing.T) {
 	parser := NewParser("${{$output(foo, bar)}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		Outputs: map[string]map[string]interface{}{
 			"foo": map[string]interface{}{
 				"bar": []interface{}{"a", "b", "c"},
@@ -2141,6 +2655,7 @@ func TestOutputArray(t *testing.T) {
 func TestLeadingUnderScore(t *testing.T) {
 	parser := NewParser("${{a__b}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		Outputs: map[string]map[string]interface{}{
 			"foo": map[string]interface{}{
 				"bar": []interface{}{"a", "b", "c"},
@@ -2153,7 +2668,8 @@ func TestLeadingUnderScore(t *testing.T) {
 func TestEvaulateValueRange(t *testing.T) {
 	parser := NewParser("${{$and($gt($val(),5), $lt($val(),10))}}")
 	val, err := parser.Eval(utils.EvaluationContext{
-		Value: 6,
+		Context: ctx,
+		Value:   6,
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, true, val)
@@ -2161,7 +2677,8 @@ func TestEvaulateValueRange(t *testing.T) {
 func TestEvaulateValueRangeOutside(t *testing.T) {
 	parser := NewParser("${{$and($gt($val(),5), $lt($val(),10))}}")
 	val, err := parser.Eval(utils.EvaluationContext{
-		Value: 16,
+		Context: ctx,
+		Value:   16,
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, false, val)
@@ -2169,6 +2686,7 @@ func TestEvaulateValueRangeOutside(t *testing.T) {
 func TestValWithJsonPath(t *testing.T) {
 	parser := NewParser("${{$val('$.foo.bar')}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		Value: map[string]interface{}{
 			"foo": map[string]interface{}{
 				"bar": "baz",
@@ -2181,6 +2699,7 @@ func TestValWithJsonPath(t *testing.T) {
 func TestValWithProperty(t *testing.T) {
 	parser := NewParser("${{$val(foo)}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		Value: map[string]interface{}{
 			"foo": "baz",
 		},
@@ -2191,6 +2710,7 @@ func TestValWithProperty(t *testing.T) {
 func TestValWithContextProperty(t *testing.T) {
 	parser := NewParser("${{$context(foo)}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		Value: map[string]interface{}{
 			"foo": "baz",
 		},
@@ -2202,6 +2722,7 @@ func TestValWithJsonPathArray(t *testing.T) {
 
 	parser := NewParser("${{$val('$[?(@.foo.bar==\"baz1\")].foo.bar')}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		Value: []interface{}{
 			map[string]interface{}{
 				"foo": map[string]interface{}{
@@ -2223,6 +2744,7 @@ func TestContextWithJsonPathArray(t *testing.T) {
 
 	parser := NewParser("${{$context('$[?(@.foo.bar==\"baz1\")].foo.bar')}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		Value: []interface{}{
 			map[string]interface{}{
 				"foo": map[string]interface{}{
@@ -2244,6 +2766,7 @@ func TestValWithJsonPathArrayBoolean(t *testing.T) {
 
 	parser := NewParser("${{$equal($val('$[?(@.foo.bar==\"baz1\")].foo.bar'),'baz1')}}")
 	val, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
 		Value: []interface{}{
 			map[string]interface{}{
 				"foo": map[string]interface{}{
@@ -2264,81 +2787,107 @@ func TestValWithJsonPathArrayBoolean(t *testing.T) {
 func TestMessedUpQuote(t *testing.T) {
 	// Note the messed up quote in the json path
 	parser := NewParser("${{$val('$[?(@.foo.bar==\"baz1\")].foo.bar)'}}")
-	_, err := parser.Eval(utils.EvaluationContext{})
+	_, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.NotNil(t, err)
 }
 
 func TestStrangeString(t *testing.T) {
 	parser := NewParser("${{~pg~edges~ffr4~adapter~collector-ffr4}}")
-	output, err := parser.Eval(utils.EvaluationContext{})
+	output, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "~pg~edges~ffr4~adapter~collector-ffr4", output)
 }
 func TestTwoDolloars(t *testing.T) {
 	parser := NewParser("/$2")
-	output, err := parser.Eval(utils.EvaluationContext{})
+	output, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "/$2", output)
 }
 func TestReqularExps(t *testing.T) {
 	parser := NewParser("/api(/|$)(.*)")
-	output, err := parser.Eval(utils.EvaluationContext{})
+	output, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "/api(/|$)(.*)", output)
 }
 
 func TestJsonPathSimple(t *testing.T) {
 	parser := NewParser("$.store.books[*]")
-	output, err := parser.Eval(utils.EvaluationContext{})
+	output, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "$.store.books[*]", output)
 }
 func TestJsonPathSlice(t *testing.T) {
 	parser := NewParser("$.store.books[-2:]")
-	output, err := parser.Eval(utils.EvaluationContext{})
+	output, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "$.store.books[-2:]", output)
 }
 func TestJsonPathConditional(t *testing.T) {
 	parser := NewParser("$.store.books[?(@author=='Nigel Rees')]")
-	output, err := parser.Eval(utils.EvaluationContext{})
+	output, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "$.store.books[?(@author=='Nigel Rees')]", output)
 }
 func TestJsonPathRegularExpression(t *testing.T) {
 	parser := NewParser("$.store.books[?(@author=~ /^Nigel|Waugh$/  )]")
-	output, err := parser.Eval(utils.EvaluationContext{})
+	output, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "$.store.books[?(@author=~ /^Nigel|Waugh$/  )]", output)
 }
 
 func TestJsonPathComplex(t *testing.T) {
 	parser := NewParser("$.store.books[?(@.sections[*]=='s1' || @.sections[*]=='s2' )]")
-	output, err := parser.Eval(utils.EvaluationContext{})
+	output, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "$.store.books[?(@.sections[*]=='s1' || @.sections[*]=='s2' )]", output)
 }
 func TestInvalidExpression1(t *testing.T) {
 	parser := NewParser("${{half-open")
-	output, err := parser.Eval(utils.EvaluationContext{})
+	output, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "${{half-open", output)
 }
 func TestInvalidExpression2(t *testing.T) {
 	parser := NewParser("${missing-one-opening-bracket}}")
-	output, err := parser.Eval(utils.EvaluationContext{})
+	output, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "${missing-one-opening-bracket}}", output)
 }
 func TestInvalidExpression3(t *testing.T) {
 	parser := NewParser("${{missing-one-closing-bracket}")
-	output, err := parser.Eval(utils.EvaluationContext{})
+	output, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, "${{missing-one-closing-bracket}", output)
 }
 func TestRecursiveUnsupported(t *testing.T) {
 	// note we don't support recursive expressions
 	parser := NewParser("${{${{recursive}}}}")
-	_, err := parser.Eval(utils.EvaluationContext{})
+	_, err := parser.Eval(utils.EvaluationContext{
+		Context: ctx,
+	})
 	assert.NotNil(t, err)
 }

--- a/api/pkg/apis/v1alpha1/utils/schema.go
+++ b/api/pkg/apis/v1alpha1/utils/schema.go
@@ -7,6 +7,7 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -46,7 +47,7 @@ func (s *SchemaResult) ToErrorMessages() string {
 	return strings.Join(errorMessages, ";")
 }
 
-func (s *Schema) CheckProperties(properties map[string]interface{}, evaluationContext *coa_utils.EvaluationContext) (SchemaResult, error) {
+func (s *Schema) CheckProperties(ctx context.Context, properties map[string]interface{}, evaluationContext *coa_utils.EvaluationContext) (SchemaResult, error) {
 	context := evaluationContext
 	if context == nil {
 		context = &coa_utils.EvaluationContext{}
@@ -105,6 +106,7 @@ func (s *Schema) CheckProperties(properties map[string]interface{}, evaluationCo
 		if v.Expression != "" {
 			if val, ok := JsonParseProperty(properties, k); ok {
 				context.Value = val
+				context.Context = ctx
 				parser := NewParser(v.Expression)
 				res, err := parser.Eval(*context)
 				if err != nil {

--- a/api/pkg/apis/v1alpha1/utils/schema_test.go
+++ b/api/pkg/apis/v1alpha1/utils/schema_test.go
@@ -23,7 +23,7 @@ func TestCheckIntType(t *testing.T) {
 	properties := map[string]interface{}{
 		"int": "1",
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.True(t, result.Valid)
 }
@@ -38,7 +38,7 @@ func TestCheckIntTypeNotMatch(t *testing.T) {
 	properties := map[string]interface{}{
 		"int": "1.1",
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.False(t, result.Valid)
 	assert.True(t, result.Errors["int"].Valid == false)
@@ -55,7 +55,7 @@ func TestCheckFloatType(t *testing.T) {
 	properties := map[string]interface{}{
 		"float": "1.1",
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.True(t, result.Valid)
 }
@@ -70,7 +70,7 @@ func TestCheckFloatTypeNotMatch(t *testing.T) {
 	properties := map[string]interface{}{
 		"float": "a",
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.False(t, result.Valid)
 	assert.True(t, result.Errors["float"].Valid == false)
@@ -87,7 +87,7 @@ func TestCheckBoolType(t *testing.T) {
 	properties := map[string]interface{}{
 		"bool": "true",
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.True(t, result.Valid)
 }
@@ -102,7 +102,7 @@ func TestCheckBoolTypeNotMatch(t *testing.T) {
 	properties := map[string]interface{}{
 		"bool": "a",
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.False(t, result.Valid)
 	assert.True(t, result.Errors["bool"].Valid == false)
@@ -119,7 +119,7 @@ func TestCheckUintType(t *testing.T) {
 	properties := map[string]interface{}{
 		"uint": "1",
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.True(t, result.Valid)
 }
@@ -134,7 +134,7 @@ func TestCheckUintTypeNotMatch(t *testing.T) {
 	properties := map[string]interface{}{
 		"uint": "a",
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.False(t, result.Valid)
 	assert.True(t, result.Errors["uint"].Valid == false)
@@ -151,7 +151,7 @@ func TestCheckStringType(t *testing.T) {
 	properties := map[string]interface{}{
 		"string": "a",
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.True(t, result.Valid)
 }
@@ -166,7 +166,7 @@ func TestInvalidType(t *testing.T) {
 	properties := map[string]interface{}{
 		"invalid": "a",
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.False(t, result.Valid)
 	assert.True(t, result.Errors["invalid"].Valid == false)
@@ -185,7 +185,7 @@ func TestNestedType(t *testing.T) {
 			"string": "a",
 		},
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.True(t, result.Valid)
 }
@@ -202,7 +202,7 @@ func TestNestedInvalidType(t *testing.T) {
 			"string": "a",
 		},
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.False(t, result.Valid)
 	assert.True(t, result.Errors["`.person.string`"].Valid == false)
@@ -219,7 +219,7 @@ func TestRequired(t *testing.T) {
 	properties := map[string]interface{}{
 		"required": "a",
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.True(t, result.Valid)
 }
@@ -236,7 +236,7 @@ func TestNestedRequired(t *testing.T) {
 			"required": "a",
 		},
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.True(t, result.Valid)
 }
@@ -249,7 +249,7 @@ func TestRequiredMissing(t *testing.T) {
 		},
 	}
 	properties := map[string]interface{}{}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.False(t, result.Valid)
 	assert.True(t, result.Errors["required"].Valid == false)
@@ -266,7 +266,7 @@ func TestNestedRequiredMissing(t *testing.T) {
 	properties := map[string]interface{}{
 		"person": map[string]interface{}{},
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.False(t, result.Valid)
 	assert.True(t, result.Errors["`.person.required`"].Valid == false)
@@ -283,7 +283,7 @@ func TestPattern(t *testing.T) {
 	properties := map[string]interface{}{
 		"pattern": "abc",
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.True(t, result.Valid)
 }
@@ -300,7 +300,7 @@ func TestNestedPattern(t *testing.T) {
 			"pattern": "abc",
 		},
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.True(t, result.Valid)
 }
@@ -315,7 +315,7 @@ func TestPatternNotMatch(t *testing.T) {
 	properties := map[string]interface{}{
 		"pattern": "123",
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.False(t, result.Valid)
 	assert.True(t, result.Errors["pattern"].Valid == false)
@@ -332,7 +332,7 @@ func TestEmailPattern(t *testing.T) {
 	properties := map[string]interface{}{
 		"pattern": "test@abc.com",
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.True(t, result.Valid)
 }
@@ -347,7 +347,7 @@ func TestEmailPatternNotMatch(t *testing.T) {
 	properties := map[string]interface{}{
 		"pattern": "test",
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.False(t, result.Valid)
 	assert.True(t, result.Errors["pattern"].Valid == false)
@@ -366,7 +366,7 @@ func TestNestedEmailPatternNotMatch(t *testing.T) {
 			"pattern": "test",
 		},
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.False(t, result.Valid)
 	assert.True(t, result.Errors["`.person.pattern`"].Valid == false)
@@ -383,7 +383,7 @@ func TestExpression(t *testing.T) {
 	properties := map[string]interface{}{
 		"expression": "13",
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.True(t, result.Valid)
 }
@@ -400,7 +400,7 @@ func TestNestedExpression(t *testing.T) {
 			"expression": "13",
 		},
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.True(t, result.Valid)
 }
@@ -415,7 +415,7 @@ func TestInExpression(t *testing.T) {
 	properties := map[string]interface{}{
 		"expression": "bar",
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.True(t, result.Valid)
 }
@@ -432,7 +432,7 @@ func TestNestedInExpression(t *testing.T) {
 			"expression": "bar",
 		},
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.True(t, result.Valid)
 }
@@ -447,7 +447,7 @@ func TestInExpressionMiss(t *testing.T) {
 	properties := map[string]interface{}{
 		"expression": "barbar",
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.False(t, result.Valid)
 }
@@ -464,7 +464,7 @@ func TestNestedInExpressionMiss(t *testing.T) {
 			"expression": "barbar",
 		},
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.False(t, result.Valid)
 }
@@ -479,7 +479,7 @@ func TestDottedNameInExpressionMiss(t *testing.T) {
 	properties := map[string]interface{}{
 		"person.expression": "barbar",
 	}
-	result, err := schema.CheckProperties(properties, nil)
+	result, err := schema.CheckProperties(ctx, properties, nil)
 	assert.Nil(t, err)
 	assert.False(t, result.Valid)
 }

--- a/api/pkg/apis/v1alpha1/utils/symphony-api_test.go
+++ b/api/pkg/apis/v1alpha1/utils/symphony-api_test.go
@@ -464,7 +464,7 @@ func TestMatchTargetsWithUnmatchedSelectors(t *testing.T) {
 }
 
 func TestCreateSymphonyDeploymentFromTarget(t *testing.T) {
-	res, err := CreateSymphonyDeploymentFromTarget(model.TargetState{
+	res, err := CreateSymphonyDeploymentFromTarget(ctx, model.TargetState{
 		ObjectMeta: model.ObjectMeta{
 			Name: "someTargetName",
 		},
@@ -575,7 +575,7 @@ func TestCreateSymphonyDeploymentFromTarget(t *testing.T) {
 }
 
 func TestCreateSymphonyDeployment(t *testing.T) {
-	res, err := CreateSymphonyDeployment(model.InstanceState{
+	res, err := CreateSymphonyDeployment(ctx, model.InstanceState{
 		ObjectMeta: model.ObjectMeta{
 			Name:      "someOtherId",
 			Namespace: "instanceScope",
@@ -725,7 +725,7 @@ func TestCreateSymphonyDeployment(t *testing.T) {
 }
 
 func TestAssignComponentsToTargetsWithMixedConstraints(t *testing.T) {
-	res, err := AssignComponentsToTargets([]model.ComponentSpec{
+	res, err := AssignComponentsToTargets(ctx, []model.ComponentSpec{
 		{
 			Name:        "componentName1",
 			Constraints: "${{$equal($property(OS),windows)}}",

--- a/api/pkg/apis/v1alpha1/validation/catalog_validator.go
+++ b/api/pkg/apis/v1alpha1/validation/catalog_validator.go
@@ -124,7 +124,7 @@ func (c *CatalogValidator) ValidateSchema(ctx context.Context, new model.Catalog
 			}
 
 			// 3). Validate the schema on the catalog which is being created/updated
-			result, err := schemaObj.CheckProperties(new.Spec.Properties, nil)
+			result, err := schemaObj.CheckProperties(ctx, new.Spec.Properties, nil)
 			if err != nil {
 				return &ErrorField{
 					FieldPath:       "spec.metadata.schema",

--- a/api/pkg/apis/v1alpha1/vendors/settings-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/settings-vendor.go
@@ -98,7 +98,7 @@ func (c *SettingsVendor) onConfig(request v1alpha2.COARequest) v1alpha2.COARespo
 			parts = strings.Split(overrides, ",")
 		}
 		if field != "" {
-			val, err := c.EvaluationContext.ConfigProvider.Get(id, field, parts, nil)
+			val, err := c.EvaluationContext.ConfigProvider.Get(ctx, id, field, parts, nil)
 			if err != nil {
 				log.ErrorfCtx(ctx, "V (Settings): onConfig failed to get config %s, error: %v", id, err)
 				return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
@@ -113,7 +113,7 @@ func (c *SettingsVendor) onConfig(request v1alpha2.COARequest) v1alpha2.COARespo
 				ContentType: "text/plain",
 			})
 		} else {
-			val, err := c.EvaluationContext.ConfigProvider.GetObject(id, parts, nil)
+			val, err := c.EvaluationContext.ConfigProvider.GetObject(ctx, id, parts, nil)
 			if err != nil {
 				log.ErrorfCtx(ctx, "V (Settings): onConfig failed to get object %s, error: %v", id, err)
 				return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{

--- a/coa/pkg/apis/v1alpha2/providers/config/config.go
+++ b/coa/pkg/apis/v1alpha2/providers/config/config.go
@@ -23,6 +23,6 @@ type IConfigProvider interface {
 }
 
 type IExtConfigProvider interface {
-	Get(object string, field string, overrides []string, localContext interface{}) (interface{}, error)
-	GetObject(object string, overrides []string, localContext interface{}) (map[string]interface{}, error)
+	Get(ctx context.Context, object string, field string, overrides []string, localContext interface{}) (interface{}, error)
+	GetObject(ctx context.Context, object string, overrides []string, localContext interface{}) (map[string]interface{}, error)
 }

--- a/coa/pkg/apis/v1alpha2/providers/config/mock/mockprovider.go
+++ b/coa/pkg/apis/v1alpha2/providers/config/mock/mockprovider.go
@@ -7,6 +7,7 @@
 package mock
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
@@ -68,10 +69,10 @@ func toMockConfigProviderConfig(config providers.IProviderConfig) (MockConfigPro
 	ret.Name = utils.ParseProperty(ret.Name)
 	return ret, err
 }
-func (m *MockConfigProvider) Get(object string, field string, overrides []string, localContext interface{}) (interface{}, error) {
+func (m *MockConfigProvider) Get(ctx context.Context, object string, field string, overrides []string, localContext interface{}) (interface{}, error) {
 	return object + "::" + field, nil
 }
-func (m *MockConfigProvider) GetObject(object string, overrides []string, localContext interface{}) (map[string]interface{}, error) {
+func (m *MockConfigProvider) GetObject(ctx context.Context, object string, overrides []string, localContext interface{}) (map[string]interface{}, error) {
 	return map[string]interface{}{object: object}, nil
 }
 func (m *MockConfigProvider) Set(object string, field string, value string) error {

--- a/coa/pkg/apis/v1alpha2/providers/config/mock/mockprovider_test.go
+++ b/coa/pkg/apis/v1alpha2/providers/config/mock/mockprovider_test.go
@@ -7,6 +7,7 @@
 package mock
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,10 +26,12 @@ func TestInit(t *testing.T) {
 	assert.Nil(t, err)
 }
 func TestGet(t *testing.T) {
+	var ctx = context.Background()
 	provider := MockConfigProvider{}
 	err := provider.Init(MockConfigProviderConfig{})
 	assert.Nil(t, err)
-	val, err := provider.Get("obj", "field", nil, nil)
+
+	val, err := provider.Get(ctx, "obj", "field", nil, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "obj::field", val)
 

--- a/coa/pkg/apis/v1alpha2/providers/secret/mock/mockprovider.go
+++ b/coa/pkg/apis/v1alpha2/providers/secret/mock/mockprovider.go
@@ -72,6 +72,6 @@ func toMockSecretProviderConfig(config providers.IProviderConfig) (MockSecretPro
 func (m *MockSecretProvider) Read(ctx context.Context, object string, field string, localContext interface{}) (string, error) {
 	return object + ">>" + field, nil
 }
-func (m *MockSecretProvider) Get(object string, field string, localContext interface{}) (string, error) {
+func (m *MockSecretProvider) Get(ctx context.Context, object string, field string, localContext interface{}) (string, error) {
 	return object + ">>" + field, nil
 }

--- a/coa/pkg/apis/v1alpha2/providers/secret/secret.go
+++ b/coa/pkg/apis/v1alpha2/providers/secret/secret.go
@@ -18,5 +18,5 @@ type ISecretProvider interface {
 }
 
 type IExtSecretProvider interface {
-	Get(name string, field string, localContext interface{}) (string, error)
+	Get(ctx context.Context, name string, field string, localContext interface{}) (string, error)
 }

--- a/coa/pkg/apis/v1alpha2/utils/utils_test.go
+++ b/coa/pkg/apis/v1alpha2/utils/utils_test.go
@@ -7,6 +7,7 @@
 package utils
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -56,7 +57,7 @@ func (t *TestSecretProvider) Init(config providers.IProviderConfig) error {
 	return nil
 }
 
-func (t *TestSecretProvider) Get(object string, field string, localContext interface{}) (string, error) {
+func (t *TestSecretProvider) Get(ctx context.Context, object string, field string, localContext interface{}) (string, error) {
 	return "test", nil
 }
 
@@ -67,11 +68,11 @@ func (t *TestExtConfigProvider) Init(config providers.IProviderConfig) error {
 	return nil
 }
 
-func (t *TestExtConfigProvider) Get(object string, field string, overrides []string, localContext interface{}) (interface{}, error) {
+func (t *TestExtConfigProvider) Get(ctx context.Context, object string, field string, overrides []string, localContext interface{}) (interface{}, error) {
 	return "test", nil
 }
 
-func (t *TestExtConfigProvider) GetObject(object string, overrides []string, localContext interface{}) (map[string]interface{}, error) {
+func (t *TestExtConfigProvider) GetObject(ctx context.Context, object string, overrides []string, localContext interface{}) (map[string]interface{}, error) {
 	return map[string]interface{}{"test": "test"}, nil
 }
 

--- a/k8s/controllers/fabric/target_controller.go
+++ b/k8s/controllers/fabric/target_controller.go
@@ -181,7 +181,7 @@ func (r *TargetReconciler) populateProvisioningError(summaryResult *model.Summar
 
 func (r *TargetReconciler) deploymentBuilder(ctx context.Context, object reconcilers.Reconcilable) (*model.DeploymentSpec, error) {
 	if target, ok := object.(*symphonyv1.Target); ok {
-		deployment, err := utils.CreateSymphonyDeploymentFromTarget(*target, object.GetNamespace())
+		deployment, err := utils.CreateSymphonyDeploymentFromTarget(ctx, *target, object.GetNamespace())
 		if err != nil {
 			return nil, err
 		}

--- a/k8s/utils/symphony-api.go
+++ b/k8s/utils/symphony-api.go
@@ -193,14 +193,14 @@ func MatchTargets(instance solution_v1.Instance, targets fabric_v1.TargetList) [
 	return slice
 }
 
-func CreateSymphonyDeploymentFromTarget(target fabric_v1.Target, namespace string) (apimodel.DeploymentSpec, error) {
+func CreateSymphonyDeploymentFromTarget(ctx context.Context, target fabric_v1.Target, namespace string) (apimodel.DeploymentSpec, error) {
 	targetState, err := K8STargetToAPITargetState(target)
 	if err != nil {
 		return apimodel.DeploymentSpec{}, err
 	}
 
 	var ret apimodel.DeploymentSpec
-	ret, err = api_utils.CreateSymphonyDeploymentFromTarget(targetState, namespace)
+	ret, err = api_utils.CreateSymphonyDeploymentFromTarget(ctx, targetState, namespace)
 	ret.Hash = HashObjects(DeploymentResources{
 		TargetCandidates: []fabric_v1.Target{target},
 	})
@@ -231,7 +231,7 @@ func CreateSymphonyDeployment(ctx context.Context, instance solution_v1.Instance
 	}
 
 	var ret apimodel.DeploymentSpec
-	ret, err = api_utils.CreateSymphonyDeployment(instanceState, solutionState, targetStates, nil, objectNamespace)
+	ret, err = api_utils.CreateSymphonyDeployment(ctx, instanceState, solutionState, targetStates, nil, objectNamespace)
 	ret.Hash = HashObjects(DeploymentResources{
 		Instance:         instance,
 		Solution:         solution,


### PR DESCRIPTION
- Added context logs for catalog provider
- Updated logs in configs and secrets manager
- Went through parser.go and add logs in the recursive functions. Errors in internal functions will be returned and be handled and logged in `evalProperties` and `enumerateProperties`.