### PR TITLE
truncate input/output/stagehistory when merging activation stages + remove response header in status outputs

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/activations/activations-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/activations/activations-manager.go
@@ -39,6 +39,14 @@ type ActivationsManager struct {
 	Validator     validation.ActivationValidator
 }
 
+const (
+	stageOutputMaxSize    = 100 * 1024
+	activationHistorySize = 10
+	// Stage size limit: 100KB. For RESTful APIs, the medium response size is 10KB to 100KB. (Only FileDownload API response size can be pretty large.)
+	// Consider the size limit of Custom Resource (CR) in Kubernetes is 1MB, the output can contain 10 biggest stage responses.
+	// And the remain 24KB will be enough for other fields.
+)
+
 func (s *ActivationsManager) Init(context *contexts.VendorContext, config managers.ManagerConfig, providers map[string]providers.IProvider) error {
 	err := s.Manager.Init(context, config, providers)
 	if err != nil {
@@ -289,7 +297,7 @@ func (t *ActivationsManager) ReportStageStatus(ctx context.Context, name string,
 
 	activationState.Status.UpdateTime = time.Now().Format(time.RFC3339) // TODO: is this correct? Shouldn't it be reported?
 
-	err = mergeStageStatus(&activationState, current)
+	err = mergeStageStatus(ctx, &activationState, current)
 	if err != nil {
 		log.ErrorfCtx(ctx, "Failed to merge stage status for activation %s in namespace %s: %v", name, namespace, err)
 		return err
@@ -323,15 +331,43 @@ func (t *ActivationsManager) ReportStageStatus(ctx context.Context, name string,
 	return nil
 }
 
-func mergeStageStatus(activationState *model.ActivationState, current model.StageStatus) error {
+func mergeStageStatus(ctx context.Context, activationState *model.ActivationState, current model.StageStatus) error {
 	if current.Outputs["__site"] == nil {
 		// The StageStatus is triggered locally
 		if activationState.Status.StageHistory == nil {
 			activationState.Status.StageHistory = make([]model.StageStatus, 0)
 		}
+
+		currentBytes, _ := json.Marshal(current)
+		if len(currentBytes) > stageOutputMaxSize {
+			log.InfofCtx(ctx, "Stage %s size exceeds the limit, truncate the inputs/outputs.", current.Stage)
+			totalLen := len(current.Outputs) + len(current.Inputs)
+			// totalLen can't be 0 since currentOutputSize > StageOutputMaxSize
+			for key, val := range current.Outputs {
+				valBytes, _ := json.Marshal(val)
+				if len(valBytes) > stageOutputMaxSize/totalLen {
+					valBytes = append(valBytes[:stageOutputMaxSize/totalLen], []byte("...")...)
+					current.Outputs[key] = string(valBytes)
+				}
+			}
+			for key, val := range current.Inputs {
+				valBytes, _ := json.Marshal(val)
+				if len(valBytes) > stageOutputMaxSize/totalLen {
+					valBytes = append(valBytes[:stageOutputMaxSize/totalLen], []byte("...")...)
+					current.Inputs[key] = string(valBytes)
+				}
+			}
+		}
+
 		if len(activationState.Status.StageHistory) == 0 {
 			activationState.Status.StageHistory = append(activationState.Status.StageHistory, current)
 		} else if activationState.Status.StageHistory[len(activationState.Status.StageHistory)-1].Stage != current.Stage {
+			if len(activationState.Status.StageHistory)+1 > activationHistorySize {
+				oldestStage := activationState.Status.StageHistory[0].Stage
+				activationState.Status.StageHistory = activationState.Status.StageHistory[1:]
+				log.InfofCtx(ctx, "Activation state size exceeds the limit %d, remove the oldest stage %s.", activationHistorySize, oldestStage)
+				// If the activation stage history is too long, remove the oldest stage status
+			}
 			activationState.Status.StageHistory = append(activationState.Status.StageHistory, current)
 		} else {
 			activationState.Status.StageHistory[len(activationState.Status.StageHistory)-1] = current

--- a/api/pkg/apis/v1alpha1/managers/stage/stage-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/stage/stage-manager.go
@@ -657,7 +657,7 @@ func (s *StageManager) HandleTriggerEvent(ctx context.Context, campaign model.Ca
 		}
 
 		for k, v := range outputs {
-			if !strings.HasPrefix(k, "__") {
+			if !(strings.HasPrefix(k, "__") || strings.HasPrefix(k, "header.")) {
 				status.Outputs[k] = v
 			}
 		}

--- a/api/pkg/apis/v1alpha1/providers/stage/http/http.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/http/http.go
@@ -11,7 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -264,7 +264,7 @@ func (i *HttpStageProvider) Process(ctx context.Context, mgrContext contexts.Man
 				)
 				return nil, false, err
 			}
-			req.Body = ioutil.NopCloser(bytes.NewBuffer(jData))
+			req.Body = io.NopCloser(bytes.NewBuffer(jData))
 			req.Header.Set("Content-Type", "application/json; charset=UTF-8")
 			req.ContentLength = int64(len(jData))
 		}
@@ -291,7 +291,7 @@ func (i *HttpStageProvider) Process(ctx context.Context, mgrContext contexts.Man
 	}
 
 	var data []byte
-	data, err = ioutil.ReadAll(resp.Body)
+	data, err = io.ReadAll(resp.Body)
 	if err != nil {
 		sLog.ErrorfCtx(ctx, "  P (Http Stage): failed to read request response: %v", err)
 		providerOperationMetrics.ProviderOperationErrors(
@@ -382,7 +382,7 @@ func (i *HttpStageProvider) Process(ctx context.Context, mgrContext contexts.Man
 			}
 			if succeeded {
 				var data []byte
-				data, err = ioutil.ReadAll(waitResp.Body)
+				data, err = io.ReadAll(waitResp.Body)
 				if err != nil {
 					sLog.ErrorfCtx(ctx, "  P (Http Stage): failed to read wait request response: %v", err)
 					providerOperationMetrics.ProviderOperationErrors(


### PR DESCRIPTION
Fix #417

Improvements to activation stage handling:

* [`api/pkg/apis/v1alpha1/managers/activations/activations-manager.go`](diffhunk://#diff-2cab4467559ea7d3b0c380f47d1af1e0c24291c0fe7c84f4db3f7a9394587434R42-R49): Added constants for stage output size limits and activation history size.
* [`api/pkg/apis/v1alpha1/managers/activations/activations-manager.go`](diffhunk://#diff-2cab4467559ea7d3b0c380f47d1af1e0c24291c0fe7c84f4db3f7a9394587434L326-R370): Modified the `mergeStageStatus` function to handle large outputs by truncating inputs/outputs and managing activation stage history.

Dependency updates:

* [`api/pkg/apis/v1alpha1/providers/stage/http/http.go`](diffhunk://#diff-c741559dd8fb19c4853d36525a7594c7bdca81b8d721d517f24218fe3e52bdb8L14-R14): Replaced `ioutil` package functions with `io` package equivalents for reading and closing streams.

Minor change:

* [`api/pkg/apis/v1alpha1/managers/stage/stage-manager.go`](diffhunk://#diff-95069362bb7d03b2bd1bd0dbbbc42ac3e56522905f03c1334ca49178b64619b2L660-R660): Updated the `HandleTriggerEvent` function to exclude outputs with the prefix `header.`.