### PR TITLE
Add generation for objectMeta and bump generation whenever spec changes

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/activations/activations-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/activations/activations-manager.go
@@ -103,7 +103,7 @@ func getActivationState(body interface{}, etag string) (model.ActivationState, e
 	if activationState.Spec == nil {
 		activationState.Spec = &model.ActivationSpec{}
 	}
-	activationState.ObjectMeta.Generation = etag
+	activationState.ObjectMeta.ETag = etag
 	if activationState.Status == nil {
 		activationState.Status = &model.ActivationStatus{}
 	}
@@ -147,7 +147,7 @@ func (m *ActivationsManager) UpsertState(ctx context.Context, name string, state
 				"metadata":   state.ObjectMeta,
 				"spec":       state.Spec,
 			},
-			ETag: state.ObjectMeta.Generation,
+			ETag: state.ObjectMeta.ETag,
 		},
 		Metadata: map[string]interface{}{
 			"namespace": state.ObjectMeta.Namespace,

--- a/api/pkg/apis/v1alpha1/managers/catalogs/catalogs-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/catalogs/catalogs-manager.go
@@ -102,7 +102,7 @@ func getCatalogState(body interface{}, etag string) (model.CatalogState, error) 
 	if catalogState.Spec == nil {
 		catalogState.Spec = &model.CatalogSpec{}
 	}
-	catalogState.ObjectMeta.Generation = etag
+	catalogState.ObjectMeta.ETag = etag
 	if catalogState.Status == nil {
 		catalogState.Status = &model.CatalogStatus{}
 	}

--- a/api/pkg/apis/v1alpha1/managers/instances/instances-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/instances/instances-manager.go
@@ -108,7 +108,7 @@ func (t *InstancesManager) UpsertState(ctx context.Context, name string, state m
 	}
 	generation := ""
 	if state.Spec != nil {
-		generation = state.ObjectMeta.Generation
+		generation = state.ObjectMeta.ETag
 	}
 	upsertRequest := states.UpsertRequest{
 		Value: states.StateEntry{
@@ -175,7 +175,7 @@ func getInstanceState(body interface{}, etag string) (model.InstanceState, error
 	if instanceState.Spec == nil {
 		instanceState.Spec = &model.InstanceSpec{}
 	}
-	instanceState.ObjectMeta.Generation = etag
+	instanceState.ObjectMeta.ETag = etag
 	return instanceState, nil
 }
 

--- a/api/pkg/apis/v1alpha1/managers/staging/staging-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/staging/staging-manager.go
@@ -101,7 +101,7 @@ func (s *StagingManager) Poll() []error {
 		}
 		var entry states.StateEntry
 		entry, err = s.StateProvider.Get(ctx, getRequest)
-		if err == nil && entry.Body != nil && entry.Body.(string) == catalog.ObjectMeta.Generation {
+		if err == nil && entry.Body != nil && entry.Body.(string) == catalog.ObjectMeta.ETag {
 			continue
 		}
 		if err != nil && !v1alpha2.IsNotFound(err) {
@@ -117,7 +117,7 @@ func (s *StagingManager) Poll() []error {
 		_, err = s.StateProvider.Upsert(ctx, states.UpsertRequest{
 			Value: states.StateEntry{
 				ID:   cacheId,
-				Body: catalog.ObjectMeta.Generation,
+				Body: catalog.ObjectMeta.ETag,
 			},
 			Metadata: map[string]interface{}{
 				"version":   "v1",

--- a/api/pkg/apis/v1alpha1/managers/targets/targets-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/targets/targets-manager.go
@@ -117,7 +117,7 @@ func (t *TargetsManager) UpsertState(ctx context.Context, name string, state mod
 		Value: states.StateEntry{
 			ID:   name,
 			Body: body,
-			ETag: state.ObjectMeta.Generation,
+			ETag: state.ObjectMeta.ETag,
 		},
 		Metadata: map[string]interface{}{
 			"namespace": state.ObjectMeta.Namespace,
@@ -238,7 +238,7 @@ func getTargetState(body interface{}, etag string) (model.TargetState, error) {
 	if targetState.Spec == nil {
 		targetState.Spec = &model.TargetSpec{}
 	}
-	targetState.ObjectMeta.Generation = etag
+	targetState.ObjectMeta.ETag = etag
 	return targetState, nil
 }
 

--- a/api/pkg/apis/v1alpha1/model/objectmeta.go
+++ b/api/pkg/apis/v1alpha1/model/objectmeta.go
@@ -18,7 +18,8 @@ import (
 type ObjectMeta struct {
 	Namespace   string            `json:"namespace,omitempty"`
 	Name        string            `json:"name,omitempty"`
-	Generation  string            `json:"generation,omitempty"`
+	ETag        string            `json:"etag,omitempty"`
+	Generation  int64             `json:"generation,omitempty"`
 	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
@@ -27,7 +28,7 @@ type ObjectMeta struct {
 func (o *ObjectMeta) UnmarshalJSON(data []byte) error {
 	type Alias ObjectMeta
 	aux := &struct {
-		Generation interface{} `json:"generation,omitempty"`
+		ETag interface{} `json:"etag,omitempty"`
 		*Alias
 	}{
 		Alias: (*Alias)(o),
@@ -37,14 +38,14 @@ func (o *ObjectMeta) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	if aux.Generation == nil {
-		o.Generation = ""
+	if aux.ETag == nil {
+		o.ETag = ""
 	} else {
-		switch v := aux.Generation.(type) {
+		switch v := aux.ETag.(type) {
 		case string:
-			o.Generation = v
+			o.ETag = v
 		case float64:
-			o.Generation = strconv.FormatInt(int64(v), 10)
+			o.ETag = strconv.FormatInt(int64(v), 10)
 		default:
 			return v1alpha2.NewCOAError(nil, fmt.Sprintf("unexpected type for generation field: %T", v), v1alpha2.BadConfig)
 		}

--- a/api/pkg/apis/v1alpha1/model/objectmeta_test.go
+++ b/api/pkg/apis/v1alpha1/model/objectmeta_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestObjectMetaWithString(t *testing.T) {
-	jsonString := `{"generation": "33"}`
+	jsonString := `{"etag": "33"}`
 
 	var newStage ObjectMeta
 	var err = json.Unmarshal([]byte(jsonString), &newStage)
@@ -20,13 +20,13 @@ func TestObjectMetaWithString(t *testing.T) {
 		t.Fatalf("Failed to unmarshal JSON: %v", err)
 	}
 	targetTime := "33"
-	if newStage.Generation != targetTime {
-		t.Fatalf("Generation is not match: %v", err)
+	if newStage.ETag != targetTime {
+		t.Fatalf("Etag is not match: %v", err)
 	}
 }
 
 func TestObjectMetaWithNumber(t *testing.T) {
-	jsonString := `{"generation": 33}`
+	jsonString := `{"etag": 33}`
 
 	var newStage ObjectMeta
 	var err = json.Unmarshal([]byte(jsonString), &newStage)
@@ -34,7 +34,7 @@ func TestObjectMetaWithNumber(t *testing.T) {
 		t.Fatalf("Failed to unmarshal JSON: %v", err)
 	}
 	targetTime := "33"
-	if newStage.Generation != targetTime {
+	if newStage.ETag != targetTime {
 		t.Fatalf("Generation is not match: %v", err)
 	}
 }

--- a/api/pkg/apis/v1alpha1/utils/symphony-api.go
+++ b/api/pkg/apis/v1alpha1/utils/symphony-api.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -727,7 +728,7 @@ func CreateSymphonyDeploymentFromTarget(target model.TargetState, namespace stri
 	ret.Targets = targets
 	ret.SolutionName = key
 	// set the target generation to the deployment
-	ret.Generation = target.ObjectMeta.Generation
+	ret.Generation = strconv.FormatInt(target.ObjectMeta.Generation, 10)
 	assignments, err := AssignComponentsToTargets(ret.Solution.Spec.Components, ret.Targets)
 	if err != nil {
 		return ret, err
@@ -746,7 +747,7 @@ func CreateSymphonyDeployment(instance model.InstanceState, solution model.Solut
 	ret := model.DeploymentSpec{
 		ObjectNamespace: namespace,
 	}
-	ret.Generation = instance.ObjectMeta.Generation
+	ret.Generation = strconv.FormatInt(instance.ObjectMeta.Generation, 10)
 
 	// convert targets
 	sTargets := make(map[string]model.TargetState)

--- a/api/pkg/apis/v1alpha1/vendors/activations-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/activations-vendor.go
@@ -8,6 +8,7 @@ package vendors
 
 import (
 	"encoding/json"
+	"strconv"
 	"time"
 
 	"github.com/eclipse-symphony/symphony/api/constants"
@@ -214,7 +215,7 @@ func (c *ActivationsVendor) onActivations(request v1alpha2.COARequest) v1alpha2.
 			c.Context.Publish("activation", v1alpha2.Event{
 				Body: v1alpha2.ActivationData{
 					Campaign:             activation.Spec.Campaign,
-					ActivationGeneration: entry.ObjectMeta.Generation,
+					ActivationGeneration: strconv.FormatInt(entry.ObjectMeta.Generation, 10),
 					Activation:           id,
 					Stage:                activation.Spec.Stage,
 					Inputs:               activation.Spec.Inputs,


### PR DESCRIPTION
1. Use different field for Generation and Etag in ObjectMeta (I think Etag is a thing related to operation which should not be maintained in ObjectMeta of an object. Instead, it should be stored in database along with the object. However, we don't handle Etag properly in state provider now so I still keep it in the ObjectMeta)
2. Add generation bump mechanism in memory state provider. Generation is bumped whenever there is spec change like it is in Kubernetes etcd. We try to achieve the same behavior in memory state provider.

Test:
1. unit tests
2. manual tests in standalone mode. Generation increases when spec changes.