### PR TITLE
init piccolo

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -8,6 +8,8 @@ replace github.com/eclipse-symphony/symphony/coa => ../coa
 
 replace github.com/eclipse-symphony/symphony/packages/mage => ../packages/mage
 
+replace "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/piccolo" => ./pkg/apis/v1alpha1/providers/target/piccolo
+
 require (
 	github.com/eclipse-symphony/symphony/coa v0.0.0
 	github.com/spf13/cobra v1.8.1

--- a/api/pkg/apis/v1alpha1/providers/providerfactory.go
+++ b/api/pkg/apis/v1alpha1/providers/providerfactory.go
@@ -37,6 +37,7 @@ import (
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/kubectl"
 	tgtmock "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/mock"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/mqtt"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/piccolo"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/proxy"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/script"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/staging"
@@ -191,6 +192,12 @@ func (s SymphonyProviderFactory) CreateProvider(providerType string, config cp.I
 		}
 	case "providers.target.docker":
 		mProvider := &docker.DockerTargetProvider{}
+		err = mProvider.Init(config)
+		if err == nil {
+			return mProvider, nil
+		}
+	case "providers.target.piccolo":
+		mProvider := &piccolo.PiccoloTargetProvider{}
 		err = mProvider.Init(config)
 		if err == nil {
 			return mProvider, nil
@@ -408,6 +415,14 @@ func CreateProviderForTargetRole(context *contexts.ManagerContext, role string, 
 					return provider, nil
 				case "providers.target.docker":
 					provider := &docker.DockerTargetProvider{}
+					err := provider.InitWithMap(binding.Config)
+					if err != nil {
+						return nil, err
+					}
+					provider.Context = context
+					return provider, nil
+				case "providers.target.piccolo":
+					provider := &piccolo.PiccoloTargetProvider{}
 					err := provider.InitWithMap(binding.Config)
 					if err != nil {
 						return nil, err

--- a/api/pkg/apis/v1alpha1/providers/providerfactory_test.go
+++ b/api/pkg/apis/v1alpha1/providers/providerfactory_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/k8s"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/kubectl"
 	tgtmock "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/mock"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/piccolo"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/proxy"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/script"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/staging"
@@ -157,6 +158,10 @@ func TestCreateProvider(t *testing.T) {
 	provider, err = providerfactory.CreateProvider("providers.target.docker", docker.DockerTargetProviderConfig{})
 	assert.Nil(t, err)
 	assert.NotNil(t, *provider.(*docker.DockerTargetProvider))
+
+	provider, err = providerfactory.CreateProvider("providers.target.piccolo", piccolo.PiccoloTargetProviderConfig{})
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*piccolo.PiccoloTargetProvider))
 
 	if getTestMiniKubeEnabled == "" {
 		t.Log("Skipping providers.target.ingress test as TEST_MINIKUBE_ENABLED is not set")
@@ -346,6 +351,11 @@ func TestCreateProviderForTargetRole(t *testing.T) {
 						{
 							Role:     "docker",
 							Provider: "providers.target.docker",
+							Config:   map[string]string{},
+						},
+						{
+							Role:     "piccolo",
+							Provider: "providers.target.piccolo",
 							Config:   map[string]string{},
 						},
 						{
@@ -633,6 +643,10 @@ func TestCreateProviderForTargetRole(t *testing.T) {
 	provider, err = CreateProviderForTargetRole(nil, "docker", targetState, nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, *provider.(*docker.DockerTargetProvider))
+
+	provider, err = CreateProviderForTargetRole(nil, "piccolo", targetState, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, *provider.(*piccolo.PiccoloTargetProvider))
 
 	if getTestMiniKubeEnabled == "" {
 		t.Log("Skipping ingress test as TEST_MINIKUBE_ENABLED is not set")

--- a/api/pkg/apis/v1alpha1/providers/target/piccolo/piccolo.go
+++ b/api/pkg/apis/v1alpha1/providers/target/piccolo/piccolo.go
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package piccolo
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/observability"
+	observ_utils "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/observability/utils"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/logger"
+)
+
+const loggerName = "providers.target.piccolo"
+
+var sLog = logger.NewLogger(loggerName)
+
+type PiccoloTargetProviderConfig struct {
+	Name string `json:"name"`
+	Url  string `json:"url"`
+}
+
+type PiccoloTargetProvider struct {
+	Config  PiccoloTargetProviderConfig
+	Context *contexts.ManagerContext
+}
+
+func PiccoloTargetProviderConfigFromMap(properties map[string]string) (PiccoloTargetProviderConfig, error) {
+	ret := PiccoloTargetProviderConfig{}
+	if v, ok := properties["name"]; ok {
+		ret.Name = v
+	}
+	return ret, nil
+}
+func (d *PiccoloTargetProvider) InitWithMap(properties map[string]string) error {
+	config, err := PiccoloTargetProviderConfigFromMap(properties)
+	if err != nil {
+		return err
+	}
+	return d.Init(config)
+}
+func (s *PiccoloTargetProvider) SetContext(ctx *contexts.ManagerContext) {
+	s.Context = ctx
+}
+
+func (d *PiccoloTargetProvider) Init(config providers.IProviderConfig) error {
+	_, span := observability.StartSpan("Piccolo Target Provider", context.TODO(), &map[string]string{
+		"method": "Init",
+	})
+	var err error = nil
+	defer observ_utils.CloseSpanWithError(span, &err)
+
+	sLog.Info("  P (Piccolo Target): Init()")
+
+	// convert config to PiccoloTargetProviderConfig type
+	piccoloConfig, err := toPiccoloTargetProviderConfig(config)
+	if err != nil {
+		sLog.Errorf("  P (Piccolo Target): expected PiccoloTargetProviderConfig: %+v", err)
+		return err
+	}
+
+	d.Config = piccoloConfig
+	return nil
+}
+
+func toPiccoloTargetProviderConfig(config providers.IProviderConfig) (PiccoloTargetProviderConfig, error) {
+	ret := PiccoloTargetProviderConfig{}
+	data, err := json.Marshal(config)
+	if err != nil {
+		return ret, err
+	}
+	err = json.Unmarshal(data, &ret)
+	return ret, err
+}
+
+func (i *PiccoloTargetProvider) Get(ctx context.Context, deployment model.DeploymentSpec, references []model.ComponentStep) ([]model.ComponentSpec, error) {
+	ctx, span := observability.StartSpan("Piccolo Target Provider", ctx, &map[string]string{
+		"method": "Get",
+	})
+	var err error = nil
+	defer observ_utils.CloseSpanWithError(span, &err)
+
+	sLog.InfofCtx(ctx, "  P (Piccolo Target): getting artifacts: %s - %s, traceId: %s", deployment.Instance.Spec.Scope, deployment.Instance.ObjectMeta.Name, span.SpanContext().TraceID().String())
+
+	ret := make([]model.ComponentSpec, 0)
+	for _, component := range references {
+		properties := component.Component.Properties
+		name := properties["workload.name"].(string)
+		workloadType := properties["workload.type"].(string)
+		req, err := http.NewRequest("GET", i.Config.Url+workloadType+"/"+name, nil)
+		if err != nil {
+			sLog.ErrorCtx(ctx, "  P (Piccolo Target): Unable to make Request")
+			return nil, err
+		}
+		client := &http.Client{}
+		resp, err := client.Do(req)
+
+		if err != nil {
+			sLog.ErrorfCtx(ctx, "  P (Piccolo Target): Unable to get workload %s from piccolo", name)
+			return nil, err
+		}
+
+		defer resp.Body.Close()
+
+		switch resp.StatusCode {
+		case http.StatusOK:
+			// respBody, err := io.ReadAll(resp.Body)
+			component := model.ComponentSpec{
+				Name:       name,
+				Properties: make(map[string]interface{}),
+			}
+			component.Properties["workload.name"] = string(name)
+			component.Properties["workload.type"] = string(workloadType)
+			ret = append(ret, component)
+		case http.StatusNotFound:
+			continue
+		}
+	}
+
+	return ret, nil
+}
+
+func (i *PiccoloTargetProvider) Apply(ctx context.Context, deployment model.DeploymentSpec, step model.DeploymentStep, isDryRun bool) (map[string]model.ComponentResultSpec, error) {
+	ctx, span := observability.StartSpan("Piccolo Target Provider", ctx, &map[string]string{
+		"method": "Apply",
+	})
+	var err error = nil
+	defer observ_utils.CloseSpanWithError(span, &err)
+
+	sLog.InfofCtx(ctx, "  P (Piccolo Target): applying artifacts: %s - %s, traceId: %s", deployment.Instance.Spec.Scope, deployment.Instance.ObjectMeta.Name, span.SpanContext().TraceID().String())
+
+	injections := &model.ValueInjections{
+		InstanceId: deployment.Instance.ObjectMeta.Name,
+		SolutionId: deployment.Instance.Spec.Solution,
+		TargetId:   deployment.ActiveTarget,
+	}
+
+	components := step.GetComponents()
+	err = i.GetValidationRule(ctx).Validate(components)
+	if err != nil {
+		sLog.ErrorfCtx(ctx, "  P (Piccolo Target): failed to validate components: %+v, traceId: %s", err, span.SpanContext().TraceID().String())
+		return nil, err
+	}
+	if isDryRun {
+		err = nil
+		return nil, nil
+	}
+
+	ret := step.PrepareResultMap()
+
+	for _, component := range step.Components {
+		if component.Action == model.ComponentUpdate {
+			name := model.ReadPropertyCompat(component.Component.Properties, "workload.name", injections)
+			if name == "" {
+				err = errors.New("component doesn't have workload.name property")
+				ret[component.Component.Name] = model.ComponentResultSpec{
+					Status:  v1alpha2.UpdateFailed,
+					Message: err.Error(),
+				}
+				sLog.ErrorfCtx(ctx, "  P (Piccolo Target): %+v, traceId: %s", err, span.SpanContext().TraceID().String())
+				return ret, err
+			}
+			reqBody := bytes.NewBufferString("https:// scenario path")
+			resp, err := http.Post(i.Config.Url+"create-scenario/"+component.Component.Name, "text/plain", reqBody)
+			if err != nil {
+				sLog.ErrorCtx(ctx, "  P (Piccolo Target): fail to create resource")
+				return ret, err
+			}
+
+			defer resp.Body.Close()
+
+			ret[component.Component.Name] = model.ComponentResultSpec{
+				Status:  v1alpha2.Updated,
+				Message: "",
+			}
+		} else {
+			req, err := http.NewRequest("DELETE", i.Config.Url+"delete-scenario/"+component.Component.Name, nil)
+			if err != nil {
+				return ret, err
+			}
+
+			client := &http.Client{}
+			_, err = client.Do(req)
+
+			if err == nil {
+				ret[component.Component.Name] = model.ComponentResultSpec{
+					Status:  v1alpha2.Deleted,
+					Message: "",
+				}
+			}
+		}
+	}
+	return ret, nil
+}
+
+func (*PiccoloTargetProvider) GetValidationRule(ctx context.Context) model.ValidationRule {
+	return model.ValidationRule{
+		AllowSidecar: false,
+		ComponentValidationRule: model.ComponentValidationRule{
+			RequiredProperties:    []string{"workload.type", "workload.name"},
+			OptionalProperties:    []string{},
+			RequiredComponentType: "",
+			RequiredMetadata:      []string{},
+			OptionalMetadata:      []string{},
+			ChangeDetectionProperties: []model.PropertyDesc{
+				{Name: "workload.name", IgnoreCase: false, SkipIfMissing: false},
+			},
+		},
+	}
+}

--- a/api/pkg/apis/v1alpha1/providers/target/piccolo/piccolo_test.go
+++ b/api/pkg/apis/v1alpha1/providers/target/piccolo/piccolo_test.go
@@ -1,0 +1,364 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package piccolo
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/target/conformance"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPiccoloTargetProviderConfigFromMapNil(t *testing.T) {
+	_, err := PiccoloTargetProviderConfigFromMap(nil)
+	assert.Nil(t, err)
+}
+func TestPiccoloTargetProviderConfigFromMapEmpty(t *testing.T) {
+	_, err := PiccoloTargetProviderConfigFromMap(map[string]string{})
+	assert.Nil(t, err)
+}
+func TestPiccoloTargetProviderInitEmptyConfig(t *testing.T) {
+	config := PiccoloTargetProviderConfig{}
+	provider := PiccoloTargetProvider{}
+	err := provider.Init(config)
+	assert.Nil(t, err)
+}
+func TestInitWithMap(t *testing.T) {
+	configMap := map[string]string{
+		"name": "name",
+	}
+	provider := PiccoloTargetProvider{}
+	err := provider.InitWithMap(configMap)
+	assert.Nil(t, err)
+}
+func TestPiccoloTargetProviderInstall(t *testing.T) {
+	testPiccoloProvider := os.Getenv("TEST_PICCOLO_PROVIDER")
+	if testPiccoloProvider == "" {
+		t.Skip("Skipping because TEST_PICCOLO_PROVIDER enviornment variable is not set")
+	}
+	config := PiccoloTargetProviderConfig{}
+	provider := PiccoloTargetProvider{}
+	err := provider.Init(config)
+	assert.Nil(t, err)
+	component := model.ComponentSpec{
+		Name: "redis-test",
+		Type: "container",
+		Properties: map[string]interface{}{
+			"workload.name": "redis:latest",
+		},
+	}
+	deployment := model.DeploymentSpec{
+		Instance: model.InstanceState{
+			Spec: &model.InstanceSpec{},
+		},
+		Solution: model.SolutionState{
+			Spec: &model.SolutionSpec{
+				Components: []model.ComponentSpec{component},
+			},
+		},
+	}
+	step := model.DeploymentStep{
+		Components: []model.ComponentStep{
+			{
+				Action:    model.ComponentUpdate,
+				Component: component,
+			},
+		},
+	}
+	_, err = provider.Apply(context.Background(), deployment, step, false)
+	assert.Nil(t, err)
+}
+
+func TestPiccoloTargetProviderGet(t *testing.T) {
+	// NOTE: To run this test case successfully, you need to have Docker and Redis container running:
+	// docker run -d --name redis-test -p 6379:6379 redis:latest
+	// Then, comment out the next 4 lines of code and run the test case.
+	testPiccoloProvider := os.Getenv("TEST_PICCOLO_PROVIDER")
+	if testPiccoloProvider == "" {
+		t.Skip("Skipping because TEST_PICCOLO_PROVIDER enviornment variable is not set")
+	}
+	config := PiccoloTargetProviderConfig{}
+	provider := PiccoloTargetProvider{}
+	err := provider.Init(config)
+	assert.Nil(t, err)
+	components, err := provider.Get(context.Background(), model.DeploymentSpec{
+		Instance: model.InstanceState{
+			Spec: &model.InstanceSpec{},
+		},
+		Solution: model.SolutionState{
+			Spec: &model.SolutionSpec{
+				Components: []model.ComponentSpec{
+					{
+						Name: "redis-test",
+						Type: "container",
+						Properties: map[string]interface{}{
+							"workload.name": "redis:latest",
+						},
+					},
+				},
+			},
+		},
+	}, []model.ComponentStep{
+		{
+			Action: model.ComponentUpdate,
+			Component: model.ComponentSpec{
+				Name: "redis-test",
+				Type: "container",
+				Properties: map[string]interface{}{
+					"workload.name":     "redis:latest",
+					"env.REDIS_VERSION": "7.0.12", // NOTE: Only environment variables passed in by the reference are returned.
+				},
+			},
+		},
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(components))
+	assert.Equal(t, "redis:latest", components[0].Properties["workload.name"])
+	assert.NotEqual(t, "", components[0].Properties["env.REDIS_VERSION"])
+}
+func TestPiccoloTargetProviderRemove(t *testing.T) {
+	testPiccoloProvider := os.Getenv("TEST_PICCOLO_PROVIDER")
+	if testPiccoloProvider == "" {
+		t.Skip("Skipping because TEST_PICCOLO_PROVIDER enviornment variable is not set")
+	}
+	config := PiccoloTargetProviderConfig{}
+	provider := PiccoloTargetProvider{}
+	err := provider.Init(config)
+	assert.Nil(t, err)
+	component := model.ComponentSpec{
+		Name: "redis-test",
+		Type: "container",
+		Properties: map[string]interface{}{
+			"workload.name": "redis:latest",
+		},
+	}
+	deployment := model.DeploymentSpec{
+		Instance: model.InstanceState{
+			Spec: &model.InstanceSpec{},
+		},
+		Solution: model.SolutionState{
+			Spec: &model.SolutionSpec{
+				Components: []model.ComponentSpec{component},
+			},
+		},
+	}
+	step := model.DeploymentStep{
+		Components: []model.ComponentStep{
+			{
+				Action:    model.ComponentDelete,
+				Component: component,
+			},
+		},
+	}
+	_, err = provider.Apply(context.Background(), deployment, step, false)
+	assert.Nil(t, err)
+}
+
+func TestUpdateGetDelete(t *testing.T) {
+	testPiccoloProvider := os.Getenv("TEST_PICCOLO_ENABLED")
+	if testPiccoloProvider == "" {
+		t.Skip("Skipping because TEST_PICCOLO_PROVIDER enviornment variable is not set")
+	}
+	config := PiccoloTargetProviderConfig{}
+	provider := PiccoloTargetProvider{}
+	err := provider.Init(config)
+	assert.Nil(t, err)
+
+	// Update
+	component := model.ComponentSpec{
+		Name: "alpine-test",
+		Type: "container",
+		Properties: map[string]interface{}{
+			"workload.name": "alpine:3.18",
+		},
+	}
+	deployment := model.DeploymentSpec{
+		Instance: model.InstanceState{
+			Spec: &model.InstanceSpec{},
+		},
+		Solution: model.SolutionState{
+			Spec: &model.SolutionSpec{
+				Components: []model.ComponentSpec{component},
+			},
+		},
+	}
+	step := model.DeploymentStep{
+		Components: []model.ComponentStep{
+			{
+				Action:    model.ComponentUpdate,
+				Component: component,
+			},
+		},
+	}
+	_, err = provider.Apply(context.Background(), deployment, step, false)
+	assert.Nil(t, err)
+
+	// Get
+	components, err := provider.Get(context.Background(), model.DeploymentSpec{
+		Instance: model.InstanceState{
+			Spec: &model.InstanceSpec{},
+		},
+		Solution: model.SolutionState{
+			Spec: &model.SolutionSpec{
+				Components: []model.ComponentSpec{
+					{
+						Name: "alpine-test",
+						Type: "container",
+						Properties: map[string]interface{}{
+							"workload.name": "alpine:3.18",
+						},
+					},
+				},
+			},
+		},
+	}, []model.ComponentStep{
+		{
+			Action: model.ComponentUpdate,
+			Component: model.ComponentSpec{
+				Name: "alpine-test",
+				Type: "container",
+				Properties: map[string]interface{}{
+					"workload.name": "alpine:3.18",
+				},
+			},
+		},
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(components))
+
+	// Delete
+	step = model.DeploymentStep{
+		Components: []model.ComponentStep{
+			{
+				Action:    model.ComponentDelete,
+				Component: component,
+			},
+		},
+	}
+	_, err = provider.Apply(context.Background(), deployment, step, false)
+	assert.Nil(t, err)
+}
+
+func TestApplyFailed(t *testing.T) {
+	testPiccoloProvider := os.Getenv("TEST_PICCOLO_ENABLED")
+	if testPiccoloProvider == "" {
+		t.Skip("Skipping because TEST_PICCOLO_PROVIDER enviornment variable is not set")
+	}
+	config := PiccoloTargetProviderConfig{}
+	provider := PiccoloTargetProvider{}
+	err := provider.Init(config)
+	assert.Nil(t, err)
+
+	// invalid container image name
+	component := model.ComponentSpec{
+		Name: "",
+		Type: "container",
+	}
+	deployment := model.DeploymentSpec{
+		Instance: model.InstanceState{
+			Spec: &model.InstanceSpec{},
+		},
+		Solution: model.SolutionState{
+			Spec: &model.SolutionSpec{
+				Components: []model.ComponentSpec{component},
+			},
+		},
+	}
+	step := model.DeploymentStep{
+		Components: []model.ComponentStep{
+			{
+				Action:    model.ComponentUpdate,
+				Component: component,
+			},
+		},
+	}
+
+	_, err = provider.Apply(context.Background(), deployment, step, false)
+	assert.NotNil(t, err)
+
+	// unknown container image
+	component = model.ComponentSpec{
+		Name: "abcd:latest",
+		Type: "container",
+		Properties: map[string]interface{}{
+			"workload.name": "abc:latest",
+		},
+	}
+	deployment = model.DeploymentSpec{
+		Instance: model.InstanceState{
+			Spec: &model.InstanceSpec{},
+		},
+		Solution: model.SolutionState{
+			Spec: &model.SolutionSpec{
+				Components: []model.ComponentSpec{component},
+			},
+		},
+	}
+	step = model.DeploymentStep{
+		Components: []model.ComponentStep{
+			{
+				Action:    model.ComponentUpdate,
+				Component: component,
+			},
+		},
+	}
+	_, err = provider.Apply(context.Background(), deployment, step, false)
+	assert.NotNil(t, err)
+}
+
+func TestApplyAlreadyRunning(t *testing.T) {
+	testPiccoloProvider := os.Getenv("TEST_PICCOLO_ENABLED")
+	if testPiccoloProvider == "" {
+		t.Skip("Skipping because TEST_PICCOLO_PROVIDER enviornment variable is not set")
+	}
+	config := PiccoloTargetProviderConfig{}
+	provider := PiccoloTargetProvider{}
+	err := provider.Init(config)
+	assert.Nil(t, err)
+
+	component := model.ComponentSpec{
+		Name: "alpine-test",
+		Type: "container",
+		Properties: map[string]interface{}{
+			"workload.name": "alpine:3.18",
+		},
+	}
+	deployment := model.DeploymentSpec{
+		Instance: model.InstanceState{
+			Spec: &model.InstanceSpec{},
+		},
+		Solution: model.SolutionState{
+			Spec: &model.SolutionSpec{
+				Components: []model.ComponentSpec{component},
+			},
+		},
+	}
+	step := model.DeploymentStep{
+		Components: []model.ComponentStep{
+			{
+				Action:    model.ComponentUpdate,
+				Component: component,
+			},
+		},
+	}
+	_, err = provider.Apply(context.Background(), deployment, step, false)
+	assert.Nil(t, err)
+
+	// already running
+	_, err = provider.Apply(context.Background(), deployment, step, false)
+	assert.Nil(t, err)
+}
+
+func TestConformanceSuite(t *testing.T) {
+	provider := &PiccoloTargetProvider{}
+	err := provider.Init(PiccoloTargetProviderConfig{})
+	assert.Nil(t, err)
+	conformance.ConformanceSuite(t, provider)
+}


### PR DESCRIPTION
Please understand that I accidentally changed the repository and made a wrong commit fix (amend), which caused the existing PR to be closed.
I will also post response to existing your code reviews here.

previous : https://github.com/eclipse-symphony/symphony/pull/502

------

The Get() method and Apply() method should be consistent. For example, the Get() method gets by the path "workload.type/workload.name", while the Apply() method posts to path component.Name, which isn't necessary the same with workload.name. If workload.name and component.name are the same, probably we should exclude workload.name in properties and use component.Name in Get()
&rarr; Thanks for letting me know I didn't know that. Also fixed it to use `workload.name` when `Apply()`

Also, the Apply() method doesn't use workload.type. Maybe workload.type should be included in the request properties?
&rarr; In fact `workload.type` was created in advance because it was supposed to be applied in the future. It was removed because it is not needed now.

Extract url from properties here. Throw COAError if url is not found in properties.
&rarr; Fixed to get Url grom properties and use default value on failure.