### PR TITLE
workaround: setup-envtest version set to be 0.19

### DIFF
--- a/k8s/magefile.go
+++ b/k8s/magefile.go
@@ -31,7 +31,7 @@ var (
 
 	envTest = bintool.Must(bintool.NewGo(
 		"sigs.k8s.io/controller-runtime/tools/setup-envtest",
-		"latest",
+		"release-0.19",
 	))
 
 	kustomize = bintool.Must(bintool.New(


### PR DESCRIPTION
https://github.com/kubernetes-sigs/controller-runtime/pull/2971/files
This PR changed the go version of setup-envtest from 1.22.0 to 1.23.0, which `mage build:k8s` can't resolve.