### PR TITLE
Materialize stage provider can wait for solution deployment

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -45,3 +45,8 @@ const (
 	API                           = "symphony-api"
 	EmitTimeFieldInUserLogs       = "EMIT_TIME_FIELD_IN_USER_LOGS"
 )
+
+const (
+	Generation string = "generation"
+	Status     string = "status"
+)

--- a/api/pkg/apis/v1alpha1/managers/activations/activations-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/activations/activations-manager.go
@@ -111,7 +111,7 @@ func getActivationState(body interface{}, etag string) (model.ActivationState, e
 	if activationState.Spec == nil {
 		activationState.Spec = &model.ActivationSpec{}
 	}
-	activationState.ObjectMeta.Generation = etag
+	activationState.ObjectMeta.ETag = etag
 	if activationState.Status == nil {
 		activationState.Status = &model.ActivationStatus{}
 	}
@@ -155,7 +155,7 @@ func (m *ActivationsManager) UpsertState(ctx context.Context, name string, state
 				"metadata":   state.ObjectMeta,
 				"spec":       state.Spec,
 			},
-			ETag: state.ObjectMeta.Generation,
+			ETag: state.ObjectMeta.ETag,
 		},
 		Metadata: map[string]interface{}{
 			"namespace": state.ObjectMeta.Namespace,

--- a/api/pkg/apis/v1alpha1/managers/catalogs/catalogs-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/catalogs/catalogs-manager.go
@@ -102,7 +102,7 @@ func getCatalogState(body interface{}, etag string) (model.CatalogState, error) 
 	if catalogState.Spec == nil {
 		catalogState.Spec = &model.CatalogSpec{}
 	}
-	catalogState.ObjectMeta.Generation = etag
+	catalogState.ObjectMeta.ETag = etag
 	if catalogState.Status == nil {
 		catalogState.Status = &model.CatalogStatus{}
 	}

--- a/api/pkg/apis/v1alpha1/managers/catalogs/catalogs-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/catalogs/catalogs-manager.go
@@ -146,6 +146,7 @@ func (m *CatalogsManager) UpsertState(ctx context.Context, name string, state mo
 				"metadata":   state.ObjectMeta,
 				"spec":       state.Spec,
 			},
+			ETag: state.ObjectMeta.ETag,
 		},
 		Metadata: map[string]interface{}{
 			"namespace": state.ObjectMeta.Namespace,

--- a/api/pkg/apis/v1alpha1/managers/instances/instances-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/instances/instances-manager.go
@@ -106,15 +106,12 @@ func (t *InstancesManager) UpsertState(ctx context.Context, name string, state m
 		"metadata":   state.ObjectMeta,
 		"spec":       state.Spec,
 	}
-	generation := ""
-	if state.Spec != nil {
-		generation = state.ObjectMeta.ETag
-	}
+
 	upsertRequest := states.UpsertRequest{
 		Value: states.StateEntry{
 			ID:   name,
 			Body: body,
-			ETag: generation,
+			ETag: state.ObjectMeta.ETag,
 		},
 		Metadata: map[string]interface{}{
 			"namespace": state.ObjectMeta.Namespace,

--- a/api/pkg/apis/v1alpha1/managers/instances/instances-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/instances/instances-manager.go
@@ -108,7 +108,7 @@ func (t *InstancesManager) UpsertState(ctx context.Context, name string, state m
 	}
 	generation := ""
 	if state.Spec != nil {
-		generation = state.ObjectMeta.Generation
+		generation = state.ObjectMeta.ETag
 	}
 	upsertRequest := states.UpsertRequest{
 		Value: states.StateEntry{
@@ -175,7 +175,7 @@ func getInstanceState(body interface{}, etag string) (model.InstanceState, error
 	if instanceState.Spec == nil {
 		instanceState.Spec = &model.InstanceSpec{}
 	}
-	instanceState.ObjectMeta.Generation = etag
+	instanceState.ObjectMeta.ETag = etag
 	return instanceState, nil
 }
 

--- a/api/pkg/apis/v1alpha1/managers/stage/stage-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/stage/stage-manager.go
@@ -427,7 +427,7 @@ func (s *StageManager) HandleTriggerEvent(ctx context.Context, campaign model.Ca
 	defer observ_utils.CloseSpanWithError(span, &err)
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
 
-	log.InfoCtx(ctx, " M (Stage): HandleTriggerEvent for campaign %s, activation %s, stage %s", triggerData.Campaign, triggerData.Activation, triggerData.Stage)
+	log.InfofCtx(ctx, " M (Stage): HandleTriggerEvent for campaign %s, activation %s, stage %s", triggerData.Campaign, triggerData.Activation, triggerData.Stage)
 	status := model.StageStatus{
 		Stage:         triggerData.Stage,
 		NextStage:     "",
@@ -441,7 +441,7 @@ func (s *StageManager) HandleTriggerEvent(ctx context.Context, campaign model.Ca
 	if currentStage, ok := campaign.Stages[triggerData.Stage]; ok {
 		sites := make([]string, 0)
 		if currentStage.Contexts != "" {
-			log.InfoCtx(ctx, " M (Stage): evaluating context %s", currentStage.Contexts)
+			log.InfofCtx(ctx, " M (Stage): evaluating context %s", currentStage.Contexts)
 			parser := utils.NewParser(currentStage.Contexts)
 
 			eCtx := s.VendorContext.EvaluationContext.Clone()

--- a/api/pkg/apis/v1alpha1/managers/staging/staging-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/staging/staging-manager.go
@@ -101,7 +101,7 @@ func (s *StagingManager) Poll() []error {
 		}
 		var entry states.StateEntry
 		entry, err = s.StateProvider.Get(ctx, getRequest)
-		if err == nil && entry.Body != nil && entry.Body.(string) == catalog.ObjectMeta.Generation {
+		if err == nil && entry.Body != nil && entry.Body.(string) == catalog.ObjectMeta.ETag {
 			continue
 		}
 		if err != nil && !utils.IsNotFound(err) {
@@ -117,7 +117,7 @@ func (s *StagingManager) Poll() []error {
 		_, err = s.StateProvider.Upsert(ctx, states.UpsertRequest{
 			Value: states.StateEntry{
 				ID:   cacheId,
-				Body: catalog.ObjectMeta.Generation,
+				Body: catalog.ObjectMeta.ETag,
 			},
 			Metadata: map[string]interface{}{
 				"version":   "v1",

--- a/api/pkg/apis/v1alpha1/managers/targets/targets-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/targets/targets-manager.go
@@ -117,7 +117,7 @@ func (t *TargetsManager) UpsertState(ctx context.Context, name string, state mod
 		Value: states.StateEntry{
 			ID:   name,
 			Body: body,
-			ETag: state.ObjectMeta.Generation,
+			ETag: state.ObjectMeta.ETag,
 		},
 		Metadata: map[string]interface{}{
 			"namespace": state.ObjectMeta.Namespace,
@@ -238,7 +238,7 @@ func getTargetState(body interface{}, etag string) (model.TargetState, error) {
 	if targetState.Spec == nil {
 		targetState.Spec = &model.TargetSpec{}
 	}
-	targetState.ObjectMeta.Generation = etag
+	targetState.ObjectMeta.ETag = etag
 	return targetState, nil
 }
 

--- a/api/pkg/apis/v1alpha1/model/deployableStatus.go
+++ b/api/pkg/apis/v1alpha1/model/deployableStatus.go
@@ -8,11 +8,6 @@ package model
 
 import "time"
 
-const (
-	Generation string = "generation"
-	Status     string = "status"
-)
-
 type DeployableStatus struct {
 	Properties         map[string]string  `json:"properties,omitempty"`
 	ProvisioningStatus ProvisioningStatus `json:"provisioningStatus"`

--- a/api/pkg/apis/v1alpha1/model/deployableStatus.go
+++ b/api/pkg/apis/v1alpha1/model/deployableStatus.go
@@ -8,6 +8,11 @@ package model
 
 import "time"
 
+const (
+	Generation string = "generation"
+	Status     string = "status"
+)
+
 type DeployableStatus struct {
 	Properties         map[string]string  `json:"properties,omitempty"`
 	ProvisioningStatus ProvisioningStatus `json:"provisioningStatus"`

--- a/api/pkg/apis/v1alpha1/model/objectmeta_test.go
+++ b/api/pkg/apis/v1alpha1/model/objectmeta_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestObjectMetaWithString(t *testing.T) {
-	jsonString := `{"generation": "33"}`
+	jsonString := `{"etag": "33"}`
 
 	var newStage ObjectMeta
 	var err = json.Unmarshal([]byte(jsonString), &newStage)
@@ -20,13 +20,13 @@ func TestObjectMetaWithString(t *testing.T) {
 		t.Fatalf("Failed to unmarshal JSON: %v", err)
 	}
 	targetTime := "33"
-	if newStage.Generation != targetTime {
+	if newStage.ETag != targetTime {
 		t.Fatalf("Generation is not match: %v", err)
 	}
 }
 
 func TestObjectMetaWithNumber(t *testing.T) {
-	jsonString := `{"generation": 33}`
+	jsonString := `{"etag": 33}`
 
 	var newStage ObjectMeta
 	var err = json.Unmarshal([]byte(jsonString), &newStage)
@@ -34,7 +34,7 @@ func TestObjectMetaWithNumber(t *testing.T) {
 		t.Fatalf("Failed to unmarshal JSON: %v", err)
 	}
 	targetTime := "33"
-	if newStage.Generation != targetTime {
+	if newStage.ETag != targetTime {
 		t.Fatalf("Generation is not match: %v", err)
 	}
 }

--- a/api/pkg/apis/v1alpha1/providers/stage/create/create.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/create/create.go
@@ -19,6 +19,7 @@ import (
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/metrics"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/stage"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	api_utils "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
@@ -198,6 +199,24 @@ func (i *CreateStageProvider) Process(ctx context.Context, mgrContext contexts.M
 				mLog.ErrorfCtx(ctx, "  P (Create Stage) process failed, failed to delete instance: %+v", err)
 				return nil, false, err
 			}
+			for ic := 0; ic < i.Config.WaitCount; ic++ {
+				remainings := utils.FilterIncompleteDelete(ctx, &i.ApiClient, objectNamespace, []string{objectName}, true, i.Config.User, i.Config.Password)
+				if len(remainings) == 0 {
+					return outputs, false, nil
+				}
+				mLog.InfofCtx(ctx, "  P (Create Stage) process: Waiting for instance deletion: %+v", remainings)
+				time.Sleep(time.Duration(i.Config.WaitInterval) * time.Second)
+			}
+			providerOperationMetrics.ProviderOperationErrors(
+				create,
+				functionName,
+				metrics.ProcessOperation,
+				metrics.RunOperationType,
+				v1alpha2.DeploymentNotReached.String(),
+			)
+			err = v1alpha2.NewCOAError(nil, "Instance deletion reconcile timeout", v1alpha2.InternalError)
+			mLog.ErrorfCtx(ctx, "  P (Create Stage) process failed, error: %+v", err)
+			return nil, false, err
 		} else if strings.EqualFold(action, CreateAction) {
 			var instanceState model.InstanceState
 			err = json.Unmarshal(objectData, &instanceState)
@@ -259,15 +278,14 @@ func (i *CreateStageProvider) Process(ctx context.Context, mgrContext contexts.M
 				return nil, false, err
 			}
 			for ic := 0; ic < i.Config.WaitCount; ic++ {
-				var summary *model.SummaryResult
-				summary, err = i.ApiClient.GetSummary(ctx, objectName, objectNamespace, i.Config.User, i.Config.Password)
-				lastSummaryMessage = summary.Summary.SummaryMessage
-				if err != nil {
-					return nil, false, err
-				}
-				if summary.Summary.SuccessCount == summary.Summary.TargetCount {
+				remaining, failed := utils.FilterIncompleteDeploymentUsingSummary(ctx, &i.ApiClient, objectNamespace, []string{objectName}, true, i.Config.User, i.Config.Password)
+				if len(remaining) == 0 {
 					outputs["objectType"] = objectType
 					outputs["objectName"] = objectName
+					mLog.InfofCtx(ctx, "  P (Create Stage) process completed with fail count is %d", len(failed))
+					if len(failed) > 0 {
+						outputs["deploymentstatus"] = failed
+					}
 					return outputs, false, nil
 				}
 				time.Sleep(time.Duration(i.Config.WaitInterval) * time.Second)
@@ -283,7 +301,7 @@ func (i *CreateStageProvider) Process(ctx context.Context, mgrContext contexts.M
 			mLog.ErrorfCtx(ctx, "  P (Create Stage) process failed, error: %+v", err)
 			return nil, false, err
 		} else {
-			err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Unsupported action: %s", action), v1alpha2.InternalError)
+			err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Unsupported action: %s", action), v1alpha2.BadRequest)
 			providerOperationMetrics.ProviderOperationErrors(
 				create,
 				functionName,
@@ -295,7 +313,7 @@ func (i *CreateStageProvider) Process(ctx context.Context, mgrContext contexts.M
 			return nil, false, err
 		}
 	default:
-		err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Unsupported object type: %s", objectType), v1alpha2.InternalError)
+		err = v1alpha2.NewCOAError(nil, fmt.Sprintf("Unsupported object type: %s", objectType), v1alpha2.BadRequest)
 		mLog.ErrorfCtx(ctx, "  P (Create Stage) process failed, error: %+v", err)
 		providerOperationMetrics.ProviderOperationErrors(
 			create,

--- a/api/pkg/apis/v1alpha1/providers/stage/create/create.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/create/create.go
@@ -284,7 +284,7 @@ func (i *CreateStageProvider) Process(ctx context.Context, mgrContext contexts.M
 					outputs["objectName"] = objectName
 					mLog.InfofCtx(ctx, "  P (Create Stage) process completed with fail count is %d", len(failed))
 					if len(failed) > 0 {
-						outputs["deploymentstatus"] = failed
+						outputs["failedDeployment"] = failed
 					}
 					return outputs, false, nil
 				}

--- a/api/pkg/apis/v1alpha1/providers/stage/create/create_test.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/create/create_test.go
@@ -191,7 +191,8 @@ func TestCreateProcessRemove(t *testing.T) {
 		"action":     "remove",
 		"object":     instance,
 	})
-	assert.Nil(t, err)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Instance deletion reconcile timeout")
 }
 
 func TestCreateProcessUnsupported(t *testing.T) {
@@ -241,9 +242,11 @@ func InitializeMockSymphonyAPI() *httptest.Server {
 		case "/solution/queue":
 			response = model.SummaryResult{
 				Summary: model.SummarySpec{
-					TargetCount:  1,
-					SuccessCount: 1,
+					TargetCount:         1,
+					SuccessCount:        1,
+					AllAssignedDeployed: true,
 				},
+				State: model.SummaryStateDone,
 			}
 		default:
 			response = AuthResponse{

--- a/api/pkg/apis/v1alpha1/providers/stage/materialize/materialize.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/materialize/materialize.go
@@ -573,7 +573,7 @@ func (i *MaterializeStageProvider) Process(ctx context.Context, mgrContext conte
 	}
 	// Wait for deployment to finish
 	if i.Config.WaitForDeployment {
-		outputs["deploymentstatus"] = []api_utils.FailedDeployment{}
+		outputs["failedDeployment"] = []api_utils.FailedDeployment{}
 		timeout := time.After(i.Config.WaitTimeoutDuration)
 		ticker := time.NewTicker(10 * time.Second)
 		defer ticker.Stop()
@@ -583,9 +583,9 @@ func (i *MaterializeStageProvider) Process(ctx context.Context, mgrContext conte
 			case <-ticker.C:
 				var failed []api_utils.FailedDeployment
 				instanceList, failed = api_utils.FilterIncompleteDeploymentUsingSummary(ctx, &i.ApiClient, namespace, instanceList, true, i.Config.User, i.Config.Password)
-				outputs["deploymentstatus"] = append(outputs["deploymentstatus"].([]api_utils.FailedDeployment), failed...)
+				outputs["failedDeployment"] = append(outputs["failedDeployment"].([]api_utils.FailedDeployment), failed...)
 				targetList, failed = api_utils.FilterIncompleteDeploymentUsingSummary(ctx, &i.ApiClient, namespace, targetList, false, i.Config.User, i.Config.Password)
-				outputs["deploymentstatus"] = append(outputs["deploymentstatus"].([]api_utils.FailedDeployment), failed...)
+				outputs["failedDeployment"] = append(outputs["failedDeployment"].([]api_utils.FailedDeployment), failed...)
 				if len(instanceList) == 0 && len(targetList) == 0 {
 					break ForLoop
 				}

--- a/api/pkg/apis/v1alpha1/providers/states/k8s/k8s.go
+++ b/api/pkg/apis/v1alpha1/providers/states/k8s/k8s.go
@@ -408,15 +408,15 @@ func (s *K8sStateProvider) List(ctx context.Context, request states.ListRequest)
 				}
 			}
 
-			generation := v.GetGeneration()
 			metadata := model.ObjectMeta{
-				Name:        v.GetName(),
-				Namespace:   v.GetNamespace(),
-				Labels:      v.GetLabels(),
-				Annotations: v.GetAnnotations(),
+				Name:          v.GetName(),
+				Namespace:     v.GetNamespace(),
+				Labels:        v.GetLabels(),
+				Annotations:   v.GetAnnotations(),
+				ObjGeneration: v.GetGeneration(),
 			}
 			entry := states.StateEntry{
-				ETag: strconv.FormatInt(generation, 10),
+				ETag: v.GetResourceVersion(),
 				ID:   v.GetName(),
 				Body: map[string]interface{}{
 					"spec":     v.Object["spec"],
@@ -508,18 +508,18 @@ func (s *K8sStateProvider) Get(ctx context.Context, request states.GetRequest) (
 		sLog.ErrorfCtx(ctx, "  P (K8s State) %v", coaError.Error())
 		return states.StateEntry{}, coaError
 	}
-	generation := item.GetGeneration()
 
 	metadata := model.ObjectMeta{
-		Name:        item.GetName(),
-		Namespace:   item.GetNamespace(),
-		Labels:      item.GetLabels(),
-		Annotations: item.GetAnnotations(),
+		Name:          item.GetName(),
+		Namespace:     item.GetNamespace(),
+		Labels:        item.GetLabels(),
+		Annotations:   item.GetAnnotations(),
+		ObjGeneration: item.GetGeneration(),
 	}
 
 	ret := states.StateEntry{
 		ID:   request.ID,
-		ETag: strconv.FormatInt(generation, 10),
+		ETag: item.GetResourceVersion(),
 		Body: map[string]interface{}{
 			"spec":     item.Object["spec"],
 			"status":   item.Object["status"],

--- a/api/pkg/apis/v1alpha1/utils/symphony-api.go
+++ b/api/pkg/apis/v1alpha1/utils/symphony-api.go
@@ -711,7 +711,7 @@ func CreateSymphonyDeploymentFromTarget(ctx context.Context, target model.Target
 	ret.Targets = targets
 	ret.SolutionName = key
 	// set the target generation to the deployment
-	ret.Generation = target.ObjectMeta.Generation
+	ret.Generation = target.ObjectMeta.ETag
 	assignments, err := AssignComponentsToTargets(ctx, ret.Solution.Spec.Components, ret.Targets)
 	if err != nil {
 		return ret, err
@@ -730,7 +730,7 @@ func CreateSymphonyDeployment(ctx context.Context, instance model.InstanceState,
 	ret := model.DeploymentSpec{
 		ObjectNamespace: namespace,
 	}
-	ret.Generation = instance.ObjectMeta.Generation
+	ret.Generation = instance.ObjectMeta.ETag
 
 	// convert targets
 	sTargets := make(map[string]model.TargetState)

--- a/api/pkg/apis/v1alpha1/utils/utils.go
+++ b/api/pkg/apis/v1alpha1/utils/utils.go
@@ -8,6 +8,7 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -17,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/eclipse-symphony/symphony/api/constants"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	coa_utils "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/utils"
 	"github.com/itchyny/gojq"
@@ -448,4 +450,88 @@ func AreSlicesEqual(slice1, slice2 []string) bool {
 	}
 
 	return true
+}
+
+type FailedDeployment struct {
+	Name    string `json:"name"`
+	Message string `json:"FailedMessage"`
+}
+
+// Once status report is enabled in standalone mode, we need to use object status rather than summary to check the deployment status
+func FilterIncompleteDeploymentUsingStatus(ctx context.Context, apiclient *ApiClient, namespace string, objectNames []string, isInstance bool, username string, password string) ([]string, []FailedDeployment) {
+	remainingObjects := make([]string, 0)
+	failedDeployments := make([]FailedDeployment, 0)
+	var err error
+	var objectMeta model.ObjectMeta
+	var status model.DeployableStatus
+	for _, objectName := range objectNames {
+		if isInstance {
+			var state model.InstanceState
+			state, err = (*apiclient).GetInstance(ctx, objectName, namespace, username, password)
+			objectMeta = state.ObjectMeta
+			status = state.Status
+		} else {
+			var state model.TargetState
+			state, err = (*apiclient).GetTarget(ctx, objectName, namespace, username, password)
+			objectMeta = state.ObjectMeta
+			status = state.Status
+		}
+		// TODO: check error code
+		if err != nil {
+			remainingObjects = append(remainingObjects, objectName)
+			continue
+		}
+		if status.Properties == nil || status.Properties[constants.Generation] != strconv.FormatInt(objectMeta.ObjGeneration, 10) ||
+			(status.Properties[constants.Status] != "Succeeded" && status.Properties[constants.Status] != "Failed") {
+			remainingObjects = append(remainingObjects, objectName)
+		} else if status.Properties[constants.Status] == "Failed" {
+			failedDeployments = append(failedDeployments, FailedDeployment{Name: objectName, Message: status.Properties["status-details"]})
+		}
+	}
+	return remainingObjects, failedDeployments
+}
+
+func FilterIncompleteDeploymentUsingSummary(ctx context.Context, apiclient *ApiClient, namespace string, objectNames []string, isInstance bool, username string, password string) ([]string, []FailedDeployment) {
+	remainingObjects := make([]string, 0)
+	failedDeployments := make([]FailedDeployment, 0)
+	var err error
+	for _, objectName := range objectNames {
+		var key string
+		if isInstance {
+			key = objectName
+		} else {
+			key = fmt.Sprintf("target-runtime-%s", objectName)
+		}
+		var summary *model.SummaryResult
+		summary, err = (*apiclient).GetSummary(ctx, key, namespace, username, password)
+		if err == nil && summary.State == model.SummaryStateDone {
+			log.DebugfCtx(ctx, "Summary for %s is %v", objectName, summary.Summary)
+			if !summary.Summary.AllAssignedDeployed {
+				log.DebugfCtx(ctx, "Summary for %s is not fully deployed with error %s", objectName, summary.Summary.SummaryMessage)
+				failedDeployments = append(failedDeployments, FailedDeployment{Name: objectName, Message: summary.Summary.SummaryMessage})
+			}
+			continue
+		}
+		remainingObjects = append(remainingObjects, objectName)
+	}
+	return remainingObjects, failedDeployments
+}
+
+func FilterIncompleteDelete(ctx context.Context, apiclient *ApiClient, namespace string, objectNames []string, isInstance bool, username string, password string) []string {
+	remainingObjects := make([]string, 0)
+	var err error
+	for _, objectName := range objectNames {
+		if isInstance {
+			_, err = (*apiclient).GetInstance(ctx, objectName, namespace, username, password)
+
+		} else {
+			_, err = (*apiclient).GetTarget(ctx, objectName, namespace, username, password)
+		}
+		//if err != nil && IsNotFound(err) {
+		if err != nil && strings.Contains(err.Error(), "Not Found") {
+			continue
+		}
+		remainingObjects = append(remainingObjects, objectName)
+	}
+	return remainingObjects
 }

--- a/api/pkg/apis/v1alpha1/vendors/activations-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/activations-vendor.go
@@ -214,7 +214,7 @@ func (c *ActivationsVendor) onActivations(request v1alpha2.COARequest) v1alpha2.
 			c.Context.Publish("activation", v1alpha2.Event{
 				Body: v1alpha2.ActivationData{
 					Campaign:             activation.Spec.Campaign,
-					ActivationGeneration: entry.ObjectMeta.Generation,
+					ActivationGeneration: entry.ObjectMeta.ETag,
 					Activation:           id,
 					Stage:                activation.Spec.Stage,
 					Inputs:               activation.Spec.Inputs,

--- a/docs/samples/campaigns/create/activation.yaml
+++ b/docs/samples/campaigns/create/activation.yaml
@@ -1,0 +1,6 @@
+apiVersion: workflow.symphony/v1
+kind: Activation
+metadata:
+  name: create-activation
+spec:
+  campaign: "create-campaign:v1"

--- a/docs/samples/campaigns/create/campaign.yaml
+++ b/docs/samples/campaigns/create/campaign.yaml
@@ -1,0 +1,32 @@
+apiVersion: workflow.symphony/v1
+kind: CampaignContainer
+metadata:
+  name: create-campaign
+spec:  
+---
+apiVersion: workflow.symphony/v1
+kind: Campaign
+metadata:
+  name: create-campaign-v-v1
+spec:
+  rootResource: create-campaign
+  firstStage: "create"
+  selfDriving: true
+  stages:
+    create:
+      name: "create"
+      provider: "providers.stage.create"      
+      config:
+        wait.count: 10
+        wait.interval: 20
+      inputs:
+        action: "create"
+        objectName: "site-instance"
+        objectType: "instance"
+        object:
+          metadata: 
+            name: site-instance
+          spec: 
+            solution: site-app:v1
+            target:
+              name: site-k8s-target

--- a/docs/samples/campaigns/create/solutions.yaml
+++ b/docs/samples/campaigns/create/solutions.yaml
@@ -1,0 +1,22 @@
+apiVersion: solution.symphony/v1
+kind: SolutionContainer
+metadata:
+  name: site-app
+spec:
+---
+apiVersion: solution.symphony/v1
+kind: Solution
+metadata:
+  name: site-app-v-v1
+spec:
+  rootResource: site-app
+  components:
+  - name: web-app
+    type: container
+    metadata:
+      service.ports: "[{\"name\":\"port3011\",\"port\": 3011,\"targetPort\":5000}]"
+      service.type: "NodePort"
+    properties:
+      deployment.replicas: "#1"
+      container.ports: "[{\"containerPort\":5000,\"protocol\":\"TCP\"}]"
+      container.image: "ghcr.io/eclipse-symphony/sample-flask-app:latest"

--- a/docs/samples/campaigns/create/targets.yaml
+++ b/docs/samples/campaigns/create/targets.yaml
@@ -1,0 +1,18 @@
+apiVersion: fabric.symphony/v1
+kind: Target
+metadata: 
+  name: site-k8s-target
+spec:
+  properties:
+    group: site
+  topologies:
+  - bindings:        
+    - role: yaml.k8s
+      provider: providers.target.kubectl
+      config:
+        inCluster: "true"
+    - role: instance
+      provider: providers.target.k8s
+      config:
+        inCluster: "true"   
+        deploymentStrategy: "services"

--- a/k8s/apis/solution/v1/instance_webhook.go
+++ b/k8s/apis/solution/v1/instance_webhook.go
@@ -95,7 +95,7 @@ var _ webhook.Defaulter = &Instance{}
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Instance) Default() {
 	ctx := diagnostic.ConstructDiagnosticContextFromAnnotations(r.Annotations, context.TODO(), instancelog)
-	diagnostic.InfoWithCtx(instancelog, ctx, "default", "name", r.Name, "namespace", r.Namespace, "spec", r.Spec, "status", r.Status)
+	diagnostic.InfoWithCtx(instancelog, ctx, "default", "name", r.Name, "namespace", r.Namespace, "spec", r.Spec, "status", r.Status, "annotation", r.Annotations)
 	if r.Spec.DisplayName == "" {
 		r.Spec.DisplayName = r.ObjectMeta.Name
 	}

--- a/k8s/reconcilers/deployment.go
+++ b/k8s/reconcilers/deployment.go
@@ -560,6 +560,10 @@ func (r *DeploymentReconciler) patchBasicStatusProps(ctx context.Context, object
 		}
 	}()
 
+	if summaryResult != nil {
+		objectStatus.Properties[model.Generation] = summaryResult.Generation
+	}
+
 	if opts.terminalErr != nil {
 		objectStatus.Properties["deployed"] = "failed"
 		objectStatus.Properties["targets"] = "failed"

--- a/k8s/reconcilers/deployment.go
+++ b/k8s/reconcilers/deployment.go
@@ -24,6 +24,7 @@ import (
 	"gopls-workspace/utils/diagnostic"
 	utilsmodel "gopls-workspace/utils/model"
 
+	apiconstants "github.com/eclipse-symphony/symphony/api/constants"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	apimodel "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	api_utils "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
@@ -561,7 +562,7 @@ func (r *DeploymentReconciler) patchBasicStatusProps(ctx context.Context, object
 	}()
 
 	if summaryResult != nil {
-		objectStatus.Properties[model.Generation] = summaryResult.Generation
+		objectStatus.Properties[apiconstants.Generation] = summaryResult.Generation
 	}
 
 	if opts.terminalErr != nil {

--- a/test/integration/scenarios/04.workflow/manifest/campaign.yaml
+++ b/test/integration/scenarios/04.workflow/manifest/campaign.yaml
@@ -42,6 +42,8 @@ spec:
         baseUrl: http://symphony-service:8080/v1alpha2/
         user: admin
         password: ""
+        waitForDeployment: true
+        WaitTimeout: 10m
       inputs:
         names: "${{$output(list,items)}}"
   selfDriving: true


### PR DESCRIPTION
- Materialize stage provider can be configured to wait for solution deployment on instances or targets in k8s mode. (standalone mode is not supported since standalone mode doesn't have status report mechanism right now and object generation is not bumped except in k8s state store).
   -  k8s write generation along with status 
   - materialize check status and generation
- Use different field for Etag and Generation in ObjectMeta.
  - Etag is like ResourceVersion in k8s which changes every time when there is change on object including status
  - Generation is like Generation in k8s which changes every time when object spec changes

This change depends on https://github.com/eclipse-symphony/symphony/pull/465

sample status for error case:
<img width="494" alt="image" src="https://github.com/user-attachments/assets/c0d354bc-775d-4984-a25d-7891e80119b8">

