### PR TITLE
[release/pp1] workaround: setup-envtest version set to be 0.19 (#514)

### DIFF
--- a/k8s/magefile.go
+++ b/k8s/magefile.go
@@ -31,7 +31,7 @@ var (
 
 	envTest = bintool.Must(bintool.NewGo(
 		"sigs.k8s.io/controller-runtime/tools/setup-envtest",
-		"latest",
+		"release-0.19",
 	))
 
 	kustomize = bintool.Must(bintool.New(


### PR DESCRIPTION
cherry-pick https://github.com/eclipse-symphony/symphony/commit/d4d4a3f3dcbfda334c8ec0cd7ce267685fcce943 to pp1 release branch