### PR TITLE
Block solution deployment with old generation

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/solution/solution-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/solution/solution-manager.go
@@ -288,14 +288,6 @@ func (s *SolutionManager) Reconcile(ctx context.Context, deployment model.Deploy
 	lock.Lock()
 	defer lock.Unlock()
 
-	defer func() {
-		s.cleanupHeartbeat(ctx, deployment.Instance.ObjectMeta.Name, namespace, remove)
-	}()
-
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	go s.sendHeartbeat(ctx, deployment.Instance.ObjectMeta.Name, namespace, remove, stopCh)
-
 	ctx, span := observability.StartSpan("Solution Manager", ctx, &map[string]string{
 		"method": "Reconcile",
 	})
@@ -325,7 +317,11 @@ func (s *SolutionManager) Reconcile(ctx context.Context, deployment model.Deploy
 	}
 	summary.IsRemoval = remove
 
-	s.saveSummaryProgress(ctx, deployment.Instance.ObjectMeta.Name, deployment.Generation, deployment.Hash, summary, namespace)
+	err = s.saveSummaryProgress(ctx, deployment.Instance.ObjectMeta.Name, deployment.Generation, deployment.Hash, summary, namespace)
+	if err != nil {
+		log.ErrorfCtx(ctx, " M (Solution): failed to save summary progress: %+v", err)
+		return summary, err
+	}
 	defer func() {
 		log.DebugfCtx(ctx, " M (Solution): Reconcile conclude Summary. Namespace: %v, deployment instance: %v, summary message: %v", namespace, deployment.Instance, summary.SummaryMessage)
 		if deployment.IsDryRun {
@@ -333,6 +329,14 @@ func (s *SolutionManager) Reconcile(ctx context.Context, deployment model.Deploy
 		}
 		s.concludeSummary(ctx, deployment.Instance.ObjectMeta.Name, deployment.Generation, deployment.Hash, summary, namespace)
 	}()
+
+	defer func() {
+		s.cleanupHeartbeat(ctx, deployment.Instance.ObjectMeta.Name, namespace, remove)
+	}()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go s.sendHeartbeat(ctx, deployment.Instance.ObjectMeta.Name, namespace, remove, stopCh)
 
 	// get the components count for the deployment
 	componentCount := len(deployment.Solution.Spec.Components)
@@ -407,7 +411,11 @@ func (s *SolutionManager) Reconcile(ctx context.Context, deployment model.Deploy
 		summary.PlannedDeployment += len(step.Components)
 	}
 	summary.CurrentDeployed = 0
-	s.saveSummaryProgress(ctx, deployment.Instance.ObjectMeta.Name, deployment.Generation, deployment.Hash, summary, namespace)
+	err = s.saveSummaryProgress(ctx, deployment.Instance.ObjectMeta.Name, deployment.Generation, deployment.Hash, summary, namespace)
+	if err != nil {
+		log.ErrorfCtx(ctx, " M (Solution): failed to save summary progress: %+v", err)
+		return summary, err
+	}
 	log.DebugfCtx(ctx, " M (Solution): reconcile save summary progress: start deploy, total %v deployments", summary.PlannedDeployment)
 
 	plannedCount := 0
@@ -498,7 +506,11 @@ func (s *SolutionManager) Reconcile(ctx context.Context, deployment model.Deploy
 				targetResult[step.Target] = 1
 				summary.AllAssignedDeployed = plannedCount == planSuccessCount
 				summary.UpdateTargetResult(step.Target, model.TargetResultSpec{Status: "OK", Message: "", ComponentResults: componentResults})
-				s.saveSummaryProgress(ctx, deployment.Instance.ObjectMeta.Name, deployment.Generation, deployment.Hash, summary, namespace)
+				err = s.saveSummaryProgress(ctx, deployment.Instance.ObjectMeta.Name, deployment.Generation, deployment.Hash, summary, namespace)
+				if err != nil {
+					log.ErrorfCtx(ctx, " M (Solution): failed to save summary progress: %+v", err)
+					return summary, err
+				}
 				break
 			} else {
 				targetResult[step.Target] = 0
@@ -524,7 +536,11 @@ func (s *SolutionManager) Reconcile(ctx context.Context, deployment model.Deploy
 		}
 		planSuccessCount++
 		summary.CurrentDeployed += len(step.Components)
-		s.saveSummaryProgress(ctx, deployment.Instance.ObjectMeta.Name, deployment.Generation, deployment.Hash, summary, namespace)
+		err = s.saveSummaryProgress(ctx, deployment.Instance.ObjectMeta.Name, deployment.Generation, deployment.Hash, summary, namespace)
+		if err != nil {
+			log.ErrorfCtx(ctx, " M (Solution): failed to save summary progress: %+v", err)
+			return summary, err
+		}
 		log.DebugfCtx(ctx, " M (Solution): reconcile save summary progress: current deployed %v out of total %v deployments", summary.PlannedDeployment, summary.CurrentDeployed)
 	}
 
@@ -591,11 +607,29 @@ func (s *SolutionManager) getTargetStateForStep(step model.DeploymentStep, deplo
 	return targetSpec
 }
 
-func (s *SolutionManager) saveSummary(ctx context.Context, objectName string, generation string, hash string, summary model.SummarySpec, state model.SummaryState, namespace string) {
+func (s *SolutionManager) saveSummary(ctx context.Context, objectName string, generation string, hash string, summary model.SummarySpec, state model.SummaryState, namespace string) error {
 	// TODO: delete this state when time expires. This should probably be invoked by the vendor (via GetSummary method, for instance)
-	log.DebugfCtx(ctx, " M (Solution): saving summary, objectName: %s, state: %s, namespace: %s, targetCount %d, successCount %d",
-		objectName, state, namespace, summary.TargetCount, summary.SuccessCount)
-	s.StateProvider.Upsert(ctx, states.UpsertRequest{
+	log.DebugfCtx(ctx, " M (Solution): saving summary, objectName: %s, state: %s, namespace: %s, jobid: %s, hash %s, targetCount %d, successCount %d",
+		objectName, state, namespace, summary.JobID, hash, summary.TargetCount, summary.SuccessCount)
+	oldSummary, err := s.GetSummary(ctx, objectName, namespace)
+	if err != nil && !v1alpha2.IsNotFound(err) {
+		log.ErrorfCtx(ctx, " M (Solution): failed to get previous summary: %+v", err)
+		return err
+	} else if err == nil {
+		var newId, oldId int64
+		newId, err = strconv.ParseInt(summary.JobID, 10, 64)
+		if err != nil {
+			log.ErrorfCtx(ctx, " M (Solution): failed to parse new job id: %+v", err)
+			return v1alpha2.NewCOAError(err, "failed to parse new job id", v1alpha2.BadRequest)
+		}
+		oldId, err = strconv.ParseInt(oldSummary.Summary.JobID, 10, 64)
+		if err == nil && oldId > newId {
+			errMsg := fmt.Sprintf("old job id %d is greater than new job id %d", oldId, newId)
+			log.ErrorfCtx(ctx, " M (Solution): %s", errMsg)
+			return v1alpha2.NewCOAError(err, errMsg, v1alpha2.BadRequest)
+		}
+	}
+	_, err = s.StateProvider.Upsert(ctx, states.UpsertRequest{
 		Value: states.StateEntry{
 			ID: fmt.Sprintf("%s-%s", "summary", objectName),
 			Body: model.SummaryResult{
@@ -613,14 +647,15 @@ func (s *SolutionManager) saveSummary(ctx context.Context, objectName string, ge
 			"resource":  Summary,
 		},
 	})
+	return err
 }
 
-func (s *SolutionManager) saveSummaryProgress(ctx context.Context, objectName string, generation string, hash string, summary model.SummarySpec, namespace string) {
-	s.saveSummary(ctx, objectName, generation, hash, summary, model.SummaryStateRunning, namespace)
+func (s *SolutionManager) saveSummaryProgress(ctx context.Context, objectName string, generation string, hash string, summary model.SummarySpec, namespace string) error {
+	return s.saveSummary(ctx, objectName, generation, hash, summary, model.SummaryStateRunning, namespace)
 }
 
-func (s *SolutionManager) concludeSummary(ctx context.Context, objectName string, generation string, hash string, summary model.SummarySpec, namespace string) {
-	s.saveSummary(ctx, objectName, generation, hash, summary, model.SummaryStateDone, namespace)
+func (s *SolutionManager) concludeSummary(ctx context.Context, objectName string, generation string, hash string, summary model.SummarySpec, namespace string) error {
+	return s.saveSummary(ctx, objectName, generation, hash, summary, model.SummaryStateDone, namespace)
 }
 
 func (s *SolutionManager) canSkipStep(ctx context.Context, step model.DeploymentStep, target string, provider tgt.ITargetProvider, currentComponents []model.ComponentSpec, state model.DeploymentState) bool {

--- a/api/pkg/apis/v1alpha1/managers/solution/solution-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/solution/solution-manager.go
@@ -616,17 +616,21 @@ func (s *SolutionManager) saveSummary(ctx context.Context, objectName string, ge
 		log.ErrorfCtx(ctx, " M (Solution): failed to get previous summary: %+v", err)
 		return err
 	} else if err == nil {
-		var newId, oldId int64
-		newId, err = strconv.ParseInt(summary.JobID, 10, 64)
-		if err != nil {
-			log.ErrorfCtx(ctx, " M (Solution): failed to parse new job id: %+v", err)
-			return v1alpha2.NewCOAError(err, "failed to parse new job id", v1alpha2.BadRequest)
-		}
-		oldId, err = strconv.ParseInt(oldSummary.Summary.JobID, 10, 64)
-		if err == nil && oldId > newId {
-			errMsg := fmt.Sprintf("old job id %d is greater than new job id %d", oldId, newId)
-			log.ErrorfCtx(ctx, " M (Solution): %s", errMsg)
-			return v1alpha2.NewCOAError(err, errMsg, v1alpha2.BadRequest)
+		if summary.JobID != "" && oldSummary.Summary.JobID != "" {
+			var newId, oldId int64
+			newId, err = strconv.ParseInt(summary.JobID, 10, 64)
+			if err != nil {
+				log.ErrorfCtx(ctx, " M (Solution): failed to parse new job id: %+v", err)
+				return v1alpha2.NewCOAError(err, "failed to parse new job id", v1alpha2.BadRequest)
+			}
+			oldId, err = strconv.ParseInt(oldSummary.Summary.JobID, 10, 64)
+			if err == nil && oldId > newId {
+				errMsg := fmt.Sprintf("old job id %d is greater than new job id %d", oldId, newId)
+				log.ErrorfCtx(ctx, " M (Solution): %s", errMsg)
+				return v1alpha2.NewCOAError(err, errMsg, v1alpha2.BadRequest)
+			}
+		} else {
+			log.WarnfCtx(ctx, " M (Solution): JobIDs are both empty, skip id check")
 		}
 	}
 	_, err = s.StateProvider.Upsert(ctx, states.UpsertRequest{


### PR DESCRIPTION
Why this change:
Redis pubsub can have multiple workers so it is possible that two versions of Deployment on the same object are kicked off very closely. And sometimes the newer version gets the reconcile lock before the old one. In this case, the old one should not run reconcile as it's out of date. We use deployment generation to check that.

This change includes:
1. Re-define the generation in deployment as a combination of instance generation, solution generation and target generation. If the instance is linked more than one target, the target generation is the sum of all target generations. (It's very unlikely that the sum is greater than int64)
2. solution reconcile in symphony API check the generation of current deployment and the existing summary. 