### PR TITLE
Remove silent/quite from curl/wget at install.sh

### DIFF
--- a/cli/install/install.sh
+++ b/cli/install/install.sh
@@ -119,9 +119,9 @@ downloadFile() {
 
     echo "Downloading $DOWNLOAD_URL ..."
     if [ "$SYMPHONY_HTTP_REQUEST_CLI" == "curl" ]; then
-        curl -SsL "$DOWNLOAD_URL" -o "$ARTIFACT_TMP_FILE"
+        curl -SL "$DOWNLOAD_URL" -o "$ARTIFACT_TMP_FILE"
     else
-        wget -q -O "$ARTIFACT_TMP_FILE" "$DOWNLOAD_URL"
+        wget -O "$ARTIFACT_TMP_FILE" "$DOWNLOAD_URL"
     fi
 
     if [ ! -f "$ARTIFACT_TMP_FILE" ]; then


### PR DESCRIPTION
When following [basic installation instructions](https://github.com/Eclipse-SDV-Hackathon-Chapter-Two/challenge-maestro/blob/main/eclipse-symphony/README.md#installing-symphony) at a slow network, it is not clear, what happens if the screen doesn't show any progress within seconds. Therefore, I unsilenced wget/curl.