### PR TITLE
Discord link change to #welcome channel

### DIFF
--- a/landing/config/_default/params.toml
+++ b/landing/config/_default/params.toml
@@ -26,7 +26,7 @@ preloader = "" # use jpg, png, svg or gif format.
 [navigation_button]
 enable = true
 label = "Join Our Discord"
-link = "https://discord.gg/JvY8qBkWbw"
+link = "https://discord.gg/RcjSrR7JAE"
 
 # cookies
 [cookies]


### PR DESCRIPTION
Changed the discord link to redirect to the appropriate channel.