### PR TITLE
update site object with ETag

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/sites/sites-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/sites/sites-manager_test.go
@@ -22,7 +22,7 @@ func TestCreateGetDeleteTargetsSpec(t *testing.T) {
 	manager := SitesManager{
 		StateProvider: stateProvider,
 	}
-	err := manager.UpsertSpec(context.Background(), "test", model.SiteSpec{})
+	err := manager.UpsertState(context.Background(), "test", model.SiteState{})
 	assert.Nil(t, err)
 	spec, err := manager.GetState(context.Background(), "test")
 	assert.Nil(t, err)

--- a/api/pkg/apis/v1alpha1/model/site.go
+++ b/api/pkg/apis/v1alpha1/model/site.go
@@ -13,10 +13,10 @@ import (
 )
 
 type SiteState struct {
-	Id       string                 `json:"id"`
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
-	Spec     *SiteSpec              `json:"spec,omitempty"`
-	Status   *SiteStatus            `json:"status,omitempty"`
+	Id         string      `json:"id"`
+	ObjectMeta ObjectMeta  `json:"metadata,omitempty"`
+	Spec       *SiteSpec   `json:"spec,omitempty"`
+	Status     *SiteStatus `json:"status,omitempty"`
 }
 type SiteTargetStatus struct {
 	State  v1alpha2.State `json:"state,omitempty"`

--- a/api/pkg/apis/v1alpha1/vendors/federation-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/federation-vendor.go
@@ -160,12 +160,26 @@ func (f *FederationVendor) Init(config vendors.VendorConfig, factories []manager
 			return nil
 		},
 	})
-	//now register the current site
-	return f.SitesManager.UpsertSpec(context.Background(), f.Context.SiteInfo.SiteId, model.SiteSpec{
-		Name:       f.Context.SiteInfo.SiteId,
-		Properties: f.Context.SiteInfo.Properties,
-		IsSelf:     true,
-	})
+	// now register the current site
+	site := model.SiteState{
+		Id: f.Context.SiteInfo.SiteId,
+		ObjectMeta: model.ObjectMeta{
+			Name: f.Context.SiteInfo.SiteId,
+		},
+		Spec: &model.SiteSpec{
+			Name:       f.Context.SiteInfo.SiteId,
+			Properties: f.Context.SiteInfo.Properties,
+			IsSelf:     true,
+		},
+	}
+	oldSite, err := f.SitesManager.GetState(context.Background(), f.Context.SiteInfo.SiteId)
+	if err != nil && !utils.IsNotFound(err) {
+		return v1alpha2.NewCOAError(err, "Get previous site state failed", v1alpha2.InternalError)
+	} else if err == nil {
+		site.ObjectMeta.UpdateEtag(oldSite.ObjectMeta.ETag)
+	}
+
+	return f.SitesManager.UpsertState(context.Background(), f.Context.SiteInfo.SiteId, site)
 }
 func (f *FederationVendor) GetEndpoints() []v1alpha2.Endpoint {
 	route := "federation"
@@ -286,11 +300,10 @@ func (f *FederationVendor) onRegistry(request v1alpha2.COARequest) v1alpha2.COAR
 		}
 		return resp
 	case fasthttp.MethodPost:
-		// TODO: POST federation/registry need to pass SiteState as request body
 		ctx, span := observability.StartSpan("onRegistry-POST", pCtx, nil)
 		id := request.Parameters["__name"]
 
-		var site model.SiteSpec
+		var site model.SiteState
 		err := json.Unmarshal(request.Body, &site)
 		if err != nil {
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
@@ -299,7 +312,7 @@ func (f *FederationVendor) onRegistry(request v1alpha2.COARequest) v1alpha2.COAR
 			})
 		}
 		//TODO: generate site key pair as needed
-		err = f.SitesManager.UpsertSpec(ctx, id, site)
+		err = f.SitesManager.UpsertState(ctx, id, site)
 		if err != nil {
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{
 				State: v1alpha2.InternalError,


### PR DESCRIPTION
Currently, site object does not preserve ETag or resource version. This will trigger k8s error if pod crashes and tries to restart because the object has no resource version and update request will fail.
Add `ObjectMeta` to site object to maintain ETag and resource version.