### PR TITLE
Get state before upsert to set resource version correct

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/sites/sites-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/sites/sites-manager.go
@@ -186,8 +186,6 @@ func (m *SitesManager) UpsertState(ctx context.Context, name string, state model
 		state.ObjectMeta.PreserveSystemMetadata(oldState.ObjectMeta)
 	}
 
-	log.InfofCtx(ctx, "Site state %+v", state)
-
 	upsertRequest := states.UpsertRequest{
 		Value: states.StateEntry{
 			ID: name,

--- a/api/pkg/apis/v1alpha1/vendors/activations-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/activations-vendor.go
@@ -187,6 +187,12 @@ func (c *ActivationsVendor) onActivations(request v1alpha2.COARequest) v1alpha2.
 			})
 		}
 
+		oldState, err := c.ActivationsManager.GetState(ctx, id, namespace)
+		if err == nil {
+			// Need to assign ETag to the new state
+			activation.ObjectMeta.UpdateEtag(oldState.ObjectMeta.ETag)
+		}
+
 		err = c.ActivationsManager.UpsertState(ctx, id, activation)
 		if err != nil {
 			vLog.ErrorfCtx(ctx, "V (Activations Vendor): onActivations failed - %s", err.Error())

--- a/api/pkg/apis/v1alpha1/vendors/campaigns-container-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/campaigns-container-vendor.go
@@ -126,7 +126,13 @@ func (c *CampaignContainersVendor) onCampaignContainers(request v1alpha2.COARequ
 			Spec: &model.CampaignContainerSpec{},
 		}
 
-		err := c.CampaignContainersManager.UpsertState(ctx, id, campaign)
+		oldState, err := c.CampaignContainersManager.GetState(ctx, id, namespace)
+		if err == nil {
+			// Need to assign ETag to the new state
+			campaign.ObjectMeta.UpdateEtag(oldState.ObjectMeta.ETag)
+		}
+
+		err = c.CampaignContainersManager.UpsertState(ctx, id, campaign)
 		if err != nil {
 			ccLog.InfofCtx(ctx, "V (CampaignContainers): onCampaignContainers failed - %s", err.Error())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{

--- a/api/pkg/apis/v1alpha1/vendors/campaigns-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/campaigns-vendor.go
@@ -128,6 +128,12 @@ func (c *CampaignsVendor) onCampaigns(request v1alpha2.COARequest) v1alpha2.COAR
 			})
 		}
 
+		oldState, err := c.CampaignsManager.GetState(ctx, id, namespace)
+		if err == nil {
+			// Need to assign ETag to the new state
+			campaign.ObjectMeta.UpdateEtag(oldState.ObjectMeta.ETag)
+		}
+
 		err = c.CampaignsManager.UpsertState(ctx, id, campaign)
 		if err != nil {
 			cLog.ErrorfCtx(ctx, "V (Campaigns): onCampaigns failed - %s", err.Error())

--- a/api/pkg/apis/v1alpha1/vendors/catalogs-container-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/catalogs-container-vendor.go
@@ -133,6 +133,12 @@ func (c *CatalogContainersVendor) onCatalogContainers(request v1alpha2.COAReques
 		catalogContainer.ObjectMeta.Namespace = namespace
 		catalogContainer.Spec = &model.CatalogContainerSpec{}
 
+		oldState, err := c.CatalogContainersManager.GetState(ctx, id, namespace)
+		if err == nil {
+			// Need to assign ETag to the new state
+			catalogContainer.ObjectMeta.UpdateEtag(oldState.ObjectMeta.ETag)
+		}
+
 		err = c.CatalogContainersManager.UpsertState(ctx, id, catalogContainer)
 		if err != nil {
 			ctLog.ErrorfCtx(ctx, "V (CatalogContainers): onCatalogContainers failed - %s", err.Error())

--- a/api/pkg/apis/v1alpha1/vendors/devices-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/devices-vendor.go
@@ -130,6 +130,11 @@ func (c *DevicesVendor) onDevices(request v1alpha2.COARequest) v1alpha2.COARespo
 			})
 		}
 
+		oldState, err := c.DevicesManager.GetState(ctx, id, namespace)
+		if err == nil {
+			// Need to assign ETag to the new state
+			device.ObjectMeta.UpdateEtag(oldState.ObjectMeta.ETag)
+		}
 		err = c.DevicesManager.UpsertState(ctx, id, device)
 		if err != nil {
 			log.ErrorfCtx(ctx, "V (Devices): failed to upsert device spec, error %v", err)

--- a/api/pkg/apis/v1alpha1/vendors/instances-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/instances-vendor.go
@@ -170,7 +170,13 @@ func (c *InstancesVendor) onInstances(request v1alpha2.COARequest) v1alpha2.COAR
 				instance.ObjectMeta.Name = id
 			}
 		}
-		err := c.InstancesManager.UpsertState(ctx, id, instance)
+
+		oldState, err := c.InstancesManager.GetState(ctx, id, namespace)
+		if err == nil {
+			// Need to assign ETag to the new state
+			instance.ObjectMeta.UpdateEtag(oldState.ObjectMeta.ETag)
+		}
+		err = c.InstancesManager.UpsertState(ctx, id, instance)
 		if err != nil {
 			iLog.ErrorfCtx(ctx, "V (Instances): onInstances failed - %s", err.Error())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{

--- a/api/pkg/apis/v1alpha1/vendors/models-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/models-vendor.go
@@ -134,6 +134,12 @@ func (c *ModelsVendor) onModels(request v1alpha2.COARequest) v1alpha2.COARespons
 			})
 		}
 
+		oldState, err := c.ModelsManager.GetState(ctx, id, namespace)
+		if err == nil {
+			// Need to assign ETag to the new state
+			model.ObjectMeta.UpdateEtag(oldState.ObjectMeta.ETag)
+		}
+
 		err = c.ModelsManager.UpsertState(ctx, id, model)
 		if err != nil {
 			tLog.ErrorfCtx(ctx, "V (Models): onModels failed to UpsertSpec, id: %s, error: %v", id, err)

--- a/api/pkg/apis/v1alpha1/vendors/skills-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/skills-vendor.go
@@ -134,6 +134,12 @@ func (c *SkillsVendor) onSkills(request v1alpha2.COARequest) v1alpha2.COARespons
 			})
 		}
 
+		oldState, err := c.SkillsManager.GetState(ctx, id, namespace)
+		if err == nil {
+			// Need to assign ETag to the new state
+			skill.ObjectMeta.UpdateEtag(oldState.ObjectMeta.ETag)
+		}
+
 		err = c.SkillsManager.UpsertState(ctx, id, skill)
 		if err != nil {
 			kLog.ErrorfCtx(ctx, "V (Skills): onSkills failed to UpsertSpec, id: %s, error: %v", id, err)

--- a/api/pkg/apis/v1alpha1/vendors/solutions-container-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/solutions-container-vendor.go
@@ -132,6 +132,12 @@ func (c *SolutionContainersVendor) onSolutionContainers(request v1alpha2.COARequ
 		solutionContainer.ObjectMeta.Namespace = namespace
 		solutionContainer.Spec = &model.SolutionContainerSpec{}
 
+		oldState, err := c.SolutionContainersManager.GetState(ctx, id, namespace)
+		if err == nil {
+			// Need to assign ETag to the new state
+			solutionContainer.ObjectMeta.UpdateEtag(oldState.ObjectMeta.ETag)
+		}
+
 		err = c.SolutionContainersManager.UpsertState(ctx, id, solutionContainer)
 		if err != nil {
 			scLog.ErrorfCtx(ctx, "V (SolutionContainers): onSolutionContainers failed - %s", err.Error())

--- a/api/pkg/apis/v1alpha1/vendors/solutions-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/solutions-vendor.go
@@ -156,7 +156,14 @@ func (c *SolutionsVendor) onSolutions(request v1alpha2.COARequest) v1alpha2.COAR
 				solution.ObjectMeta.Name = id
 			}
 		}
-		err := c.SolutionsManager.UpsertState(ctx, id, solution)
+
+		oldState, err := c.SolutionsManager.GetState(ctx, id, namespace)
+		if err == nil {
+			// Need to assign ETag to the new state
+			solution.ObjectMeta.UpdateEtag(oldState.ObjectMeta.ETag)
+		}
+
+		err = c.SolutionsManager.UpsertState(ctx, id, solution)
 		if err != nil {
 			uLog.ErrorfCtx(ctx, "V (Solutions): onSolutions failed - %s", err.Error())
 			return observ_utils.CloseSpanWithCOAResponse(span, v1alpha2.COAResponse{

--- a/api/pkg/apis/v1alpha1/vendors/targets-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/targets-vendor.go
@@ -213,6 +213,11 @@ func (c *TargetsVendor) onRegistry(request v1alpha2.COARequest) v1alpha2.COAResp
 				})
 			}
 		}
+		oldState, err := c.TargetsManager.GetState(ctx, id, namespace)
+		if err == nil {
+			// Need to assign ETag to the new state
+			target.ObjectMeta.UpdateEtag(oldState.ObjectMeta.ETag)
+		}
 		err = c.TargetsManager.UpsertState(ctx, id, target)
 		if err != nil {
 			tLog.ErrorfCtx(ctx, "V (Targets) : onRegistry failed - %s", err.Error())


### PR DESCRIPTION
Partial fix for #580
We need to get the current state of object if exists before upserting the new state to ensure resource version is correct.