### PR TITLE
fix submodules by using https:// to replace git@ to avoid ssh config issue

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,10 @@
 [submodule "landing/public"]
 	path = landing/public
-	url = git@github.com:eclipse-symphony/symphony-website.git
+	url = https://github.com/eclipse-symphony/symphony-website.git
 	branch = main
 [submodule "docs-site/public"]
 	path = docs-site/public
-	url = git@github.com:eclipse-symphony/docs.git
+	url = https://github.com/eclipse-symphony/docs.git
 [submodule "docs-site/themes/docsy"]
 	path = docs-site/themes/docsy
 	url = https://github.com/google/docsy.git


### PR DESCRIPTION
previous:
![image](https://github.com/user-attachments/assets/ece0b23f-f6dc-4c62-a59f-5e758a87eb39)

after my fix:
![image](https://github.com/user-attachments/assets/09f87a34-970a-4ab1-92a4-00c6c6465e82)
