### PR TITLE
General improvements to the Rust binding

### DIFF
--- a/api/pkg/apis/v1alpha1/providers/target/rust/Cargo.toml
+++ b/api/pkg/apis/v1alpha1/providers/target/rust/Cargo.toml
@@ -1,7 +1,21 @@
+# Copyright (c) Microsoft Corporation and others.
+# Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
+
 [workspace]
+resolver = "2"
 members = [
     "symphony",
     "rust_providers/mock",
     "rust_providers/ankaios"
 ]
-resolver = "2"
+
+[workspace.package]
+edition = "2021"
+
+[workspace.dependencies]
+symphony = { path = "./symphony" }
+serde = { version = "1.0", default-features = false }
+serde_json = "1.0"
+tracing = { version = "0.1" }
+tracing-subscriber = { version = "0.3" }

--- a/api/pkg/apis/v1alpha1/providers/target/rust/rust.go
+++ b/api/pkg/apis/v1alpha1/providers/target/rust/rust.go
@@ -1,7 +1,7 @@
 //go:build !azure
 
 /*
- * Copyright (c) Microsoft Corporation.
+ * Copyright (c) Microsoft Corporation and others.
  * Licensed under the MIT license.
  * SPDX-License-Identifier: MIT
  */
@@ -49,7 +49,7 @@ type RustTargetProvider struct {
 	Context  *contexts.ManagerContext
 }
 
-func RustTargetProviderConfiggFromMap(properties map[string]string) (RustTargetProviderConfig, error) {
+func RustTargetProviderConfigFromMap(properties map[string]string) (RustTargetProviderConfig, error) {
 	ret := RustTargetProviderConfig{}
 	if v, ok := properties["name"]; ok {
 		ret.Name = v
@@ -67,27 +67,12 @@ func RustTargetProviderConfiggFromMap(properties map[string]string) (RustTargetP
 	return ret, nil
 }
 
-func toRustTargetProviderConfig(config providers.IProviderConfig) (RustTargetProviderConfig, error) {
-	ret := RustTargetProviderConfig{}
-	data, err := json.Marshal(config)
-	if err != nil {
-		return ret, err
-	}
-
-	err = json.Unmarshal(data, &ret)
-	return ret, err
+func (s *RustTargetProvider) SetContext(ctx *contexts.ManagerContext) {
+	s.Context = ctx
 }
 
 func (i *RustTargetProvider) InitWithMap(properties map[string]string) error {
-	config, err := RustTargetProviderConfiggFromMap(properties)
-	if err != nil {
-		return err
-	}
-	return i.Init(config)
-}
-
-func (s *RustTargetProvider) SetContext(ctx *contexts.ManagerContext) {
-	s.Context = ctx
+	return i.Init(properties)
 }
 
 func (r *RustTargetProvider) Init(config providers.IProviderConfig) error {
@@ -103,40 +88,39 @@ func (r *RustTargetProvider) Init(config providers.IProviderConfig) error {
 	defer observ_utils.EmitUserDiagnosticsLogs(ctx, &err)
 	log.InfoCtx(ctx, "  P (Rust Target): Init()")
 
-	rustConfig, err := toRustTargetProviderConfig(config)
-	if err != nil {
-		log.ErrorfCtx(ctx, "  P (Rust Target): expected RustTargetProviderConfig - %+v", err)
-		return v1alpha2.NewCOAError(err, fmt.Sprintf("%s: expected RustTargetProviderConfig", providerName), v1alpha2.InitFailed)
+	if rustConfig, ok := config.(map[string]string); ok {
+		rustProviderConfig, err := RustTargetProviderConfigFromMap(rustConfig)
+		if err != nil {
+			return err
+		}
+		// Create Rust provider from shared library file
+		cProviderPath := C.CString(rustProviderConfig.LibFile)
+		cExpectedHash := C.CString(rustProviderConfig.LibHash)
+		defer C.free(unsafe.Pointer(cProviderPath))
+		defer C.free(unsafe.Pointer(cExpectedHash))
+
+		configJSON, err := json.Marshal(config)
+		if err != nil {
+			log.ErrorfCtx(ctx, "  P (Rust Target): failed to serialize Rust provider configuration to JSON  - %+v", err)
+			return v1alpha2.NewCOAError(err, fmt.Sprintf("%s: failed to serialize Rust provider configuration to JSON", providerName), v1alpha2.InitFailed)
+		}
+
+		cConfigJSON := C.CString(string(configJSON))
+		defer C.free(unsafe.Pointer(cConfigJSON))
+
+		r.provider = C.create_provider_instance(cProviderPath, cExpectedHash, cConfigJSON)
+		if r.provider == nil {
+			log.ErrorfCtx(ctx, "  P (Rust Target): failed to create Rust provider from library file - %+v", err)
+			return v1alpha2.NewCOAError(nil, fmt.Sprintf("%s: failed to create Rust provider from library file", providerName), v1alpha2.InitFailed)
+		}
+
+		return nil
+
+	} else {
+		log.ErrorfCtx(ctx, "  P (Rust Target): expected config properties map")
+		return v1alpha2.NewCOAError(err, fmt.Sprintf("%s: expected config properties map", providerName), v1alpha2.InitFailed)
 	}
 
-	// Create Rust provider from file
-	cProviderPath := C.CString(rustConfig.LibFile)
-	cExpectedHash := C.CString(rustConfig.LibHash)
-	defer C.free(unsafe.Pointer(cProviderPath))
-	defer C.free(unsafe.Pointer(cExpectedHash))
-
-	r.provider = C.create_provider_instance(cProviderPath, cExpectedHash)
-	if r.provider == nil {
-		log.ErrorfCtx(ctx, "  P (Rust Target): failed to create Rust provider from library file - %+v", err)
-		return v1alpha2.NewCOAError(nil, fmt.Sprintf("%s: failed to create Rust provider from library file", providerName), v1alpha2.InitFailed)
-	}
-
-	configJSON, err := json.Marshal(config)
-	if err != nil {
-		log.ErrorfCtx(ctx, "  P (Rust Target): failed to serialize Rust provider configuration - %+v", err)
-		return v1alpha2.NewCOAError(err, fmt.Sprintf("%s: failed to serialize Rust provider configuration", providerName), v1alpha2.InitFailed)
-	}
-
-	cConfigJSON := C.CString(string(configJSON))
-	defer C.free(unsafe.Pointer(cConfigJSON))
-
-	res := C.init_provider(r.provider, cConfigJSON)
-	if res != 0 {
-		log.ErrorfCtx(ctx, "  P (Rust Target): ailed to initialize provider - %+v", err)
-		return v1alpha2.NewCOAError(err, fmt.Sprintf("%s: ailed to initialize provider", providerName), v1alpha2.InitFailed)
-	}
-
-	return nil
 }
 
 func (r *RustTargetProvider) GetValidationRule(ctx context.Context) model.ValidationRule {

--- a/api/pkg/apis/v1alpha1/providers/target/rust/rust_providers/ankaios/Cargo.toml
+++ b/api/pkg/apis/v1alpha1/providers/target/rust/rust_providers/ankaios/Cargo.toml
@@ -1,16 +1,18 @@
 [package]
 name = "ankaios"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-symphony = { path = "../../symphony" }
 ankaios_sdk = { version = "0.5.0-rc1", git = "https://github.com/GabyUnalaq/ank-sdk-rust.git", branch = "first-version" }
-tokio = { version = "1", features = ["full"] }
 futures = "0.3"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 serde_yaml = "0.9"
+symphony = { workspace = true }
+tokio = { version = "1", features = ["full"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/api/pkg/apis/v1alpha1/providers/target/rust/rust_providers/ankaios/src/lib.rs
+++ b/api/pkg/apis/v1alpha1/providers/target/rust/rust_providers/ankaios/src/lib.rs
@@ -1,229 +1,337 @@
 /*
- * Copyright (c) Microsoft Corporation.
+ * Copyright (c) Microsoft Corporation and others.
  * Licensed under the MIT license.
  * SPDX-License-Identifier: MIT
  */
 
- extern crate symphony;
+use std::collections::HashMap;
+use std::ffi::{c_char, CStr};
+use std::ptr;
+use std::time::Duration;
+use symphony::models::{
+    ComponentAction, ComponentResultSpec, ComponentSpec, ComponentStep, DeploymentSpec,
+    DeploymentStep, ProviderConfig, State, ValidationRule,
+};
+use symphony::ITargetProvider;
+use symphony::ProviderWrapper;
 
- use symphony::models::{
-     ProviderConfig, ValidationRule, DeploymentSpec, ComponentStep, ComponentSpec,
-     DeploymentStep, ComponentResultSpec, State, ComponentAction,
- };
- use symphony::ITargetProvider;
- use symphony::ProviderWrapper;
- use std::collections::HashMap;
- 
- use tokio::runtime::Runtime;
- use ankaios_sdk::{Ankaios, Workload};
- use tokio::time::Duration;
- use std::sync::{Arc};
- use tokio::sync::Mutex;
- 
- pub struct AnkaiosProvider {
-    runtime: Runtime,            // Tokio runtime for async execution
-    ank: Arc<Mutex<Option<Ankaios>>>,
+use ankaios_sdk::{Ankaios, Workload};
+use tracing::{debug, error};
+
+/// Creates a new Ankaios target provider instance.
+///
+/// # Safety
+///
+/// Client code needs to make sure that the passed in pointer is valid.
+#[no_mangle]
+pub unsafe extern "C" fn create_provider(config_json: *const c_char) -> *mut ProviderWrapper {
+    // try to configure tracing to output Events to stdout
+    if tracing_subscriber::fmt::try_init().is_err() {
+        // This will fail on subsequent invocations of the target provider's functions
+        // because the provider is stateless and thus newly created for each and every invocation.
+        // Consequently, we do not need to clutter stdout with corresponding warning
+        // but can assume that the subscriber has been initialized one way or the other ...
+    }
+    if config_json.is_null() {
+        error!("Pointer to configuration JSON string is null");
+        return ptr::null_mut();
+    }
+
+    let config_str = match unsafe { CStr::from_ptr(config_json).to_str() } {
+        Ok(str) => str,
+        Err(err) => {
+            error!("Error converting pointer to JSON string: {:?}", err);
+            return ptr::null_mut();
+        }
+    };
+    debug!("creating AnkaiosProvider using config: {}", config_str);
+
+    let config: ProviderConfig = match serde_json::from_str(config_str) {
+        Ok(cfg) => cfg,
+        Err(err) => {
+            error!("Error deserializing configuration JSON string: {:?}", err);
+            return ptr::null_mut();
+        }
+    };
+
+    let provider = match AnkaiosProvider::new(&config) {
+        Ok(provider) => Box::new(provider),
+        Err(e) => {
+            error!("Error creating AnkaiosTargetProvider: {:?}", e);
+            return ptr::null_mut();
+        }
+    };
+    let wrapper = Box::new(ProviderWrapper { inner: provider });
+    Box::into_raw(wrapper)
 }
 
- #[no_mangle]
- pub extern "C" fn create_provider() -> *mut ProviderWrapper  {
-    let provider: Box<dyn ITargetProvider> = Box::new(AnkaiosProvider {
-        runtime: Runtime::new().unwrap(), // Initialize runtime
-        ank: Arc::new(Mutex::new(None)),  // Lazy initialization
-    });
-     let wrapper = Box::new(ProviderWrapper { inner: provider });
-     Box::into_raw(wrapper)
- }
+pub struct AnkaiosProvider {
+    // Tokio runtime for async execution
+    runtime: tokio::runtime::Runtime,
+    ank: tokio::sync::Mutex<Ankaios>,
+    validation_rule: ValidationRule,
+}
 
- impl ITargetProvider for AnkaiosProvider {
-    fn init(&self, _config: ProviderConfig) -> Result<(), String> {        
-        let ank_clone = Arc::clone(&self.ank);
-        let _  = self.runtime.block_on(async {
-            let needs_init = {
-                let ank_guard = ank_clone.lock().await;
-                ank_guard.is_none() // Check if initialization is needed
-            }; 
-            if needs_init {
-                match Ankaios::new().await {
-                    Ok(ankaios_instance) => {
-                        let mut ank_guard = ank_clone.lock().await;
-                        *ank_guard = Some(ankaios_instance);
-                        return Ok(());
+impl AnkaiosProvider {
+    fn new(_config: &ProviderConfig) -> Result<Self, Box<dyn core::error::Error>> {
+        let tokio_runtime = tokio::runtime::Runtime::new()?;
+
+        let ankaios_client = tokio_runtime
+            .block_on(Ankaios::new_with_timeout(Duration::from_secs(5)))
+            .inspect_err(|err| {
+                error!("Failed to initialize Ankaios: {err}");
+            })
+            .map(tokio::sync::Mutex::new)?;
+
+        // this might be adapted to determine the validation rule from config properties
+        let validation_rule = ValidationRule::default();
+
+        Ok(Self {
+            runtime: tokio_runtime,
+            ank: ankaios_client,
+            validation_rule,
+        })
+    }
+
+    async fn async_get(
+        &self,
+        _deployment: DeploymentSpec,
+        references: Vec<ComponentStep>,
+    ) -> Result<Vec<ComponentSpec>, String> {
+        let complete_state = {
+            // drop the guard as soon as we have retrieved the state from Ankaios
+            let mut ankaios_client = self.ank.lock().await;
+            ankaios_client
+                .get_state(vec!["workloadStates".to_string(), "workloads".to_string()])
+                .await
+                .map_err(|err| {
+                    error!("Failed to retrieve component state from Ankaios: {err}");
+                    err.to_string()
+                })?
+        };
+
+        let result_componentspecs = references
+            .iter()
+            .map(|step| step.component.clone())
+            .filter_map(|mut spec| {
+                // determine corresponding Ankaios workflow state
+                if let Some(workload_state) = complete_state
+                    .get_workload(&spec.name)
+                    .map(|wl| wl.to_dict())
+                {
+                    let mut props = spec.properties.unwrap_or_default();
+                    if let Some(v) = workload_state["agent"].as_str() {
+                        props.insert(
+                            "ankaios.agent".to_string(),
+                            serde_json::Value::String(v.to_string()),
+                        );
+                    }
+                    if let Some(v) = workload_state["runtime"].as_str() {
+                        props.insert(
+                            "ankaios.runtime".to_string(),
+                            serde_json::Value::String(v.to_string()),
+                        );
+                    }
+                    if let Some(v) = workload_state["restartPolicy"].as_str() {
+                        props.insert(
+                            "ankaios.restartPolicy".to_string(),
+                            serde_json::Value::String(v.to_string()),
+                        );
+                    }
+                    if let Some(v) = workload_state["runtimeConfig"].as_str() {
+                        props.insert(
+                            "ankaios.runtimeConfig".to_string(),
+                            serde_json::Value::String(v.to_string()),
+                        );
+                    }
+                    spec.properties = Some(props);
+                    Some(spec)
+                } else {
+                    // no workload with the given component name found
+                    None
+                }
+            })
+            .collect();
+
+        // let mut result_componentspecs = vec![];
+
+        // // Get the workload states present in the complete state
+        // let workload_states_dict = complete_state.get_workload_states().as_dict();
+        // // Print the states of the workloads
+        // for (agent_name, workload_states) in workload_states_dict.iter() {
+        //     for (workload_name, workload_execution_states) in workload_states.iter() {
+        //         for (_workload_id, workload_execution_state) in workload_execution_states.iter() {
+        //             let _state = workload_execution_state.state;
+        //             //if state == WorkloadStateEnum::Running {
+        //             for component in references.iter() {
+        //                 if component.component.name == workload_name.as_str() {
+        //                     let mut ret_component = component.component.clone();
+        //                     let mut properties =
+        //                         ret_component.properties.clone().unwrap_or_default();
+        //                     // Ankaios agent name
+        //                     let agent_json_value: serde_json::Value =
+        //                         serde_json::to_value(agent_name).unwrap_or(serde_json::Value::Null);
+        //                     properties.insert("ankaios.agent".to_string(), agent_json_value);
+
+        //                     if let Ok(workload) =
+        //                         self.ank.get_workload(workload_name.to_owned()).await
+        //                     {
+        //                         let workload_properties = workload.to_dict();
+        //                         // Ankaios runtime
+        //                         properties.insert(
+        //                             "ankaios.runtime".to_string(),
+        //                             serde_json::Value::String(
+        //                                 workload_properties["runtime"]
+        //                                     .as_str()
+        //                                     .unwrap()
+        //                                     .to_string(),
+        //                             ),
+        //                         );
+        //                         // Ankaios restart policy
+        //                         properties.insert(
+        //                             "ankaios.restartPolicy".to_string(),
+        //                             serde_json::Value::String(
+        //                                 workload_properties["restartPolicy"]
+        //                                     .as_str()
+        //                                     .unwrap()
+        //                                     .to_string(),
+        //                             ),
+        //                         );
+        //                         // runtimeConfig
+        //                         properties.insert(
+        //                             "ankaios.runtimeConfig".to_string(),
+        //                             serde_json::Value::String(
+        //                                 workload_properties["runtimeConfig"]
+        //                                     .as_str()
+        //                                     .unwrap()
+        //                                     .to_string(),
+        //                             ),
+        //                         );
+        //                     }
+        //                     ret_component.properties = Some(properties);
+        //                     result_componentspecs.push(ret_component);
+        //                     break;
+        //                 }
+        //             }
+        //             //}
+        //         }
+        //     }
+        // }
+        Ok(result_componentspecs)
+    }
+
+    async fn async_apply(
+        &self,
+        _deployment: DeploymentSpec,
+        step: DeploymentStep,
+    ) -> Result<HashMap<String, ComponentResultSpec>, String> {
+        let mut result: HashMap<String, ComponentResultSpec> = HashMap::new();
+        let mut ankaios_client = self.ank.lock().await;
+
+        for component in step.components.iter() {
+            if component.action == ComponentAction::Delete {
+                // Simulate deletion
+                match ankaios_client.delete_workload(component.component.name.clone()).await {
+                    Ok(_) => {
+                        let component_result = ComponentResultSpec {
+                            status: State::OK,
+                            message: "Component deleted successfully".to_string(),
+                        };
+                        result.insert(component.component.name.clone(), component_result);
                     }
                     Err(e) => {
-                        return Err(format!("Failed to initialize Ankaios: {:?}", e));
+                        let component_result = ComponentResultSpec {
+                            status: State::InternalError,
+                            message: format!("Failed to delete workload: {:?}", e),
+                        };
+                        result.insert(component.component.name.clone(), component_result);
                     }
-                }                
+                }
+            } else if component.action == ComponentAction::Update {
+                let workload = Workload::builder()
+                    .workload_name(component.component.name.clone())
+                    .agent_name(
+                        component
+                            .component
+                            .properties
+                            .as_ref()
+                            .and_then(|props| props.get("ankaios.agent")?.as_str())
+                            .unwrap_or("agent_A"),
+                    )
+                    .runtime(
+                        component
+                            .component
+                            .properties
+                            .as_ref()
+                            .and_then(|props| props.get("ankaios.runtime")?.as_str())
+                            .unwrap_or("poaman"),
+                    )
+                    .restart_policy(
+                        component
+                            .component
+                            .properties
+                            .as_ref()
+                            .and_then(|props| props.get("ankaios.restartPolicy")?.as_str())
+                            .unwrap_or("NEVER"),
+                    )
+                    .runtime_config(
+                        component
+                            .component
+                            .properties
+                            .as_ref()
+                            .and_then(|props| props.get("ankaios.runtimeConfig")?.as_str())
+                            .unwrap_or(""),
+                    )
+                    .build()
+                    .unwrap();
+                match ankaios_client.apply_workload(workload).await {
+                    Ok(_) => {
+                        let component_result = ComponentResultSpec {
+                            status: State::OK,
+                            message: "Component applied successfully".to_string(),
+                        };
+                        result.insert(component.component.name.clone(), component_result);
+                    }
+                    Err(e) => {
+                        let component_result = ComponentResultSpec {
+                            status: State::InternalError,
+                            message: format!("Failed to apply workload: {:?}", e),
+                        };
+                        result.insert(component.component.name.clone(), component_result);
+                    }
+                }
             }
-            Ok(())
-        });
-           
-        Ok(())
+        }
+        Ok(result) // Simulated async operation
     }
+}
+
+impl ITargetProvider for AnkaiosProvider {
     fn get_validation_rule(&self) -> Result<ValidationRule, String> {
-        Ok(ValidationRule::new())
+        Ok(self.validation_rule.clone())
     }
 
     fn get(
         &self,
-        _deployment: DeploymentSpec,
-        _references: Vec<ComponentStep>,
+        deployment: DeploymentSpec,
+        references: Vec<ComponentStep>,
     ) -> Result<Vec<ComponentSpec>, String> {
-        let runtime_handle = self.runtime.handle().clone();
-        let ank_clone = Arc::clone(&self.ank);
-
-        let result = runtime_handle.block_on(async {
-            let mut ank_guard = ank_clone.lock().await;
-            AnkaiosProvider::async_get(&mut ank_guard, _deployment, _references).await
-        });
-
-        result
+        self.runtime
+            .block_on(self.async_get(deployment, references))
     }
+
     fn apply(
         &self,
         deployment: DeploymentSpec,
         step: DeploymentStep,
         is_dry_run: bool,
     ) -> Result<HashMap<String, ComponentResultSpec>, String> {
-        let runtime_handle = self.runtime.handle().clone();
-        let ank_clone = Arc::clone(&self.ank);
-
-        let result = runtime_handle.block_on(async {
-            let mut ank_guard = ank_clone.lock().await;
-            AnkaiosProvider::async_apply(&mut ank_guard, deployment, step, is_dry_run).await
-        });
-
-        result
-    }
-}
-
-impl AnkaiosProvider {
-    /// This is an internal async function, **not part of the trait**.
-    async fn async_get(
-        ank_guard: &mut Option<Ankaios>, 
-        _deployment: DeploymentSpec,
-        references: Vec<ComponentStep>,
-    ) -> Result<Vec<ComponentSpec>, String> {
-        
-        let mut result_componentspecs: Vec<ComponentSpec> = vec![];
-
-        if let Some(ank) = &mut *ank_guard { // Get a mutable reference
-            if let Ok(complete_state) = ank
-                .get_state(
-                    Some(vec!["workloadStates".to_string(), "workloads".to_string()]),
-                    Some(Duration::from_secs(5)),
-                )
-                .await
-            {
-                // Get the workload states present in the complete state
-                let workload_states_dict = complete_state.get_workload_states().get_as_dict();                
-                // Print the states of the workloads
-                for (agent_name, workload_states) in workload_states_dict.iter() {
-                    for (workload_name, workload_states) in workload_states.as_mapping().unwrap().iter() {
-                        for (_workload_id, workload_state) in workload_states.as_mapping().unwrap().iter() {
-                           
-                            let _state = workload_state.get("state").unwrap().as_str().unwrap();
-                            //if state == "running" {
-                                for component in references.iter() {
-                                    if component.component.name == workload_name.as_str().unwrap() {
-                                        let mut ret_component = component.component.clone();
-                                        let mut properties = ret_component.properties.clone().unwrap_or_default();
-                                        // Ankaios agent name
-                                        let agent_json_value: serde_json::Value = serde_json::to_value(agent_name).unwrap_or(serde_json::Value::Null);
-                                        properties.insert("ankaios.agent".to_string(), agent_json_value);
-                                        
-                                        if let Some(workload_name_str) = workload_name.as_str() {                                         
-                                            if let Ok(workload) = ank.get_workload(workload_name_str.to_owned(), Some(Duration::from_secs(5))).await {                                            
-                                                let workload_properties = workload.to_dict();            
-                                                // Ankaios runtime
-                                                properties.insert("ankaios.runtime".to_string(), serde_json::Value::String(workload_properties["runtime"].as_str().unwrap().to_string()));
-                                                // Ankasios restart policy
-                                                properties.insert("ankaios.restartPolicy".to_string(), serde_json::Value::String(workload_properties["restartPolicy"].as_str().unwrap().to_string()));
-                                                // runtimeConfig
-                                                properties.insert("ankaios.runtimeConfig".to_string(), serde_json::Value::String(workload_properties["runtimeConfig"].as_str().unwrap().to_string()));
-                                            }
-                                        }                                         
-                                        ret_component.properties = Some(properties);
-                                        result_componentspecs.push(ret_component);
-                                        break;
-                                    }
-                                }
-                            //}
-                        }
-                    }
-                }
-            }
-        } else {
-            return Err("Failed to acquire lock".to_string());
+        if is_dry_run {
+            println!("Dry run is enabled, skipping actual apply");
+            return Ok(HashMap::new());
         }
-        Ok(result_componentspecs) // Simulated async operation
-    }
-    async fn async_apply(
-        ank_guard: &mut Option<Ankaios>, 
-        _deployment: DeploymentSpec,
-        step: DeploymentStep,
-        is_dry_run: bool,
-    ) -> Result<HashMap<String, ComponentResultSpec>, String> {
-        
-        let mut result: HashMap<String, ComponentResultSpec> = HashMap::new();
 
-        if let Some(ank) = &mut *ank_guard {
-            if is_dry_run {
-                println!("Dry run is enabled, skipping actual apply");
-                return Ok(result);
-            }
-
-            for component in step.components.iter() {
-                if component.action == ComponentAction::Delete {
-                    // Simulate deletion
-                    match ank.delete_workload(component.component.name.clone(), None).await {
-                        Ok(_) => {
-                            let component_result = ComponentResultSpec {
-                                status: State::OK,
-                                message: "Component deleted successfully".to_string(),
-                            };
-                            result.insert(component.component.name.clone(), component_result);
-                        }
-                        Err(e) => {
-                            let component_result = ComponentResultSpec {
-                                status: State::InternalError,
-                                message: format!("Failed to delete workload: {:?}", e),
-                            };
-                            result.insert(component.component.name.clone(), component_result);
-                        }
-                    }
-                } else if component.action == ComponentAction::Update {
-                    let workload = Workload::builder()
-                        .workload_name(component.component.name.clone())
-                        .agent_name(component.component.properties.as_ref().and_then(|props| props.get("ankaios.agent")?.as_str()).unwrap_or("agent_A"))
-                        .runtime(component.component.properties.as_ref().and_then(|props| props.get("ankaios.runtime")?.as_str()).unwrap_or("poaman"))
-                        .restart_policy(component.component.properties.as_ref().and_then(|props| props.get("ankaios.restartPolicy")?.as_str()).unwrap_or("NEVER"))
-                        .runtime_config(component.component.properties.as_ref().and_then(|props| props.get("ankaios.runtimeConfig")?.as_str()).unwrap_or(""))
-                        .build()
-                        .unwrap();
-                    match ank.apply_workload(workload, None).await {
-                        Ok(_) => {
-                            let component_result = ComponentResultSpec {
-                                status: State::OK,
-                                message: "Component applied successfully".to_string(),
-                            };
-                            result.insert(component.component.name.clone(), component_result);
-                        }
-                        Err(e) => {
-                            let component_result = ComponentResultSpec {
-                                status: State::InternalError,
-                                message: format!("Failed to apply workload: {:?}", e),
-                            };
-                            result.insert(component.component.name.clone(), component_result);
-                        }
-                    }
-
-                }                
-            }
-        }  else {
-            return Err("Failed to acquire lock".to_string());
-        }
-        Ok(result) // Simulated async operation
+        self.runtime.block_on(self.async_apply(deployment, step))
     }
 }
 
@@ -245,7 +353,7 @@ impl AnkaiosProvider {
 //         eprintln!("Initialization failed: {}", e);
 //         return;
 //     }
-    
+
 //     eprintln!("Provider initialized successfully.");
 
 //     let deployment = DeploymentSpec::empty();
@@ -262,8 +370,8 @@ impl AnkaiosProvider {
 //             constraints: None,
 //             parameters: Some(HashMap::new()),
 //             routes: Some(vec![]),
-//             sidecars: Some(vec![]),        
-//             skills: Some(vec![]),    
+//             sidecars: Some(vec![]),
+//             skills: Some(vec![]),
 //         },
 //     }];
 
@@ -280,7 +388,7 @@ impl AnkaiosProvider {
 //     let step = DeploymentStep {
 //         is_first: false,
 //         role: "ankaios_workload".to_string(),
-//         target: Some("my-target".to_string()),       
+//         target: Some("my-target".to_string()),
 //         components: vec![ComponentStep {
 //             action: ComponentAction::Delete,
 //             component: ComponentSpec {
@@ -299,15 +407,15 @@ impl AnkaiosProvider {
 //                 constraints: None,
 //                 parameters: Some(HashMap::new()),
 //                 routes: Some(vec![]),
-//                 sidecars: Some(vec![]),        
-//                 skills: Some(vec![]),                
+//                 sidecars: Some(vec![]),
+//                 skills: Some(vec![]),
 //             },
 //         }],
 //     };
 
 //     match provider.apply(deployment, step, false) {
 //         Ok(components) => {
-//             println!("Apply result: {:?}", components);            
+//             println!("Apply result: {:?}", components);
 //         }
 //         Err(e) => eprintln!("Failed to get components: {}", e),
 //     }

--- a/api/pkg/apis/v1alpha1/providers/target/rust/rust_providers/mock/Cargo.toml
+++ b/api/pkg/apis/v1alpha1/providers/target/rust/rust_providers/mock/Cargo.toml
@@ -1,12 +1,17 @@
+# Copyright (c) Microsoft Corporation and others.
+# Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
+
 [package]
 name = "mock"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
+publish = false
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-symphony = { path = "../../symphony" }
-serde = "1.0"
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
+symphony = { workspace = true }

--- a/api/pkg/apis/v1alpha1/providers/target/rust/rust_providers/mock/src/lib.rs
+++ b/api/pkg/apis/v1alpha1/providers/target/rust/rust_providers/mock/src/lib.rs
@@ -1,124 +1,110 @@
 /*
- * Copyright (c) Microsoft Corporation.
+ * Copyright (c) Microsoft Corporation and others.
  * Licensed under the MIT license.
  * SPDX-License-Identifier: MIT
  */
 
- extern crate symphony;
+use std::collections::HashMap;
+use std::ffi::{c_char, CStr};
+use symphony::{ITargetProvider, ProviderWrapper};
+use symphony::models::{
+    ComponentResultSpec, ComponentSpec, ComponentStep, DeploymentSpec,
+    DeploymentStep, RouteSpec, SidecarSpec, State, ValidationRule,
+};
 
- use symphony::models::{
-     ProviderConfig, ValidationRule, DeploymentSpec, ComponentStep, ComponentSpec,
-     DeploymentStep, ComponentResultSpec,
-     ComponentValidationRule, RouteSpec, SidecarSpec, State
- };
- use symphony::ITargetProvider;
- use symphony::ProviderWrapper;
- use std::collections::HashMap;
- 
- pub struct MockProvider;
- 
- #[no_mangle]
- pub extern "C" fn create_provider() -> *mut ProviderWrapper  {
-     let provider: Box<dyn ITargetProvider> = Box::new(MockProvider {});
-     let wrapper = Box::new(ProviderWrapper { inner: provider });
-     Box::into_raw(wrapper)
- }
- 
- impl ITargetProvider for MockProvider {
-     fn init(&self, _config: ProviderConfig) -> Result<(), String> {
-         println!("MOCK RUST PROVIDER: ------ init()");
-         Ok(())
-     }
- 
-     fn get_validation_rule(&self) -> Result<ValidationRule, String> {
-         println!("MOCK RUST PROVIDER: ------ get_validation_rule()");
-         let validation_rule = ValidationRule {
-             required_component_type: "".to_string(),
-             component_validation_rule: ComponentValidationRule {
-                 required_component_type: "".to_string(),
-                 change_detection_properties: vec![],
-                 change_detection_metadata: vec![],
-                 required_properties: vec![],
-                 optional_properties: vec![],
-                 required_metadata: vec![],
-                 optional_metadata: vec![],
-             },
-             sidecar_validation_rule: ComponentValidationRule {
-                 required_component_type: "".to_string(),
-                 change_detection_properties: vec![],
-                 change_detection_metadata: vec![],
-                 required_properties: vec![],
-                 optional_properties: vec![],
-                 required_metadata: vec![],
-                 optional_metadata: vec![],
-             },
-             allow_sidecar: true,
-             scope_isolation: true,
-             instance_isolation: true,
-         };
-     
-         Ok(validation_rule)
-     }
-     
- 
-     fn get(&self, _deployment: DeploymentSpec, _references: Vec<ComponentStep>) -> Result<Vec<ComponentSpec>, String> {
-         println!("MOCK RUST PROVIDER: ------ get()");
-         let component_spec = ComponentSpec {
-             name: "example_component".to_string(),
-             component_type: Some("example_type".to_string()),
-             metadata: Some(HashMap::from([
-                 ("example_metadata_key".to_string(), "example_metadata_value".to_string())
-             ])),
-             properties: Some(HashMap::from([
-                 ("example_property_key".to_string(), serde_json::json!("example_property_value"))
-             ])),
-             parameters: Some(HashMap::from([
-                 ("example_parameter_key".to_string(), "example_parameter_value".to_string())
-             ])),
-             routes: Some(vec![
-                 RouteSpec {
-                     route: "example_route".to_string(),
-                     route_type: "example_type".to_string(),
-                     properties: Some(HashMap::from([
-                         ("example_route_property_key".to_string(), "example_route_property_value".to_string())
-                     ])),
-                     filters: Some(Vec::new()),
-                 }
-             ]),
-             constraints: Some("example_constraint".to_string()),
-             dependencies: Some(Vec::new()),
-             skills: Some(Vec::new()),
-             sidecars: Some(vec![
-                 SidecarSpec {
-                     name: Some("example_sidecar".to_string()),
-                     sidecar_type: Some("example_type".to_string()),
-                     properties: Some(HashMap::from([
-                         ("example_sidecar_property_key".to_string(), serde_json::json!("example_sidecar_property_value"))
-                     ])),
-                 }
-             ]),
-         };
- 
-         Ok(vec![component_spec])        
-     }
- 
-     fn apply(
-         &self,
-         _deployment: DeploymentSpec,
-         step: DeploymentStep,
-         _is_dry_run: bool,
-     ) -> Result<HashMap<String, ComponentResultSpec>, String> {
-         println!("MOCK RUST PROVIDER: ------ apply()");
-         let mut result_map = HashMap::new();
- 
-         for component_step in step.components {
-             let result_spec = ComponentResultSpec {
-                 status: State::OK,
-                 message: format!("Component {} applied successfully", component_step.component.name),
-             };
-             result_map.insert(component_step.component.name.clone(), result_spec);
-         }
- 
-         Ok(result_map)
-     }
- }
+pub struct MockProvider;
+
+/// Creates a new provider for configuration data.
+///
+/// # Safety
+///
+/// Client code must make sure that the provided pointer is valid.
+#[no_mangle]
+pub unsafe extern "C" fn create_provider(config_json: *const c_char) -> *mut ProviderWrapper {
+    if !config_json.is_null() {
+        unsafe {
+            if let Ok(config_str) = CStr::from_ptr(config_json).to_str() {
+                println!("creating provider for configuration: {}", config_str);
+            }
+        }
+    }
+    let provider = Box::new(MockProvider {});
+    let wrapper = Box::new(ProviderWrapper { inner: provider });
+    Box::into_raw(wrapper)
+}
+
+impl ITargetProvider for MockProvider {
+    fn get_validation_rule(&self) -> Result<ValidationRule, String> {
+        println!("MOCK RUST PROVIDER: ------ get_validation_rule()");
+        Ok(ValidationRule::default())
+    }
+
+    fn get(
+        &self,
+        _deployment: DeploymentSpec,
+        _references: Vec<ComponentStep>,
+    ) -> Result<Vec<ComponentSpec>, String> {
+        println!("MOCK RUST PROVIDER: ------ get()");
+        let component_spec = ComponentSpec {
+            name: "example_component".to_string(),
+            component_type: Some("example_type".to_string()),
+            metadata: Some(HashMap::from([(
+                "example_metadata_key".to_string(),
+                "example_metadata_value".to_string(),
+            )])),
+            properties: Some(HashMap::from([(
+                "example_property_key".to_string(),
+                serde_json::json!("example_property_value"),
+            )])),
+            parameters: Some(HashMap::from([(
+                "example_parameter_key".to_string(),
+                "example_parameter_value".to_string(),
+            )])),
+            routes: Some(vec![RouteSpec {
+                route: "example_route".to_string(),
+                route_type: "example_type".to_string(),
+                properties: Some(HashMap::from([(
+                    "example_route_property_key".to_string(),
+                    "example_route_property_value".to_string(),
+                )])),
+                filters: Some(Vec::new()),
+            }]),
+            constraints: Some("example_constraint".to_string()),
+            dependencies: Some(Vec::new()),
+            skills: Some(Vec::new()),
+            sidecars: Some(vec![SidecarSpec {
+                name: Some("example_sidecar".to_string()),
+                sidecar_type: Some("example_type".to_string()),
+                properties: Some(HashMap::from([(
+                    "example_sidecar_property_key".to_string(),
+                    serde_json::json!("example_sidecar_property_value"),
+                )])),
+            }]),
+        };
+
+        Ok(vec![component_spec])
+    }
+
+    fn apply(
+        &self,
+        _deployment: DeploymentSpec,
+        step: DeploymentStep,
+        _is_dry_run: bool,
+    ) -> Result<HashMap<String, ComponentResultSpec>, String> {
+        println!("MOCK RUST PROVIDER: ------ apply()");
+        let mut result_map = HashMap::new();
+
+        for component_step in step.components {
+            let result_spec = ComponentResultSpec {
+                status: State::OK,
+                message: format!(
+                    "Component {} applied successfully",
+                    component_step.component.name
+                ),
+            };
+            result_map.insert(component_step.component.name.clone(), result_spec);
+        }
+
+        Ok(result_map)
+    }
+}

--- a/api/pkg/apis/v1alpha1/providers/target/rust/symphony/Cargo.toml
+++ b/api/pkg/apis/v1alpha1/providers/target/rust/symphony/Cargo.toml
@@ -1,16 +1,23 @@
+# Copyright (c) Microsoft Corporation and others.
+# Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
+
 [package]
 name = "symphony"
 version = "0.1.3"
-edition = "2021"
+edition = { workspace = true }
 license = "MIT"
 description = "Eclipse Symphony Target Provider Rust binding"
 repository = "https://github.com/eclipse-symphony/symphony.git"
 keywords = ["orchestration"]
+
 [lib]
 crate-type = ["staticlib", "rlib"]
 
 [dependencies]
-libloading = "0.7"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-sha2 = "0.10"
+libloading = { version = "0.8" }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+sha2 = { version = "0.10", default-features = false, features = ["std"]}
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/api/pkg/apis/v1alpha1/providers/target/rust/symphony/README.md
+++ b/api/pkg/apis/v1alpha1/providers/target/rust/symphony/README.md
@@ -1,12 +1,13 @@
 # Eclipse Symphony Target Provider Rust Binding
-This crate is [Eclipse Symphony](https://github.com/eclipse-symphony/symphony) Target provider Rust binding, which allows a custom Target provider to be written in Rust. 
+
+This crate provides the [Eclipse Symphony](https://github.com/eclipse-symphony/symphony) Target provider Rust binding, which allows a custom Target provider to be written in Rust.
 
 Symphony is a toolchain orchestrator that aims to provide consistent management experience across multiple toolchains. A key capability of Symphony is state seeking, where a system's current is brought towards a new desired state. Symphony allows different toolchains to join the state seeking process through a Target Provider trait.
+
 ```rust
 pub trait ITargetProvider: Send + Sync {
-    fn init(&self, config: ProviderConfig) -> Result<(), String>;
-    fn get_validation_rule(&self) -> Result<ValidationRule, String>; // Return Rust native type
-    fn get(&self, deployment: DeploymentSpec, references: Vec<ComponentStep>) -> Result<Vec<ComponentSpec>, String>; // Return Rust native types
+    fn get_validation_rule(&self) -> Result<ValidationRule, String>;
+    fn get(&self, deployment: DeploymentSpec, references: Vec<ComponentStep>) -> Result<Vec<ComponentSpec>, String>;
     fn apply(&self, deployment: DeploymentSpec, step: DeploymentStep, is_dry_run: bool) -> Result<HashMap<String, ComponentResultSpec>, String>; 
  }
  ```
@@ -14,11 +15,12 @@ pub trait ITargetProvider: Send + Sync {
  * The `apply()` method applies the new desired state.
  * The `get_validation_rule()` allows a provider to define what properties are expected in the incoming state spec, and what properties to be used for change detection.
 
- ## Current Rust Providers
+ ## Current Rust based Target Providers
+
  | Provider | Info |
- |--------|--------|
- | ankaios | An [Eclipse Ankaios](https://github.com/eclipse-ankaios/ankaios) provider |
- | mock | A mock provider for testing purposes |
+ |----------|------|
+ | ankaios  | An [Eclipse Ankaios](https://github.com/eclipse-ankaios/ankaios) provider |
+ | mock     | A mock provider for testing purposes |
  
 
 

--- a/api/pkg/apis/v1alpha1/providers/target/rust/symphony/include/rust_target_provider.h
+++ b/api/pkg/apis/v1alpha1/providers/target/rust/symphony/include/rust_target_provider.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) Microsoft Corporation and others.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef RUST_TARGET_PROVIDER_H
 #define RUST_TARGET_PROVIDER_H
 
@@ -14,22 +20,19 @@ typedef struct {
     void* lib;       // Pointer to the dynamically loaded library (to keep it in memory)
 } ProviderHandle;
 
-// Function to create a provider instance based on the provider type and path
-ProviderHandle* create_provider_instance(const char* provider_path, const char* expected_hash);
+// Creates a new Rust target provider instance based on a dynamically loaded shared library.
+ProviderHandle *create_provider_instance(const char *provider_path, const char *expected_hash, const char *config_json);
 
-// Function to destroy a provider instance
+// Destroys a provider instance.
 void destroy_provider_instance(ProviderHandle* handle);
 
-// Initialize the provider with the given configuration
-int init_provider(ProviderHandle* handle, const char* config_json);
-
-// Get the validation rule from the provider
+// Gets a target provider's validation rule.
 const char* get_validation_rule(ProviderHandle* handle);
 
-// Get component specifications from the provider
+// Gets component specifications from a target provider.
 const char* get(ProviderHandle* handle, const char* deployment_json, const char* references_json);
 
-// Apply a deployment step
+// Applies a deployment step to a target provider.
 const char* apply(ProviderHandle* handle, const char* deployment_json, const char* step_json, int is_dry_run);
 
 #ifdef __cplusplus

--- a/api/pkg/apis/v1alpha1/providers/target/rust/symphony/src/lib.rs
+++ b/api/pkg/apis/v1alpha1/providers/target/rust/symphony/src/lib.rs
@@ -1,222 +1,282 @@
 /*
- * Copyright (c) Microsoft Corporation.
+ * Copyright (c) Microsoft Corporation and others.
  * Licensed under the MIT license.
  * SPDX-License-Identifier: MIT
  */
 
- use std::ffi::{CStr, CString};
- use std::os::raw::c_char;
- use libloading::{Library, Symbol};
- use std::ptr;
- use std::fs::File;
- use std::io::{self, Read};
- use sha2::{Sha256, Digest};
- use std::collections::HashMap; 
- 
- pub mod models;
- use crate::models::*;
- 
- // Function to compute the SHA-256 hash of a file
- fn compute_sha256_hash(file_path: &str) -> Result<String, io::Error> {
-     let mut file = File::open(file_path)?;
-     let mut hasher = Sha256::new();
-     let mut buffer = [0; 4096];
-     
-     loop {
-         let bytes_read = file.read(&mut buffer)?;
-         if bytes_read == 0 {
-             break;
-         }
-         hasher.update(&buffer[..bytes_read]);
-     }
-     
-     let hash = hasher.finalize();
-     Ok(format!("{:x}", hash))
- }
- 
- // Function to validate the computed hash against the expected hash value
- fn validate_hash(file_path: &str, expected_hash: &str) -> Result<(), String> {
-     let computed_hash = compute_sha256_hash(file_path).map_err(|e| format!("Error computing hash: {}", e))?;
-     
-     if computed_hash == expected_hash {        
-         Ok(())
-     } else {
-         Err(format!("Hash mismatch! Expected: {}, Got: {}", expected_hash, computed_hash))
-     }
- }
- 
- // Trait that all Rust-based Target providers must implement
- pub trait ITargetProvider: Send + Sync {
-     fn init(&self, config: ProviderConfig) -> Result<(), String>;
-     fn get_validation_rule(&self) -> Result<ValidationRule, String>; // Return Rust native type
-     fn get(&self, deployment: DeploymentSpec, references: Vec<ComponentStep>) -> Result<Vec<ComponentSpec>, String>; // Return Rust native types
-     fn apply(&self, deployment: DeploymentSpec, step: DeploymentStep, is_dry_run: bool) -> Result<HashMap<String, ComponentResultSpec>, String>; 
- }
- 
- // Struct to hold the provider instance
- #[repr(C)]
- pub struct ProviderHandle {
-     provider: Box<dyn ITargetProvider>,
-     lib: Library, // Keep the library loaded to ensure the provider's functions remain valid
- }
- 
- pub struct ProviderWrapper {
-     pub inner: Box<dyn ITargetProvider>,
- }
- 
- // External function to create the provider instance
- #[no_mangle]
- pub extern "C" fn create_provider_instance(
-     provider_path: *const c_char, 
-     expected_hash: *const c_char
- ) -> *mut ProviderHandle {
-     let provider_path = unsafe { CStr::from_ptr(provider_path) }
-         .to_str()
-         .expect("Invalid provider path");
- 
-     let expected_hash = unsafe { CStr::from_ptr(expected_hash) }
-         .to_str()
-         .expect("Invalid hash value");
- 
-     // Validate the hash before loading the provider
-     if let Err(err) = validate_hash(provider_path, expected_hash) {
-         eprintln!("Hash validation failed: {}", err);
-         return ptr::null_mut();
-     }
- 
-     let lib = unsafe { Library::new(provider_path).expect("Failed to load provider library") };
- 
-     type CreateProviderFn = unsafe fn() -> *mut ProviderWrapper;
-     let create_provider: Symbol<CreateProviderFn> = unsafe {
-         lib.get(b"create_provider\0").expect("Failed to load create_provider function")
-     };
- 
-     let wrapper = unsafe { create_provider() };
- 
-     if wrapper.is_null() {
-         eprintln!("Error: create_provider returned null pointer");
-         return ptr::null_mut();
-     }
- 
-     // Take ownership of the `Box<dyn ITargetProvider>` from the wrapper
-     let provider_box = unsafe { Box::from_raw(wrapper).inner };
- 
-     let handle = Box::new(ProviderHandle {
-         provider: provider_box, // Move the Box into ProviderHandle
-         lib: lib,
-     });
- 
-     Box::into_raw(handle)
- }
- 
- // Destroy the provider instance
- #[no_mangle]
- pub extern "C" fn destroy_provider_instance(handle: *mut ProviderHandle) {
-     if !handle.is_null() {
-         unsafe {
-             drop(Box::from_raw(handle));
-         }
-     }
- }
- 
- // Initialize the provider with JSON configuration
- #[no_mangle]
- pub extern "C" fn init_provider(handle: *mut ProviderHandle, config_json: *const c_char) -> i32 {    
-     if handle.is_null() {
-         eprintln!("Error: handle pointer is null");
-         return -1;
-     }
-     
-     if config_json.is_null() {
-         eprintln!("Error: config_json pointer is null");
-         return -1;
-     }
-     
-     let config_str = match unsafe { CStr::from_ptr(config_json).to_str() } {
-         Ok(str) => str,
-         Err(err) => {
-             eprintln!("Error converting config_json to string: {:?}", err);
-             return -1;
-         },
-     };
-     let config: ProviderConfig = match serde_json::from_str(config_str) {
-         Ok(cfg) => cfg,
-         Err(err) => {
-             eprintln!("Error deserializing config_json: {:?}", err);
-             return -1;
-         },
-     };
-     let handle_ref = unsafe { &*handle };
-     match handle_ref.provider.init(config) {
-         Ok(_) => {
-             return 0;
-         }
-         Err(err) => {
-             eprintln!("Error during provider initialization: {:?}", err);
-             return -1;
-         },
-     }
- }
- 
- // Get validation rule as a JSON string
- #[no_mangle]
- pub extern "C" fn get_validation_rule(handle: *mut ProviderHandle) -> *mut c_char {
-     let handle = unsafe { &*handle };
-     match handle.provider.get_validation_rule() {
-         Ok(validation_rule) => {
-             match CString::new(serde_json::to_string(&validation_rule).unwrap()) {
-                 Ok(cstr) => cstr.into_raw(),
-                 Err(_) => ptr::null_mut(),
-             }
-         }
-         Err(_) => ptr::null_mut(),
-     }
- }
- 
- // Get components as a JSON string
- #[no_mangle]
- pub extern "C" fn get(
-     handle: *mut ProviderHandle,
-     deployment_json: *const c_char,
-     references_json: *const c_char,
- ) -> *mut c_char {
-     let handle = unsafe { &*handle };
-     let deployment_str = unsafe { CStr::from_ptr(deployment_json).to_str().unwrap() };
-     let references_str = unsafe { CStr::from_ptr(references_json).to_str().unwrap() };
-     let deployment: DeploymentSpec = serde_json::from_str(deployment_str).unwrap();
-     let references: Vec<ComponentStep> = serde_json::from_str(references_str).unwrap();
-     match handle.provider.get(deployment, references) {
-         Ok(components) => {
-             let json = serde_json::to_string(&components).unwrap();
-             CString::new(json).unwrap().into_raw()
-         }
-         Err(_) => {
-             println!("Error getting components");
-             ptr::null_mut()
-         } 
-     }
- }
- 
- // Apply deployment as a JSON string
- #[no_mangle]
- pub extern "C" fn apply(
-     handle: *mut ProviderHandle,
-     deployment_json: *const c_char,
-     step_json: *const c_char,
-     is_dry_run: i32,
- ) -> *mut c_char {
-     let handle = unsafe { &*handle };
-     let deployment_str = unsafe { CStr::from_ptr(deployment_json).to_str().unwrap() };
-     let step_str = unsafe { CStr::from_ptr(step_json).to_str().unwrap() };
-     let deployment: DeploymentSpec = serde_json::from_str(deployment_str).unwrap();
-     let step: DeploymentStep = serde_json::from_str(step_str).unwrap();
-     let is_dry_run = is_dry_run != 0;
-    
-     match handle.provider.apply(deployment, step, is_dry_run) {
-         Ok(result_map) => {
-             let json = serde_json::to_string(&result_map).unwrap();
-             CString::new(json).unwrap().into_raw()
-         }
-         Err(_) => ptr::null_mut(),
-     }
- }
+use core::ffi::c_char;
+use libloading::Library;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::ffi::{CStr, CString};
+use std::fs::File;
+use std::io;
+use std::ptr;
+use tracing::{debug, error, warn};
+
+pub mod models;
+use crate::models::*;
+
+/// Computes the SHA-256 hash of a file.
+fn compute_sha256_hash(file_path: &str) -> Result<String, io::Error> {
+    let mut file = File::open(file_path)?;
+    let mut hasher = Sha256::new();
+    io::copy(&mut file, &mut hasher)?;
+    let hash = hasher.finalize();
+    Ok(format!("{:x}", hash))
+}
+
+/// Validates the computed hash against the expected hash value.
+fn validate_hash(file_path: &str, expected_hash: &str) -> Result<(), String> {
+    debug!("expected hash value: {}", expected_hash);
+    if "any".eq(expected_hash) {
+        warn!("Validation of shared library's hash value has been disabled! Make sure that the shared library is what you expect it to be!");
+        return Ok(());
+    }
+    let computed_hash =
+        compute_sha256_hash(file_path).map_err(|e| format!("Error computing hash: {}", e))?;
+
+    if computed_hash == expected_hash {
+        Ok(())
+    } else {
+        Err(format!(
+            "Hash mismatch! Expected: {}, Got: {}",
+            expected_hash, computed_hash
+        ))
+    }
+}
+
+/// A Rust-based Symphony Target Provider.
+pub trait ITargetProvider: Send + Sync {
+    fn get_validation_rule(&self) -> Result<ValidationRule, String>;
+
+    fn get(
+        &self,
+        deployment: DeploymentSpec,
+        references: Vec<ComponentStep>,
+    ) -> Result<Vec<ComponentSpec>, String>;
+
+    fn apply(
+        &self,
+        deployment: DeploymentSpec,
+        step: DeploymentStep,
+        is_dry_run: bool,
+    ) -> Result<HashMap<String, ComponentResultSpec>, String>;
+}
+
+/// A reference to the Target Provider instance that
+/// has been created using a dynamically loaded library.
+#[repr(C)]
+pub struct ProviderHandle {
+    provider: Box<dyn ITargetProvider>,
+    // Keep the library loaded to ensure the provider's functions remain valid
+    lib: Library,
+}
+
+pub struct ProviderWrapper {
+    pub inner: Box<dyn ITargetProvider>,
+}
+
+/// Creates a new instance of the provider.
+///
+/// The Symphony runtime invokes this function to create a new Rust-based Target Provider based on
+/// configuration properties specified for a Symphony _Target_'s binding.
+///
+/// This function tries to create the new instance by means of a dynamically loaded shared library
+/// that it expects to find at the given path. The library must contain a function with the
+/// following signature:
+///
+/// ```
+/// use core::ffi::c_char;
+/// use rust_binding::ProviderWrapper;
+///
+/// #[no_mangle]
+/// pub unsafe extern "C" fn create_provider(config_json: *const c_char) -> *mut ProviderWrapper {
+///   todo!()
+/// }
+/// ```
+///
+/// The library's provenance/integrity is verified by means of computing the SHA256 hash value for the library file
+/// and comparing it to the expected hash value.
+///
+/// # Arguments
+///
+/// * `provider_path` - A UTF8 string containing the absolute path to the shared
+///                     library that contains the provider code.
+///                     The new instance will be created by looking up and
+///                     invoking the shared library's `create_provider` function.
+/// * `expected_hash` - A UTF8 string containing the hex representation of the hash
+///                     code to use for verifying the integrity of the shared library.
+///                     This value will be compared to the SHA256 hash value computed
+///                     for the given library.
+///                     A value of `any` disables the check. This is useful during
+///                     development, when updating the expected hash value for each
+///                     build cycle seems undesirable/unnecessary.
+/// * `config_json` - The UTF8 representation of the JSON encoded provider configuration.
+///
+/// # Returns
+///
+/// A wrapper around the newly created provider instance or a `null` pointer
+/// if the provider instance could not be created using the given library, e.g. because the
+/// library file does not exist or its hash value does not match the expected value or the
+/// library does not contain the required symbol.
+///
+/// # Safety
+///
+/// Client code needs to make sure that the provided pointers are valid.
+#[no_mangle]
+pub unsafe extern "C" fn create_provider_instance(
+    provider_path: *const c_char,
+    expected_hash: *const c_char,
+    config_json: *const c_char,
+) -> *mut ProviderHandle {
+    // try to configure tracing to output Events to stdout
+    if tracing_subscriber::fmt::try_init().is_err() {
+        // This will fail on subsequent invocations of the target provider's functions
+        // because the provider is stateless and thus newly created for each and every invocation.
+        // Consequently, we do not need to clutter stdout with corresponding warning
+        // but can assume that the subscriber has been initialized one way or the other ...
+    }
+    let Ok(provider_path) = unsafe { CStr::from_ptr(provider_path) }.to_str() else {
+        error!("Path to shared library is not valid UTF-8");
+        return ptr::null_mut();
+    };
+
+    let Ok(expected_hash) = unsafe { CStr::from_ptr(expected_hash) }.to_str() else {
+        error!("Hash value is not valid UTF-8");
+        return ptr::null_mut();
+    };
+
+    // Validate the hash before loading the provider
+    if let Err(err) = validate_hash(provider_path, expected_hash) {
+        error!("Hash validation failed: {}", err);
+        return ptr::null_mut();
+    }
+
+    let Ok(lib) = (unsafe {
+        Library::new(provider_path).inspect_err(|err| {
+            error!("Failed to load provider library [{}]: {err}", provider_path);
+        })
+    }) else {
+        return ptr::null_mut();
+    };
+
+    let Ok(newly_created_provider_wrapper) = (unsafe {
+        type CreateProviderFn = unsafe extern "C" fn(*const c_char) -> *mut ProviderWrapper;
+        lib.get::<CreateProviderFn>(b"create_provider\0")
+            .map(|create_provider| create_provider(config_json))
+    }) else {
+        error!(
+            "Shared library [{}] does not contain required symbol: create_provider",
+            provider_path
+        );
+        return ptr::null_mut();
+    };
+
+    if newly_created_provider_wrapper.is_null() {
+        error!("Error: create_provider returned null pointer");
+        return ptr::null_mut();
+    }
+
+    // Take ownership of the `Box<dyn ITargetProvider>` from the wrapper
+    let provider = unsafe { Box::from_raw(newly_created_provider_wrapper).inner };
+
+    let handle = Box::new(ProviderHandle {
+        provider, // Move the Box into ProviderHandle
+        lib,
+    });
+
+    Box::into_raw(handle)
+}
+
+/// Destroys the provider instance.
+///
+/// # Safety
+///
+/// Client code needs to make sure that the passed in handle is a valid (raw) pointer.
+#[no_mangle]
+pub unsafe extern "C" fn destroy_provider_instance(handle: *mut ProviderHandle) {
+    if !handle.is_null() {
+        unsafe {
+            drop(Box::from_raw(handle));
+        }
+    }
+}
+
+/// Gets validation rule as a JSON string.
+///
+/// # Safety
+///
+/// Client code needs to make sure that the passed in arguments are valid (raw) pointers.
+#[no_mangle]
+pub unsafe extern "C" fn get_validation_rule(handle: *mut ProviderHandle) -> *mut c_char {
+    let handle = unsafe { &*handle };
+    match handle.provider.get_validation_rule() {
+        Ok(validation_rule) => {
+            match CString::new(serde_json::to_string(&validation_rule).unwrap()) {
+                Ok(cstr) => cstr.into_raw(),
+                Err(_) => ptr::null_mut(),
+            }
+        }
+        Err(_) => ptr::null_mut(),
+    }
+}
+
+/// Gets components as a JSON string.
+///
+/// # Safety
+///
+/// Client code needs to make sure that the passed in arguments are valid (raw) pointers.
+#[no_mangle]
+pub unsafe extern "C" fn get(
+    handle: *mut ProviderHandle,
+    deployment_json: *const c_char,
+    references_json: *const c_char,
+) -> *mut c_char {
+    let handle = unsafe { &*handle };
+    let deployment_str = unsafe { CStr::from_ptr(deployment_json).to_str().unwrap() };
+    let references_str = unsafe { CStr::from_ptr(references_json).to_str().unwrap() };
+    let deployment: DeploymentSpec = serde_json::from_str(deployment_str).unwrap();
+    let references: Vec<ComponentStep> = serde_json::from_str(references_str).unwrap();
+    match handle.provider.get(deployment, references) {
+        Ok(components) => {
+            let json = serde_json::to_string(&components).unwrap();
+            CString::new(json).unwrap().into_raw()
+        }
+        Err(err) => {
+            debug!("Error getting components: {err}");
+            ptr::null_mut()
+        }
+    }
+}
+
+/// Applies deployment as a JSON string.
+///
+/// # Safety
+///
+/// Client code needs to make sure that the passed in arguments are valid (raw) pointers.
+#[no_mangle]
+pub unsafe extern "C" fn apply(
+    handle: *mut ProviderHandle,
+    deployment_json: *const c_char,
+    step_json: *const c_char,
+    is_dry_run: i32,
+) -> *mut c_char {
+    let handle = unsafe { &*handle };
+    let deployment_str = unsafe { CStr::from_ptr(deployment_json).to_str().unwrap() };
+    let step_str = unsafe { CStr::from_ptr(step_json).to_str().unwrap() };
+    let deployment: DeploymentSpec = serde_json::from_str(deployment_str).unwrap();
+    let step: DeploymentStep = serde_json::from_str(step_str).unwrap();
+    let is_dry_run = is_dry_run != 0;
+
+    match handle.provider.apply(deployment, step, is_dry_run) {
+        Ok(result_map) => {
+            let json = serde_json::to_string(&result_map).unwrap();
+            CString::new(json).unwrap().into_raw()
+        }
+        Err(err) => {
+            debug!("Error applying changes: {err}");
+            ptr::null_mut()
+        }
+    }
+}

--- a/api/pkg/apis/v1alpha1/providers/target/rust/symphony/src/models.rs
+++ b/api/pkg/apis/v1alpha1/providers/target/rust/symphony/src/models.rs
@@ -1,49 +1,46 @@
 /*
- * Copyright (c) Microsoft Corporation.
+ * Copyright (c) Microsoft Corporation and others.
  * Licensed under the MIT license.
  * SPDX-License-Identifier: MIT
  */
 
- use serde::{Deserialize, Serialize};
- use std::collections::HashMap;
- use std::time::SystemTime;
- 
- use serde_json::Value;
- 
- pub type ProviderConfig = Value;
- 
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- pub struct ValidationRule {
-     #[serde(rename = "requiredType")]
-     pub required_component_type: String,
-     #[serde(rename = "componentValidationRule")]
-     pub component_validation_rule: ComponentValidationRule,
-     #[serde(rename = "sidecarValidationRule")]
-     pub sidecar_validation_rule: ComponentValidationRule,
-     #[serde(rename = "allowSidecar")]
-     pub allow_sidecar: bool,
-     #[serde(rename = "supportScopes")]
-     pub scope_isolation: bool,
-     #[serde(rename = "instanceIsolation")]
-     pub instance_isolation: bool,
- }
- 
- impl ValidationRule {
-    pub fn new() -> Self {
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::time::SystemTime;
+
+use serde_json::Value;
+
+pub type ProviderConfig = Value;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ValidationRule {
+    #[serde(rename = "requiredType")]
+    pub required_component_type: String,
+    #[serde(rename = "componentValidationRule")]
+    pub component_validation_rule: ComponentValidationRule,
+    #[serde(rename = "sidecarValidationRule")]
+    pub sidecar_validation_rule: ComponentValidationRule,
+    #[serde(rename = "allowSidecar")]
+    pub allow_sidecar: bool,
+    #[serde(rename = "supportScopes")]
+    pub scope_isolation: bool,
+    #[serde(rename = "instanceIsolation")]
+    pub instance_isolation: bool,
+}
+
+impl Default for ValidationRule {
+    fn default() -> Self {
         ValidationRule {
             required_component_type: "".to_string(),
             component_validation_rule: ComponentValidationRule {
                 required_component_type: "".to_string(),
-                change_detection_properties: vec![
-                    PropertyDesc {
-                        ignore_case: true,
-                        is_component_name: false,
-                        name: "*".to_string(),
-                        skip_if_missing: true,
-                        prefix_match: false,
-                    },
-                ],
+                change_detection_properties: vec![PropertyDesc {
+                    ignore_case: true,
+                    is_component_name: false,
+                    name: "*".to_string(),
+                    skip_if_missing: true,
+                    prefix_match: false,
+                }],
                 change_detection_metadata: vec![],
                 required_properties: vec![],
                 optional_properties: vec![],
@@ -66,24 +63,24 @@
     }
 }
 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct DeploymentSpec {
-     pub solution_name: String,
-     pub solution: SolutionState,
-     pub instance: InstanceState,
-     pub targets: HashMap<String, TargetState>,
-     pub devices: Option<Vec<DeviceSpec>>,
-     pub assignments: Option<HashMap<String, String>>,
-     pub component_start_index: Option<i32>,
-     pub component_end_index: Option<i32>,
-     pub active_target: Option<String>,
-     pub generation: Option<String>,
-     pub object_namespace: Option<String>,
-     pub hash: Option<String>,
- }
- 
- impl DeploymentSpec {
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DeploymentSpec {
+    pub solution_name: String,
+    pub solution: SolutionState,
+    pub instance: InstanceState,
+    pub targets: HashMap<String, TargetState>,
+    pub devices: Option<Vec<DeviceSpec>>,
+    pub assignments: Option<HashMap<String, String>>,
+    pub component_start_index: Option<i32>,
+    pub component_end_index: Option<i32>,
+    pub active_target: Option<String>,
+    pub generation: Option<String>,
+    pub object_namespace: Option<String>,
+    pub hash: Option<String>,
+}
+
+impl DeploymentSpec {
     /// Creates an empty `DeploymentSpec` with default values.
     pub fn empty() -> Self {
         DeploymentSpec {
@@ -122,88 +119,88 @@
     }
 }
 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct ComponentSpec {
-     pub name: String,
-     #[serde(rename = "type")]
-     pub component_type: Option<String>,
-     pub metadata: Option<HashMap<String, String>>,
-     pub properties: Option<HashMap<String, serde_json::Value>>,
-     pub parameters: Option<HashMap<String, String>>,
-     pub routes: Option<Vec<RouteSpec>>,
-     pub constraints: Option<String>,
-     pub dependencies: Option<Vec<String>>,
-     pub skills: Option<Vec<String>>,
-     pub sidecars: Option<Vec<SidecarSpec>>,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- pub struct PropertyDesc {
-     pub name: String,
-     #[serde(rename = "ignoreCase")]
-     pub ignore_case: bool,
-     #[serde(rename = "skipIfMissing")]
-     pub skip_if_missing: bool,
-     #[serde(rename = "prefixMatch")]
-     pub prefix_match: bool,
-     #[serde(rename = "isComponentName")]
-     pub is_component_name: bool,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- pub struct ComponentValidationRule {
-     #[serde(rename = "requiredType")]
-     pub required_component_type: String,
-     #[serde(rename = "changeDetection")]
-     pub change_detection_properties: Vec<PropertyDesc>,
-     #[serde(rename = "changeDetectionMetadata")]
-     pub change_detection_metadata: Vec<PropertyDesc>,
-     #[serde(rename = "requiredProperties")]
-     pub required_properties: Vec<String>,
-     #[serde(rename = "optionalProperties")]
-     pub optional_properties: Vec<String>,
-     #[serde(rename = "requiredMetadata")]
-     pub required_metadata: Vec<String>,
-     #[serde(rename = "optionalMetadata")]
-     pub optional_metadata: Vec<String>,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct RouteSpec {
-     pub route: String,
-     #[serde(rename = "type")]
-     pub route_type: String,
-     pub properties: Option<HashMap<String, String>>,
-     pub filters: Option<Vec<FilterSpec>>,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct SidecarSpec {
-     pub name: Option<String>,
-     #[serde(rename = "type")]
-     pub sidecar_type: Option<String>,
-     pub properties: Option<HashMap<String, serde_json::Value>>,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct ComponentStep {
-     pub action: ComponentAction,
-     pub component: ComponentSpec,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct DeploymentStep {
-     pub target: Option<String>,
-     #[serde(default)]
-     pub components: Vec<ComponentStep>,
-     pub role: String,
-     pub is_first: bool,
- }
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentSpec {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub component_type: Option<String>,
+    pub metadata: Option<HashMap<String, String>>,
+    pub properties: Option<HashMap<String, serde_json::Value>>,
+    pub parameters: Option<HashMap<String, String>>,
+    pub routes: Option<Vec<RouteSpec>>,
+    pub constraints: Option<String>,
+    pub dependencies: Option<Vec<String>>,
+    pub skills: Option<Vec<String>>,
+    pub sidecars: Option<Vec<SidecarSpec>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PropertyDesc {
+    pub name: String,
+    #[serde(rename = "ignoreCase")]
+    pub ignore_case: bool,
+    #[serde(rename = "skipIfMissing")]
+    pub skip_if_missing: bool,
+    #[serde(rename = "prefixMatch")]
+    pub prefix_match: bool,
+    #[serde(rename = "isComponentName")]
+    pub is_component_name: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ComponentValidationRule {
+    #[serde(rename = "requiredType")]
+    pub required_component_type: String,
+    #[serde(rename = "changeDetection")]
+    pub change_detection_properties: Vec<PropertyDesc>,
+    #[serde(rename = "changeDetectionMetadata")]
+    pub change_detection_metadata: Vec<PropertyDesc>,
+    #[serde(rename = "requiredProperties")]
+    pub required_properties: Vec<String>,
+    #[serde(rename = "optionalProperties")]
+    pub optional_properties: Vec<String>,
+    #[serde(rename = "requiredMetadata")]
+    pub required_metadata: Vec<String>,
+    #[serde(rename = "optionalMetadata")]
+    pub optional_metadata: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RouteSpec {
+    pub route: String,
+    #[serde(rename = "type")]
+    pub route_type: String,
+    pub properties: Option<HashMap<String, String>>,
+    pub filters: Option<Vec<FilterSpec>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SidecarSpec {
+    pub name: Option<String>,
+    #[serde(rename = "type")]
+    pub sidecar_type: Option<String>,
+    pub properties: Option<HashMap<String, serde_json::Value>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentStep {
+    pub action: ComponentAction,
+    pub component: ComponentSpec,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DeploymentStep {
+    pub target: Option<String>,
+    #[serde(default)]
+    pub components: Vec<ComponentStep>,
+    pub role: String,
+    pub is_first: bool,
+}
 
 //  impl DeploymentStep {
 //     // The get_components method that returns a Vec<ComponentSpec>
@@ -215,436 +212,436 @@
 //         ret
 //     }
 // }
- 
- #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
- #[serde(rename_all = "camelCase")]
- pub enum ComponentAction {
-     Update,
-     Delete
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct SolutionState {
-     pub metadata: ObjectMeta,
-     pub spec: Option<SolutionSpec>,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct SolutionSpec {
-     pub display_name: Option<String>,
-     pub metadata: Option<HashMap<String, String>>,
-     pub components: Option<Vec<ComponentSpec>>,
-     pub version: Option<String>,
-     pub root_resource: Option<String>,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct InstanceState {
-     pub metadata: ObjectMeta,
-     pub spec: Option<InstanceSpec>,
-     pub status: InstanceStatus,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct InstanceSpec {
-     pub display_name: Option<String>,
-     pub scope: Option<String>,
-     pub parameters: Option<HashMap<String, String>>,
-     pub metadata: Option<HashMap<String, String>>,
-     pub solution: String,
-     pub target: Option<TargetSelector>, // Include TargetSelector
-     pub topologies: Option<Vec<TopologySpec>>,
-     pub pipelines: Option<Vec<PipelineSpec>>,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct TargetSelector {
-     pub name: Option<String>,
-     pub selector: Option<HashMap<String, String>>,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct TargetState {
-     pub metadata: ObjectMeta,
-     pub status: TargetStatus,
-     pub spec: Option<TargetSpec>,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct TargetSpec {
-     pub display_name: Option<String>,
-     pub scope: Option<String>,
-     pub metadata: Option<HashMap<String, String>>,
-     pub properties: Option<HashMap<String, String>>,
-     pub components: Option<Vec<ComponentSpec>>,
-     pub constraints: Option<String>,
-     pub topologies: Option<Vec<TopologySpec>>,
-     pub force_redeploy: Option<bool>,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct DeviceSpec {
-     pub display_name: Option<String>,
-     pub properties: Option<HashMap<String, String>>,
-     pub bindings: Option<Vec<BindingSpec>>,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct BindingSpec {
-     pub role: String,
-     pub provider: String,
-     pub config: Option<HashMap<String, String>>,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct FilterSpec {
-     pub direction: String,
-     pub filter_type: String,
-     pub parameters: Option<HashMap<String, String>>,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct TopologySpec {
-     pub device: Option<String>,
-     pub selector: Option<HashMap<String, String>>,
-     pub bindings: Option<Vec<BindingSpec>>,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct ObjectMeta {
-     pub namespace: Option<String>,
-     pub name: Option<String>,
-     pub generation: Option<String>,
-     pub labels: Option<HashMap<String, String>>,
-     pub annotations: Option<HashMap<String, String>>,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct InstanceStatus {
-     // Fields for instance status
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct TargetStatus {
-     // Fields for target status
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct PipelineSpec {
-     pub name: String,
-     pub skill: String,
-     pub parameters: Option<HashMap<String, String>>,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct DeployableStatus {
-     pub properties: Option<HashMap<String, String>>,
-     pub provisioning_status: ProvisioningStatus,
-     pub last_modified: Option<SystemTime>,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct ProvisioningStatus {
-     pub operation_id: String,
-     pub status: String,
-     pub failure_cause: Option<String>,
-     pub log_errors: Option<bool>,
-     pub error: Option<ErrorType>,
-     pub output: Option<HashMap<String, String>>,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct ErrorType {
-     pub code: Option<String>,
-     pub message: Option<String>,
-     pub target: Option<String>,
-     pub details: Option<Vec<TargetError>>,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct TargetError {
-     pub code: Option<String>,
-     pub message: Option<String>,
-     pub target: Option<String>,
-     pub details: Option<Vec<ComponentError>>,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct ComponentError {
-     pub code: Option<String>,
-     pub message: Option<String>,
-     pub target: Option<String>,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct ComponentResultSpec {
-     pub status: State,
-     pub message: String,
- }
- 
- #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
- #[serde(into = "u16", from = "u16")]
- pub enum State {
-     // HTTP Status codes
-     OK = 200,
-     Accepted = 202,
-     BadRequest = 400,
-     Unauthorized = 403,
-     NotFound = 404,
-     MethodNotAllowed = 405,
-     Conflict = 409,
-     InternalError = 500,
- 
-     // Config errors
-     BadConfig = 1000,
-     MissingConfig = 1001,
- 
-     // API invocation errors
-     InvalidArgument = 2000,
-     APIRedirect = 3030,
- 
-     // IO errors
-     FileAccessError = 4000,
- 
-     // Serialization errors
-     SerializationError = 5000,
-     DeserializeError = 5001,
- 
-     // Async requests
-     DeleteRequested = 6000,
- 
-     // Operation results
-     UpdateFailed = 8001,
-     DeleteFailed = 8002,
-     ValidateFailed = 8003,
-     Updated = 8004,
-     Deleted = 8005,
- 
-     // Workflow status
-     Running = 9994,
-     Paused = 9995,
-     Done = 9996,
-     Delayed = 9997,
-     Untouched = 9998,
-     NotImplemented = 9999,
- 
-     // Detailed error codes
-     InitFailed = 10000,
-     CreateActionConfigFailed = 10001,
-     HelmActionFailed = 10002,
-     GetComponentSpecFailed = 10003,
-     CreateProjectorFailed = 10004,
-     K8sRemoveServiceFailed = 10005,
-     K8sRemoveDeploymentFailed = 10006,
-     K8sDeploymentFailed = 10007,
-     ReadYamlFailed = 10008,
-     ApplyYamlFailed = 10009,
-     ReadResourcePropertyFailed = 10010,
-     ApplyResourceFailed = 10011,
-     DeleteYamlFailed = 10012,
-     DeleteResourceFailed = 10013,
-     CheckResourceStatusFailed = 10014,
-     ApplyScriptFailed = 10015,
-     RemoveScriptFailed = 10016,
-     YamlResourcePropertyNotFound = 10017,
-     GetHelmPropertyFailed = 10018,
-     HelmChartPullFailed = 10019,
-     HelmChartLoadFailed = 10020,
-     HelmChartApplyFailed = 10021,
-     HelmChartUninstallFailed = 10022,
-     IngressApplyFailed = 10023,
-     HttpNewRequestFailed = 10024,
-     HttpSendRequestFailed = 10025,
-     HttpErrorResponse = 10026,
-     MqttPublishFailed = 10027,
-     MqttApplyFailed = 10028,
-     MqttApplyTimeout = 10029,
-     ConfigMapApplyFailed = 10030,
-     HttpBadWaitStatusCode = 10031,
-     HttpNewWaitRequestFailed = 10032,
-     HttpSendWaitRequestFailed = 10033,
-     HttpErrorWaitResponse = 10034,
-     HttpBadWaitExpression = 10035,
-     ScriptExecutionFailed = 10036,
-     ScriptResultParsingFailed = 10037,
-     WaitToGetInstancesFailed = 10038,
-     WaitToGetSitesFailed = 10039,
-     WaitToGetCatalogsFailed = 10040,
-     InvalidWaitObjectType = 10041,
-     CatalogsGetFailed = 10042,
-     InvalidInstanceCatalog = 10043,
-     CreateInstanceFromCatalogFailed = 10044,
-     InvalidSolutionCatalog = 10045,
-     CreateSolutionFromCatalogFailed = 10046,
-     InvalidTargetCatalog = 10047,
-     CreateTargetFromCatalogFailed = 10048,
-     InvalidCatalogCatalog = 10049,
-     CreateCatalogFromCatalogFailed = 10050,
-     ParentObjectMissing = 10051,
-     ParentObjectCreateFailed = 10052,
-     MaterializeBatchFailed = 10053,
-     DeleteInstanceFailed = 10054,
-     CreateInstanceFailed = 10055,
-     DeploymentNotReached = 10056,
-     InvalidObjectType = 10057,
-     UnsupportedAction = 10058,
- 
-     // Instance controller errors
-     SolutionGetFailed = 11000,
-     TargetCandidatesNotFound = 11001,
-     TargetListGetFailed = 11002,
-     ObjectInstanceConversionFailed = 11003,
-     TimedOut = 11004,
- 
-     // Target controller errors
-     TargetPropertyNotFound = 12000,
- }
- 
- impl Into<u16> for State {
-     fn into(self) -> u16 {
-         self as u16
-     }
- }
- 
- impl From<u16> for State {
-     fn from(value: u16) -> Self {
-         match value {
-             // HTTP Status codes
-             200 => State::OK,
-             202 => State::Accepted,
-             400 => State::BadRequest,
-             403 => State::Unauthorized,
-             404 => State::NotFound,
-             405 => State::MethodNotAllowed,
-             409 => State::Conflict,
-             500 => State::InternalError,
- 
-             // Config errors
-             1000 => State::BadConfig,
-             1001 => State::MissingConfig,
- 
-             // API invocation errors
-             2000 => State::InvalidArgument,
-             3030 => State::APIRedirect,
- 
-             // IO errors
-             4000 => State::FileAccessError,
- 
-             // Serialization errors
-             5000 => State::SerializationError,
-             5001 => State::DeserializeError,
- 
-             // Async requests
-             6000 => State::DeleteRequested,
- 
-             // Operation results
-             8001 => State::UpdateFailed,
-             8002 => State::DeleteFailed,
-             8003 => State::ValidateFailed,
-             8004 => State::Updated,
-             8005 => State::Deleted,
- 
-             // Workflow status
-             9994 => State::Running,
-             9995 => State::Paused,
-             9996 => State::Done,
-             9997 => State::Delayed,
-             9998 => State::Untouched,
-             9999 => State::NotImplemented,
- 
-             // Detailed error codes
-             10000 => State::InitFailed,
-             10001 => State::CreateActionConfigFailed,
-             10002 => State::HelmActionFailed,
-             10003 => State::GetComponentSpecFailed,
-             10004 => State::CreateProjectorFailed,
-             10005 => State::K8sRemoveServiceFailed,
-             10006 => State::K8sRemoveDeploymentFailed,
-             10007 => State::K8sDeploymentFailed,
-             10008 => State::ReadYamlFailed,
-             10009 => State::ApplyYamlFailed,
-             10010 => State::ReadResourcePropertyFailed,
-             10011 => State::ApplyResourceFailed,
-             10012 => State::DeleteYamlFailed,
-             10013 => State::DeleteResourceFailed,
-             10014 => State::CheckResourceStatusFailed,
-             10015 => State::ApplyScriptFailed,
-             10016 => State::RemoveScriptFailed,
-             10017 => State::YamlResourcePropertyNotFound,
-             10018 => State::GetHelmPropertyFailed,
-             10019 => State::HelmChartPullFailed,
-             10020 => State::HelmChartLoadFailed,
-             10021 => State::HelmChartApplyFailed,
-             10022 => State::HelmChartUninstallFailed,
-             10023 => State::IngressApplyFailed,
-             10024 => State::HttpNewRequestFailed,
-             10025 => State::HttpSendRequestFailed,
-             10026 => State::HttpErrorResponse,
-             10027 => State::MqttPublishFailed,
-             10028 => State::MqttApplyFailed,
-             10029 => State::MqttApplyTimeout,
-             10030 => State::ConfigMapApplyFailed,
-             10031 => State::HttpBadWaitStatusCode,
-             10032 => State::HttpNewWaitRequestFailed,
-             10033 => State::HttpSendWaitRequestFailed,
-             10034 => State::HttpErrorWaitResponse,
-             10035 => State::HttpBadWaitExpression,
-             10036 => State::ScriptExecutionFailed,
-             10037 => State::ScriptResultParsingFailed,
-             10038 => State::WaitToGetInstancesFailed,
-             10039 => State::WaitToGetSitesFailed,
-             10040 => State::WaitToGetCatalogsFailed,
-             10041 => State::InvalidWaitObjectType,
-             10042 => State::CatalogsGetFailed,
-             10043 => State::InvalidInstanceCatalog,
-             10044 => State::CreateInstanceFromCatalogFailed,
-             10045 => State::InvalidSolutionCatalog,
-             10046 => State::CreateSolutionFromCatalogFailed,
-             10047 => State::InvalidTargetCatalog,
-             10048 => State::CreateTargetFromCatalogFailed,
-             10049 => State::InvalidCatalogCatalog,
-             10050 => State::CreateCatalogFromCatalogFailed,
-             10051 => State::ParentObjectMissing,
-             10052 => State::ParentObjectCreateFailed,
-             10053 => State::MaterializeBatchFailed,
-             10054 => State::DeleteInstanceFailed,
-             10055 => State::CreateInstanceFailed,
-             10056 => State::DeploymentNotReached,
-             10057 => State::InvalidObjectType,
-             10058 => State::UnsupportedAction,
- 
-             // Instance controller errors
-             11000 => State::SolutionGetFailed,
-             11001 => State::TargetCandidatesNotFound,
-             11002 => State::TargetListGetFailed,
-             11003 => State::ObjectInstanceConversionFailed,
-             11004 => State::TimedOut,
- 
-             // Target controller errors
-             12000 => State::TargetPropertyNotFound,
- 
-             _ => State::InternalError, // Default case for unknown values
-         }
-     }
- }
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum ComponentAction {
+    Update,
+    Delete,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SolutionState {
+    pub metadata: ObjectMeta,
+    pub spec: Option<SolutionSpec>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SolutionSpec {
+    pub display_name: Option<String>,
+    pub metadata: Option<HashMap<String, String>>,
+    pub components: Option<Vec<ComponentSpec>>,
+    pub version: Option<String>,
+    pub root_resource: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct InstanceState {
+    pub metadata: ObjectMeta,
+    pub spec: Option<InstanceSpec>,
+    pub status: InstanceStatus,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct InstanceSpec {
+    pub display_name: Option<String>,
+    pub scope: Option<String>,
+    pub parameters: Option<HashMap<String, String>>,
+    pub metadata: Option<HashMap<String, String>>,
+    pub solution: String,
+    pub target: Option<TargetSelector>, // Include TargetSelector
+    pub topologies: Option<Vec<TopologySpec>>,
+    pub pipelines: Option<Vec<PipelineSpec>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TargetSelector {
+    pub name: Option<String>,
+    pub selector: Option<HashMap<String, String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TargetState {
+    pub metadata: ObjectMeta,
+    pub status: TargetStatus,
+    pub spec: Option<TargetSpec>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TargetSpec {
+    pub display_name: Option<String>,
+    pub scope: Option<String>,
+    pub metadata: Option<HashMap<String, String>>,
+    pub properties: Option<HashMap<String, String>>,
+    pub components: Option<Vec<ComponentSpec>>,
+    pub constraints: Option<String>,
+    pub topologies: Option<Vec<TopologySpec>>,
+    pub force_redeploy: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceSpec {
+    pub display_name: Option<String>,
+    pub properties: Option<HashMap<String, String>>,
+    pub bindings: Option<Vec<BindingSpec>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BindingSpec {
+    pub role: String,
+    pub provider: String,
+    pub config: Option<HashMap<String, String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct FilterSpec {
+    pub direction: String,
+    pub filter_type: String,
+    pub parameters: Option<HashMap<String, String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TopologySpec {
+    pub device: Option<String>,
+    pub selector: Option<HashMap<String, String>>,
+    pub bindings: Option<Vec<BindingSpec>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ObjectMeta {
+    pub namespace: Option<String>,
+    pub name: Option<String>,
+    pub generation: Option<String>,
+    pub labels: Option<HashMap<String, String>>,
+    pub annotations: Option<HashMap<String, String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct InstanceStatus {
+    // Fields for instance status
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TargetStatus {
+    // Fields for target status
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PipelineSpec {
+    pub name: String,
+    pub skill: String,
+    pub parameters: Option<HashMap<String, String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DeployableStatus {
+    pub properties: Option<HashMap<String, String>>,
+    pub provisioning_status: ProvisioningStatus,
+    pub last_modified: Option<SystemTime>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ProvisioningStatus {
+    pub operation_id: String,
+    pub status: String,
+    pub failure_cause: Option<String>,
+    pub log_errors: Option<bool>,
+    pub error: Option<ErrorType>,
+    pub output: Option<HashMap<String, String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ErrorType {
+    pub code: Option<String>,
+    pub message: Option<String>,
+    pub target: Option<String>,
+    pub details: Option<Vec<TargetError>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TargetError {
+    pub code: Option<String>,
+    pub message: Option<String>,
+    pub target: Option<String>,
+    pub details: Option<Vec<ComponentError>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentError {
+    pub code: Option<String>,
+    pub message: Option<String>,
+    pub target: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentResultSpec {
+    pub status: State,
+    pub message: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[serde(into = "u16", from = "u16")]
+pub enum State {
+    // HTTP Status codes
+    OK = 200,
+    Accepted = 202,
+    BadRequest = 400,
+    Unauthorized = 403,
+    NotFound = 404,
+    MethodNotAllowed = 405,
+    Conflict = 409,
+    InternalError = 500,
+
+    // Config errors
+    BadConfig = 1000,
+    MissingConfig = 1001,
+
+    // API invocation errors
+    InvalidArgument = 2000,
+    APIRedirect = 3030,
+
+    // IO errors
+    FileAccessError = 4000,
+
+    // Serialization errors
+    SerializationError = 5000,
+    DeserializeError = 5001,
+
+    // Async requests
+    DeleteRequested = 6000,
+
+    // Operation results
+    UpdateFailed = 8001,
+    DeleteFailed = 8002,
+    ValidateFailed = 8003,
+    Updated = 8004,
+    Deleted = 8005,
+
+    // Workflow status
+    Running = 9994,
+    Paused = 9995,
+    Done = 9996,
+    Delayed = 9997,
+    Untouched = 9998,
+    NotImplemented = 9999,
+
+    // Detailed error codes
+    InitFailed = 10000,
+    CreateActionConfigFailed = 10001,
+    HelmActionFailed = 10002,
+    GetComponentSpecFailed = 10003,
+    CreateProjectorFailed = 10004,
+    K8sRemoveServiceFailed = 10005,
+    K8sRemoveDeploymentFailed = 10006,
+    K8sDeploymentFailed = 10007,
+    ReadYamlFailed = 10008,
+    ApplyYamlFailed = 10009,
+    ReadResourcePropertyFailed = 10010,
+    ApplyResourceFailed = 10011,
+    DeleteYamlFailed = 10012,
+    DeleteResourceFailed = 10013,
+    CheckResourceStatusFailed = 10014,
+    ApplyScriptFailed = 10015,
+    RemoveScriptFailed = 10016,
+    YamlResourcePropertyNotFound = 10017,
+    GetHelmPropertyFailed = 10018,
+    HelmChartPullFailed = 10019,
+    HelmChartLoadFailed = 10020,
+    HelmChartApplyFailed = 10021,
+    HelmChartUninstallFailed = 10022,
+    IngressApplyFailed = 10023,
+    HttpNewRequestFailed = 10024,
+    HttpSendRequestFailed = 10025,
+    HttpErrorResponse = 10026,
+    MqttPublishFailed = 10027,
+    MqttApplyFailed = 10028,
+    MqttApplyTimeout = 10029,
+    ConfigMapApplyFailed = 10030,
+    HttpBadWaitStatusCode = 10031,
+    HttpNewWaitRequestFailed = 10032,
+    HttpSendWaitRequestFailed = 10033,
+    HttpErrorWaitResponse = 10034,
+    HttpBadWaitExpression = 10035,
+    ScriptExecutionFailed = 10036,
+    ScriptResultParsingFailed = 10037,
+    WaitToGetInstancesFailed = 10038,
+    WaitToGetSitesFailed = 10039,
+    WaitToGetCatalogsFailed = 10040,
+    InvalidWaitObjectType = 10041,
+    CatalogsGetFailed = 10042,
+    InvalidInstanceCatalog = 10043,
+    CreateInstanceFromCatalogFailed = 10044,
+    InvalidSolutionCatalog = 10045,
+    CreateSolutionFromCatalogFailed = 10046,
+    InvalidTargetCatalog = 10047,
+    CreateTargetFromCatalogFailed = 10048,
+    InvalidCatalogCatalog = 10049,
+    CreateCatalogFromCatalogFailed = 10050,
+    ParentObjectMissing = 10051,
+    ParentObjectCreateFailed = 10052,
+    MaterializeBatchFailed = 10053,
+    DeleteInstanceFailed = 10054,
+    CreateInstanceFailed = 10055,
+    DeploymentNotReached = 10056,
+    InvalidObjectType = 10057,
+    UnsupportedAction = 10058,
+
+    // Instance controller errors
+    SolutionGetFailed = 11000,
+    TargetCandidatesNotFound = 11001,
+    TargetListGetFailed = 11002,
+    ObjectInstanceConversionFailed = 11003,
+    TimedOut = 11004,
+
+    // Target controller errors
+    TargetPropertyNotFound = 12000,
+}
+
+impl From<State> for u16 {
+    fn from(value: State) -> Self {
+        value as u16
+    }
+}
+
+impl From<u16> for State {
+    fn from(value: u16) -> Self {
+        match value {
+            // HTTP Status codes
+            200 => State::OK,
+            202 => State::Accepted,
+            400 => State::BadRequest,
+            403 => State::Unauthorized,
+            404 => State::NotFound,
+            405 => State::MethodNotAllowed,
+            409 => State::Conflict,
+            500 => State::InternalError,
+
+            // Config errors
+            1000 => State::BadConfig,
+            1001 => State::MissingConfig,
+
+            // API invocation errors
+            2000 => State::InvalidArgument,
+            3030 => State::APIRedirect,
+
+            // IO errors
+            4000 => State::FileAccessError,
+
+            // Serialization errors
+            5000 => State::SerializationError,
+            5001 => State::DeserializeError,
+
+            // Async requests
+            6000 => State::DeleteRequested,
+
+            // Operation results
+            8001 => State::UpdateFailed,
+            8002 => State::DeleteFailed,
+            8003 => State::ValidateFailed,
+            8004 => State::Updated,
+            8005 => State::Deleted,
+
+            // Workflow status
+            9994 => State::Running,
+            9995 => State::Paused,
+            9996 => State::Done,
+            9997 => State::Delayed,
+            9998 => State::Untouched,
+            9999 => State::NotImplemented,
+
+            // Detailed error codes
+            10000 => State::InitFailed,
+            10001 => State::CreateActionConfigFailed,
+            10002 => State::HelmActionFailed,
+            10003 => State::GetComponentSpecFailed,
+            10004 => State::CreateProjectorFailed,
+            10005 => State::K8sRemoveServiceFailed,
+            10006 => State::K8sRemoveDeploymentFailed,
+            10007 => State::K8sDeploymentFailed,
+            10008 => State::ReadYamlFailed,
+            10009 => State::ApplyYamlFailed,
+            10010 => State::ReadResourcePropertyFailed,
+            10011 => State::ApplyResourceFailed,
+            10012 => State::DeleteYamlFailed,
+            10013 => State::DeleteResourceFailed,
+            10014 => State::CheckResourceStatusFailed,
+            10015 => State::ApplyScriptFailed,
+            10016 => State::RemoveScriptFailed,
+            10017 => State::YamlResourcePropertyNotFound,
+            10018 => State::GetHelmPropertyFailed,
+            10019 => State::HelmChartPullFailed,
+            10020 => State::HelmChartLoadFailed,
+            10021 => State::HelmChartApplyFailed,
+            10022 => State::HelmChartUninstallFailed,
+            10023 => State::IngressApplyFailed,
+            10024 => State::HttpNewRequestFailed,
+            10025 => State::HttpSendRequestFailed,
+            10026 => State::HttpErrorResponse,
+            10027 => State::MqttPublishFailed,
+            10028 => State::MqttApplyFailed,
+            10029 => State::MqttApplyTimeout,
+            10030 => State::ConfigMapApplyFailed,
+            10031 => State::HttpBadWaitStatusCode,
+            10032 => State::HttpNewWaitRequestFailed,
+            10033 => State::HttpSendWaitRequestFailed,
+            10034 => State::HttpErrorWaitResponse,
+            10035 => State::HttpBadWaitExpression,
+            10036 => State::ScriptExecutionFailed,
+            10037 => State::ScriptResultParsingFailed,
+            10038 => State::WaitToGetInstancesFailed,
+            10039 => State::WaitToGetSitesFailed,
+            10040 => State::WaitToGetCatalogsFailed,
+            10041 => State::InvalidWaitObjectType,
+            10042 => State::CatalogsGetFailed,
+            10043 => State::InvalidInstanceCatalog,
+            10044 => State::CreateInstanceFromCatalogFailed,
+            10045 => State::InvalidSolutionCatalog,
+            10046 => State::CreateSolutionFromCatalogFailed,
+            10047 => State::InvalidTargetCatalog,
+            10048 => State::CreateTargetFromCatalogFailed,
+            10049 => State::InvalidCatalogCatalog,
+            10050 => State::CreateCatalogFromCatalogFailed,
+            10051 => State::ParentObjectMissing,
+            10052 => State::ParentObjectCreateFailed,
+            10053 => State::MaterializeBatchFailed,
+            10054 => State::DeleteInstanceFailed,
+            10055 => State::CreateInstanceFailed,
+            10056 => State::DeploymentNotReached,
+            10057 => State::InvalidObjectType,
+            10058 => State::UnsupportedAction,
+
+            // Instance controller errors
+            11000 => State::SolutionGetFailed,
+            11001 => State::TargetCandidatesNotFound,
+            11002 => State::TargetListGetFailed,
+            11003 => State::ObjectInstanceConversionFailed,
+            11004 => State::TimedOut,
+
+            // Target controller errors
+            12000 => State::TargetPropertyNotFound,
+
+            _ => State::InternalError, // Default case for unknown values
+        }
+    }
+}


### PR DESCRIPTION
Improved several formal aspects of the Rust binding.
In particular
* added doc comments,
* made the code comply with the rustfmt rules,
* replaced println statements with tracing events.

Also removed ITargetProvider::init in favor of providing the (full)
JSON configuration to the create_provider function that is used to
create the Target Provider instance. This accounts for the fact that
it is usually a little tedious to alter internal state of an instance in
Rust.