### PR TITLE
[PublicPreview] Disable RecoverPanic in controller and enable fault tests (#696)

### DIFF
--- a/k8s/apis/fabric/v1/target_webhook.go
+++ b/k8s/apis/fabric/v1/target_webhook.go
@@ -100,7 +100,7 @@ var _ webhook.Defaulter = &Target{}
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Target) Default() {
 	ctx := diagnostic.ConstructDiagnosticContextFromAnnotations(r.Annotations, context.TODO(), targetlog)
-	diagnostic.InfoWithCtx(targetlog, ctx, "default", "name", r.Name, "namespace", r.Namespace, "spec", r.Spec, "status", r.Status)
+	diagnostic.InfoWithCtx(targetlog, ctx, "default", "name", r.Name, "namespace", r.Namespace, "spec", r.Spec, "status", r.Status, "annotation", r.Annotations)
 
 	if r.Spec.DisplayName == "" {
 		r.Spec.DisplayName = r.ObjectMeta.Name

--- a/k8s/controllers/actions/catalogeval_controller.go
+++ b/k8s/controllers/actions/catalogeval_controller.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -162,8 +163,11 @@ func (r *CatalogEvalReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *CatalogEvalReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// We need to re-able recoverPanic once the behavior is tested #691
+	recoverPanic := false
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("CatalogEval").
+		WithOptions((controller.Options{RecoverPanic: &recoverPanic})).
 		For(&federationv1.CatalogEvalExpression{}).
 		Complete(r)
 }

--- a/k8s/controllers/ai/model_controller.go
+++ b/k8s/controllers/ai/model_controller.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	aiv1 "gopls-workspace/apis/ai/v1"
@@ -46,8 +47,11 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// We need to re-able recoverPanic once the behavior is tested #691
+	recoverPanic := false
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("Model").
+		WithOptions((controller.Options{RecoverPanic: &recoverPanic})).
 		For(&aiv1.Model{}).
 		Complete(r)
 }

--- a/k8s/controllers/ai/skill_controller.go
+++ b/k8s/controllers/ai/skill_controller.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	aiv1 "gopls-workspace/apis/ai/v1"
@@ -46,8 +47,11 @@ func (r *SkillReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SkillReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// We need to re-able recoverPanic once the behavior is tested #691
+	recoverPanic := false
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("Skill").
+		WithOptions((controller.Options{RecoverPanic: &recoverPanic})).
 		For(&aiv1.Skill{}).
 		Complete(r)
 }

--- a/k8s/controllers/ai/skillpackage_controller.go
+++ b/k8s/controllers/ai/skillpackage_controller.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	aiv1 "gopls-workspace/apis/ai/v1"
@@ -46,8 +47,11 @@ func (r *SkillPackageReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SkillPackageReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// We need to re-able recoverPanic once the behavior is tested #691
+	recoverPanic := false
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("SkillPackage").
+		WithOptions((controller.Options{RecoverPanic: &recoverPanic})).
 		For(&aiv1.SkillPackage{}).
 		Complete(r)
 }

--- a/k8s/controllers/fabric/device_controller.go
+++ b/k8s/controllers/fabric/device_controller.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	fabricv1 "gopls-workspace/apis/fabric/v1"
@@ -46,8 +47,11 @@ func (r *DeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *DeviceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// We need to re-able recoverPanic once the behavior is tested #691
+	recoverPanic := false
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("Device").
+		WithOptions((controller.Options{RecoverPanic: &recoverPanic})).
 		For(&fabricv1.Device{}).
 		Complete(r)
 }

--- a/k8s/controllers/fabric/target_polling_controller.go
+++ b/k8s/controllers/fabric/target_polling_controller.go
@@ -19,6 +19,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -103,8 +104,11 @@ func (r *TargetPollingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err != nil {
 		return err
 	}
+	// We need to re-able recoverPanic once the behavior is tested #691
+	recoverPanic := false
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("TargetPolling").
+		WithOptions((controller.Options{RecoverPanic: &recoverPanic})).
 		WithEventFilter(jobIDPredicate).
 		For(&symphonyv1.Target{}).
 		Complete(r)

--- a/k8s/controllers/fabric/target_queueing_controller.go
+++ b/k8s/controllers/fabric/target_queueing_controller.go
@@ -22,6 +22,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -121,8 +122,11 @@ func (r *TargetQueueingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err != nil {
 		return err
 	}
+	// We need to re-able recoverPanic once the behavior is tested #691
+	recoverPanic := false
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("TargetQueueing").
+		WithOptions((controller.Options{RecoverPanic: &recoverPanic})).
 		WithEventFilter(predicate.Or(genChangePredicate, operationIdPredicate)).
 		For(&symphonyv1.Target{}).
 		Complete(r)

--- a/k8s/controllers/federation/catalog_controller.go
+++ b/k8s/controllers/federation/catalog_controller.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	federationv1 "gopls-workspace/apis/federation/v1"
@@ -77,8 +78,11 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 // CatalogReconciler sets up the controller with the Manager.
 func (r *CatalogReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// We need to re-able recoverPanic once the behavior is tested #691
+	recoverPanic := false
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("Catalog").
+		WithOptions((controller.Options{RecoverPanic: &recoverPanic})).
 		For(&federationv1.Catalog{}).
 		Complete(r)
 }

--- a/k8s/controllers/federation/catalogcontainer_controller.go
+++ b/k8s/controllers/federation/catalogcontainer_controller.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	federationv1 "gopls-workspace/apis/federation/v1"
@@ -46,8 +47,11 @@ func (r *CatalogContainerReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *CatalogContainerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// We need to re-able recoverPanic once the behavior is tested #691
+	recoverPanic := false
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("CatalogContainer").
+		WithOptions((controller.Options{RecoverPanic: &recoverPanic})).
 		For(&federationv1.CatalogContainer{}).
 		Complete(r)
 }

--- a/k8s/controllers/federation/site_controller.go
+++ b/k8s/controllers/federation/site_controller.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	federationv1 "gopls-workspace/apis/federation/v1"
@@ -46,8 +47,11 @@ func (r *SiteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SiteReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// We need to re-able recoverPanic once the behavior is tested #691
+	recoverPanic := false
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("Site").
+		WithOptions((controller.Options{RecoverPanic: &recoverPanic})).
 		For(&federationv1.Site{}).
 		Complete(r)
 }

--- a/k8s/controllers/monitor/diagnostic_controller.go
+++ b/k8s/controllers/monitor/diagnostic_controller.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	monitorv1 "gopls-workspace/apis/monitor/v1"
@@ -47,8 +48,11 @@ func (r *DiagnosticReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *DiagnosticReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// We need to re-able recoverPanic once the behavior is tested #691
+	recoverPanic := false
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("Diagnostic").
+		WithOptions((controller.Options{RecoverPanic: &recoverPanic})).
 		For(&monitorv1.Diagnostic{}).
 		Complete(r)
 }

--- a/k8s/controllers/solution/instance_polling_controller.go
+++ b/k8s/controllers/solution/instance_polling_controller.go
@@ -19,6 +19,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -105,8 +106,11 @@ func (r *InstancePollingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	jobIDPredicate := predicates.JobIDPredicate{}
+	// We need to re-able recoverPanic once the behavior is tested #691
+	recoverPanic := false
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("InstancePolling").
+		WithOptions((controller.Options{RecoverPanic: &recoverPanic})).
 		For(&solution_v1.Instance{}).
 		WithEventFilter(jobIDPredicate).
 		Watches(new(solution_v1.Solution), handler.EnqueueRequestsFromMapFunc(

--- a/k8s/controllers/solution/instance_queueing_controller.go
+++ b/k8s/controllers/solution/instance_queueing_controller.go
@@ -25,6 +25,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -129,8 +130,11 @@ func (r *InstanceQueueingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	generationChange := predicate.GenerationChangedPredicate{}
 	operationIdPredicate := predicates.OperationIdPredicate{}
+	// We need to re-able recoverPanic once the behavior is tested
+	recoverPanic := false
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("InstanceQueueing").
+		WithOptions((controller.Options{RecoverPanic: &recoverPanic})).
 		For(&solution_v1.Instance{}).
 		WithEventFilter(predicate.Or(generationChange, operationIdPredicate)).
 		Watches(new(solution_v1.Solution), handler.EnqueueRequestsFromMapFunc(

--- a/k8s/controllers/solution/instancehistory_controller.go
+++ b/k8s/controllers/solution/instancehistory_controller.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	solutionv1 "gopls-workspace/apis/solution/v1"
@@ -46,8 +47,11 @@ func (r *InstanceHistoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *InstanceHistoryReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// We need to re-able recoverPanic once the behavior is tested #691
+	recoverPanic := false
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("InstanceHistory").
+		WithOptions((controller.Options{RecoverPanic: &recoverPanic})).
 		For(&solutionv1.InstanceHistory{}).
 		Complete(r)
 }

--- a/k8s/controllers/solution/solution_controller.go
+++ b/k8s/controllers/solution/solution_controller.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	solutionv1 "gopls-workspace/apis/solution/v1"
@@ -46,8 +47,11 @@ func (r *SolutionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SolutionReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// We need to re-able recoverPanic once the behavior is tested #691
+	recoverPanic := false
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("Solution").
+		WithOptions((controller.Options{RecoverPanic: &recoverPanic})).
 		For(&solutionv1.Solution{}).
 		Complete(r)
 }

--- a/k8s/controllers/solution/solutioncontainer_controller.go
+++ b/k8s/controllers/solution/solutioncontainer_controller.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -46,8 +47,11 @@ func (r *SolutionContainerReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SolutionContainerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// We need to re-able recoverPanic once the behavior is tested #691
+	recoverPanic := false
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("SolutionContainer").
+		WithOptions((controller.Options{RecoverPanic: &recoverPanic})).
 		For(&solutionv1.SolutionContainer{}).
 		Complete(r)
 }

--- a/k8s/controllers/workflow/activation_controller.go
+++ b/k8s/controllers/workflow/activation_controller.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	workflowv1 "gopls-workspace/apis/workflow/v1"
 	"gopls-workspace/configutils"
@@ -113,8 +114,11 @@ func convertRawExtensionToMap(raw *runtime.RawExtension) map[string]interface{} 
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ActivationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// We need to re-able recoverPanic once the behavior is tested #691
+	recoverPanic := false
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("Activation").
+		WithOptions((controller.Options{RecoverPanic: &recoverPanic})).
 		For(&workflowv1.Activation{}).
 		Complete(r)
 }

--- a/k8s/controllers/workflow/campaign_controller.go
+++ b/k8s/controllers/workflow/campaign_controller.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	workflowv1 "gopls-workspace/apis/workflow/v1"
@@ -46,8 +47,11 @@ func (r *CampaignReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *CampaignReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// We need to re-able recoverPanic once the behavior is tested #691
+	recoverPanic := false
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("Campaign").
+		WithOptions((controller.Options{RecoverPanic: &recoverPanic})).
 		For(&workflowv1.Campaign{}).
 		Complete(r)
 }

--- a/k8s/controllers/workflow/campaigncontainer_controller.go
+++ b/k8s/controllers/workflow/campaigncontainer_controller.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	workflowv1 "gopls-workspace/apis/workflow/v1"
@@ -46,8 +47,11 @@ func (r *CampaignContainerReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *CampaignContainerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// We need to re-able recoverPanic once the behavior is tested #691
+	recoverPanic := false
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("CampaignContainer").
+		WithOptions((controller.Options{RecoverPanic: &recoverPanic})).
 		For(&workflowv1.CampaignContainer{}).
 		Complete(r)
 }

--- a/k8s/reconcilers/deployment.go
+++ b/k8s/reconcilers/deployment.go
@@ -231,6 +231,7 @@ func (r *DeploymentReconciler) PollingResult(ctx context.Context, object Reconci
 
 	// populate diagnostics and activities from annotations
 	ctx = r.populateDiagnosticsAndActivitiesFromAnnotations(ctx, object, operationName, r.kubeClient, log)
+	diagnostic.InfoWithCtx(log, ctx, "Populated diagnostics and activities from annotations")
 	// Get reconciliation interval
 	reconciliationInterval, timeout := r.deriveReconcileInterval(log, ctx, object)
 
@@ -251,6 +252,7 @@ func (r *DeploymentReconciler) PollingResult(ctx context.Context, object Reconci
 		}
 	} else {
 		if object.GetAnnotations()[operationStartTimeKey] == "" {
+			diagnostic.InfoWithCtx(log, ctx, "failed to get operation start time")
 			return metrics.DeploymentPolling, ctrl.Result{RequeueAfter: r.pollInterval}, nil
 		}
 		// If the object hasn't reached a terminal state and the time since the operation started is greater than the


### PR DESCRIPTION
* Disable RecoverPanic in controller and enable fault tests

* Skip verifying stageHistory in fault tests

* add logging

* Move readyflag after endpoint is ready

* disable pr gate and add schedule run