### PR TITLE
Jiaxinyan/latency

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/solution/summary-cleanup-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/solution/summary-cleanup-manager.go
@@ -17,7 +17,7 @@ import (
 	observability "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/observability"
 	observ_utils "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/observability/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
-	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/states"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers/states"
 )
 
 const (

--- a/api/pkg/apis/v1alpha1/managers/solution/summary-cleanup-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/solution/summary-cleanup-manager.go
@@ -8,6 +8,7 @@ package solution
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
@@ -16,6 +17,10 @@ import (
 	observability "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/observability"
 	observ_utils "github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/observability/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
 )
 
 const (
@@ -64,6 +69,33 @@ func (s *SummaryCleanupManager) Poll() []error {
 	defer observ_utils.CloseSpanWithError(span, &err)
 
 	log.InfoCtx(ctx, "M (Summary Cleanup): Polling summaries")
+
+	// Initialize Kubernetes dynamic client
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		log.ErrorCtx(ctx, "Failed to create Kubernetes config: %v", err)
+		return []error{err}
+	}
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		log.ErrorCtx(ctx, "Failed to create dynamic client: %v", err)
+		return []error{err}
+	}
+
+	// Get resource counts
+	resourceCounts, err := s.getResourceCounts(ctx, dynamicClient)
+	if err != nil {
+		log.ErrorCtx(ctx, "Failed to get resource counts: %v", err)
+		return []error{err}
+	}
+
+	// Log the counts as a single string
+	log.InfofCtx(ctx, fmt.Sprintf(
+		"Summary: Found %d instances, %d targets, %d solutions, and %d solution containers across all namespaces",
+		resourceCounts["instances"], resourceCounts["targets"], resourceCounts["solutions"], resourceCounts["solutioncontainers"],
+	))
+
+	// Proceed with summary cleanup logic
 	summaries, err := s.ListSummary(ctx, "")
 	if err != nil {
 		return []error{err}
@@ -73,7 +105,11 @@ func (s *SummaryCleanupManager) Poll() []error {
 		// Check the upsert time of summary.
 		duration := time.Since(summary.Time)
 		if duration > s.SummaryRetentionDuration {
-			log.InfofCtx(ctx, "M (Summary Cleanup): Deleting summary %s since it has deprecated for %s", summary.SummaryId, duration.String())
+			log.InfofCtx(ctx, fmt.Sprintf(
+				"M (Summary Cleanup): Deleting summary %s since it has deprecated for %s",
+				summary.SummaryId, duration.String(),
+			))
+
 			err = s.DeleteSummary(ctx, summary.SummaryId, "", false)
 			if err != nil {
 				ret = append(ret, err)
@@ -81,6 +117,55 @@ func (s *SummaryCleanupManager) Poll() []error {
 		}
 	}
 	return ret
+}
+
+// getResourceCounts is a helper function to get resource counts across all namespaces
+func (s *SummaryCleanupManager) getResourceCounts(ctx context.Context, client dynamic.Interface) (map[string]int, error) {
+	// Define the GVRs (GroupVersionResource) for the resources
+	resourceGVRs := map[string]schema.GroupVersionResource{
+		"instances":          {Group: "solution.symphony", Version: "v1", Resource: "instances"},
+		"targets":            {Group: "fabric.symphony", Version: "v1", Resource: "targets"},
+		"solutions":          {Group: "solution.symphony", Version: "v1", Resource: "solutions"},
+		"solutioncontainers": {Group: "solution.symphony", Version: "v1", Resource: "solutioncontainers"},
+	}
+
+	// Get all namespaces
+	namespaces, err := client.Resource(schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "namespaces",
+	}).List(ctx, v1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	log.InfofCtx(ctx, fmt.Sprintf("Found %d namespaces", len(namespaces.Items)))
+
+	// Initialize counters
+	resourceCounts := make(map[string]int)
+
+	// Iterate through namespaces and count resources
+	for _, ns := range namespaces.Items {
+		namespace := ns.GetName()
+		log.InfofCtx(ctx, fmt.Sprintf("Checking namespace: %s", namespace))
+
+		for resourceName, gvr := range resourceGVRs {
+			resourceCounts[resourceName] += countResources(ctx, client, gvr, namespace, resourceName)
+		}
+	}
+
+	return resourceCounts, nil
+}
+
+// countResources is a helper function to count resources in a namespace
+func countResources(ctx context.Context, client dynamic.Interface, gvr schema.GroupVersionResource, namespace, resourceName string) int {
+	resources, err := client.Resource(gvr).Namespace(namespace).List(ctx, v1.ListOptions{})
+	if err != nil {
+		log.InfofCtx(ctx, fmt.Sprintf("Failed to list %s in namespace %s: %v", resourceName, namespace, err))
+		return 0
+	}
+	log.InfofCtx(ctx, fmt.Sprintf("Namespace: %s, Found %d %s", namespace, len(resources.Items), resourceName))
+	return len(resources.Items)
 }
 
 func (s *SummaryCleanupManager) Reconcil() []error {

--- a/k8s/reconcilers/deployment.go
+++ b/k8s/reconcilers/deployment.go
@@ -505,19 +505,19 @@ func (r *DeploymentReconciler) updateObjectStatus(ctx context.Context, object Re
 
 	// Check if the operation is in a final status
 	if status == utilsmodel.ProvisioningStatusSucceeded || status == utilsmodel.ProvisioningStatusFailed {
-		var timeout time.Duration
+		var latency time.Duration
 		if isRemoval { // For delete operations
-			timeout = time.Since(object.GetDeletionTimestamp().Time)
+			latency = time.Since(object.GetDeletionTimestamp().Time)
 		} else { // For create or update operations
 			startTimeStr := object.GetAnnotations()[operationStartTimeKey]
 			startTime, parseErr := time.Parse(time.RFC3339, startTimeStr)
 			if parseErr != nil {
 				diagnostic.ErrorWithCtx(log, ctx, parseErr, "Failed to parse operation start time")
 			} else {
-				timeout = time.Since(startTime)
+				latency = time.Since(startTime)
 			}
 		}
-		diagnostic.InfoWithCtx(log, ctx, fmt.Sprintf("Operation reached final status: status=%s, timeout=%s", status, timeout))
+		diagnostic.InfoWithCtx(log, ctx, fmt.Sprintf("Operation reached final status: status=%s, latency=%s", status, latency))
 	}
 
 	r.patchBasicStatusProps(ctx, object, summaryResult, status, nextStatus, opts, log)

--- a/k8s/reconcilers/deployment.go
+++ b/k8s/reconcilers/deployment.go
@@ -203,7 +203,7 @@ func (r *DeploymentReconciler) AttemptUpdate(ctx context.Context, object Reconci
 	// gofail: var beforeQueueJob string
 	if err := r.queueDeploymentJob(ctx, object, isRemoval, operationStartTimeKey); err != nil {
 		diagnostic.ErrorWithCtx(log, ctx, err, "failed to queue deployment job")
-		return r.handleDeploymentError(ctx, object, nil, isRemoval, reconciliationInterval, err, log)
+		return r.handleDeploymentError(ctx, object, nil, isRemoval, reconciliationInterval, operationStartTimeKey, err, log)
 	}
 	// DO NOT REMOVE THIS COMMENT
 	// gofail: var afterQueueJob string
@@ -351,7 +351,7 @@ func (r *DeploymentReconciler) PollingResult(ctx context.Context, object Reconci
 	}
 }
 
-func (r *DeploymentReconciler) handleDeploymentError(ctx context.Context, object Reconcilable, summary *model.SummaryResult, isRemoval bool, reconcileInterval time.Duration, err error, log logr.Logger) (metrics.OperationStatus, ctrl.Result, error) {
+func (r *DeploymentReconciler) handleDeploymentError(ctx context.Context, object Reconcilable, summary *model.SummaryResult, isRemoval bool, reconcileInterval time.Duration, operationStartTimeKey string, err error, log logr.Logger) (metrics.OperationStatus, ctrl.Result, error) {
 	patchOptions := patchStatusOptions{}
 	if isTermnalError(err, termialErrors) {
 		patchOptions.terminalErr = err
@@ -360,7 +360,7 @@ func (r *DeploymentReconciler) handleDeploymentError(ctx context.Context, object
 	}
 
 	// update the object status
-	if _, err = r.updateObjectStatus(ctx, object, summary, patchOptions, log, isRemoval, constants.OperationStartTimeKey); err != nil {
+	if _, err = r.updateObjectStatus(ctx, object, summary, patchOptions, log, isRemoval, operationStartTimeKey); err != nil {
 		return metrics.StatusUpdateFailed, ctrl.Result{}, err
 	}
 

--- a/k8s/reconcilers/deployment.go
+++ b/k8s/reconcilers/deployment.go
@@ -209,7 +209,7 @@ func (r *DeploymentReconciler) AttemptUpdate(ctx context.Context, object Reconci
 	// gofail: var afterQueueJob string
 
 	diagnostic.InfoWithCtx(log, ctx, "Updating object status with deployment queued")
-	if _, err := r.updateObjectStatus(ctx, object, nil, patchStatusOptions{deploymentQueued: true}, log); err != nil {
+	if _, err := r.updateObjectStatus(ctx, object, nil, patchStatusOptions{deploymentQueued: true}, log, isRemoval, operationStartTimeKey); err != nil {
 		diagnostic.ErrorWithCtx(log, ctx, err, "failed to update object status with deployment queued")
 		return metrics.StatusUpdateFailed, ctrl.Result{}, err
 	}
@@ -245,7 +245,7 @@ func (r *DeploymentReconciler) PollingResult(ctx context.Context, object Reconci
 			diagnostic.InfoWithCtx(log, ctx, "Operation timed out", "timeout", r.deleteTimeOut)
 			if _, err := r.updateObjectStatus(ctx, object, nil, patchStatusOptions{
 				terminalErr: v1alpha2.NewCOAError(nil, "failed to completely delete the resource within the allocated time", v1alpha2.TimedOut),
-			}, log); err != nil {
+			}, log, isRemoval, operationStartTimeKey); err != nil {
 				diagnostic.ErrorWithCtx(log, ctx, err, "failed to update object status with timeout error")
 				return metrics.StatusUpdateFailed, ctrl.Result{}, err
 			}
@@ -267,7 +267,7 @@ func (r *DeploymentReconciler) PollingResult(ctx context.Context, object Reconci
 			diagnostic.InfoWithCtx(log, ctx, "Failed to completely poll within the allocated time.", "timeout", timeout)
 			if _, err := r.updateObjectStatus(ctx, object, nil, patchStatusOptions{
 				terminalErr: v1alpha2.NewCOAError(nil, "failed to completely reconcile within the allocated time", v1alpha2.TimedOut),
-			}, log); err != nil {
+			}, log, isRemoval, operationStartTimeKey); err != nil {
 				diagnostic.ErrorWithCtx(log, ctx, err, "failed to update object status with timeout error")
 				return metrics.StatusUpdateFailed, ctrl.Result{}, err
 			}
@@ -283,7 +283,7 @@ func (r *DeploymentReconciler) PollingResult(ctx context.Context, object Reconci
 			if !timeOverDue {
 				if _, err := r.updateObjectStatus(ctx, object, summary, patchStatusOptions{
 					nonTerminalErr: err,
-				}, log); err != nil {
+				}, log, isRemoval, operationStartTimeKey); err != nil {
 					diagnostic.ErrorWithCtx(log, ctx, err, "failed to update object status with non-terminal error")
 					return metrics.StatusUpdateFailed, ctrl.Result{RequeueAfter: r.pollInterval}, err
 				}
@@ -314,7 +314,7 @@ func (r *DeploymentReconciler) PollingResult(ctx context.Context, object Reconci
 		// we'll update the status and also the current progress. Either way, we'll check back in POLL seconds
 		diagnostic.InfoWithCtx(log, ctx, "Updating object status when deployment is running")
 		if !timeOverDue {
-			if _, err := r.updateObjectStatus(ctx, object, summary, patchStatusOptions{}, log); err != nil {
+			if _, err := r.updateObjectStatus(ctx, object, summary, patchStatusOptions{}, log, isRemoval, operationStartTimeKey); err != nil {
 				diagnostic.ErrorWithCtx(log, ctx, err, "failed to update object status")
 				return metrics.StatusUpdateFailed, ctrl.Result{}, err
 			}
@@ -323,7 +323,7 @@ func (r *DeploymentReconciler) PollingResult(ctx context.Context, object Reconci
 		return metrics.DeploymentStatusPolled, ctrl.Result{RequeueAfter: r.pollInterval}, nil
 	case apimodel.SummaryStateDone:
 		diagnostic.InfoWithCtx(log, ctx, "Updating object status when deployment is done")
-		if _, err := r.updateObjectStatus(ctx, object, summary, patchStatusOptions{}, log); err != nil {
+		if _, err := r.updateObjectStatus(ctx, object, summary, patchStatusOptions{}, log, isRemoval, operationStartTimeKey); err != nil {
 			diagnostic.ErrorWithCtx(log, ctx, err, "failed to update object status")
 			return metrics.StatusUpdateFailed, ctrl.Result{}, err
 		}
@@ -360,7 +360,7 @@ func (r *DeploymentReconciler) handleDeploymentError(ctx context.Context, object
 	}
 
 	// update the object status
-	if _, err = r.updateObjectStatus(ctx, object, summary, patchOptions, log); err != nil {
+	if _, err = r.updateObjectStatus(ctx, object, summary, patchOptions, log, isRemoval, constants.OperationStartTimeKey); err != nil {
 		return metrics.StatusUpdateFailed, ctrl.Result{}, err
 	}
 
@@ -497,11 +497,28 @@ func (r *DeploymentReconciler) ensureOperationState(annotations map[string]strin
 	objectStatus.ProvisioningStatus.OperationID = annotations[constants.AzureOperationIdKey]
 }
 
-func (r *DeploymentReconciler) updateObjectStatus(ctx context.Context, object Reconcilable, summaryResult *model.SummaryResult, opts patchStatusOptions, log logr.Logger) (provisioningState string, err error) {
+func (r *DeploymentReconciler) updateObjectStatus(ctx context.Context, object Reconcilable, summaryResult *model.SummaryResult, opts patchStatusOptions, log logr.Logger, isRemoval bool, operationStartTimeKey string) (provisioningState string, err error) {
 	status := r.determineProvisioningStatus(ctx, object, summaryResult, opts, log)
 	originalStatus := object.GetStatus()
 	nextStatus := originalStatus.DeepCopy()
 	diagnostic.InfoWithCtx(log, ctx, "Updating object status", "status", status, "patchStatusOptions", opts)
+
+	// Check if the operation is in a final status
+	if status == utilsmodel.ProvisioningStatusSucceeded || status == utilsmodel.ProvisioningStatusFailed {
+		var timeout time.Duration
+		if isRemoval { // For delete operations
+			timeout = time.Since(object.GetDeletionTimestamp().Time)
+		} else { // For create or update operations
+			startTimeStr := object.GetAnnotations()[operationStartTimeKey]
+			startTime, parseErr := time.Parse(time.RFC3339, startTimeStr)
+			if parseErr != nil {
+				diagnostic.ErrorWithCtx(log, ctx, parseErr, "Failed to parse operation start time")
+			} else {
+				timeout = time.Since(startTime)
+			}
+		}
+		diagnostic.InfoWithCtx(log, ctx, fmt.Sprintf("Operation reached final status: status=%s, timeout=%s", status, timeout))
+	}
 
 	r.patchBasicStatusProps(ctx, object, summaryResult, status, nextStatus, opts, log)
 	r.patchComponentStatusReport(ctx, object, summaryResult, nextStatus, log)
@@ -518,7 +535,6 @@ func (r *DeploymentReconciler) updateObjectStatus(ctx context.Context, object Re
 		diagnostic.ErrorWithCtx(log, ctx, err, "failed to update object status")
 	}
 	return string(status), err
-
 }
 
 func (r *DeploymentReconciler) determineProvisioningStatus(ctx context.Context, object Reconcilable, summaryResult *model.SummaryResult, opts patchStatusOptions, log logr.Logger) utilsmodel.ProvisioningStatus {

--- a/packages/helm/symphony/files/symphony-api.json
+++ b/packages/helm/symphony/files/symphony-api.json
@@ -203,22 +203,15 @@
             "name": "summary-cleanup-manager",
             "type": "managers.symphony.summarycleanup",
             "properties": {
-              "providers.persistentstate": "redis-state",
+              "providers.persistentstate": "k8s-state",
               "RetentionDuration": "{{ .Values.SummaryCleanup.retentionDuration }}"                      
             },
             "providers": {
-              "redis-state": {
-                {{- if .Values.redis.enabled }}
-                "type": "providers.state.redis",
+              "k8s-state": {
+                "type": "providers.state.k8s",
                 "config": {
-                  "host": "{{ include "symphony.redisHost" . }}",
-                  "requireTLS": false,
-                  "password": ""
+                  "inCluster": true
                 }
-                {{- else }}
-                "type": "providers.state.memory",
-                "config": {}
-                {{- end }}
               }
             }
           }


### PR DESCRIPTION
For latency:
You can find the following log in symphony-controller-manager pod:
 {"level":"info","time":"2025-04-22T07:10:19.647Z","caller":"/k8s/reconcilers/deployment.go:520","msg":"Operation reached final status: status=Succeeded, timeout=10.647917417s","controller":"TargetPolling","controllerGroup":"fabric.symphony","controllerKind":"Target","Target":{"name":"test-target","namespace":"default"},"namespace":"default","name":"test-target","reconcileID":"94a5cb95-ecdf-4b93-a14e-3148c5254b18","diagnostics":"{\"correlationId\":\"836b95ef-24da-4fb3-bc29-548d07f9afa7\",\"resourceId\":\"\",\"traceContext\":{\"spanId\":\"\",\"traceId\":\"\"}}"}

For instance count: 
{"caller":"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/managers/solution.(*SummaryCleanupManager).Poll:78","diagnostics":{"correlationId":"","resourceId":"","traceContext":{"spanId":"b7d263e5b4757215","traceId":"a7e47bd5e3332a7ca132de444e4cdf5e"}},"instance":"symphony-api-7c4fcb8f85-l4k7x","level":"info","msg":"M (Summary Cleanup): Summary: Found 0 instances, 1 targets, 0 solutions, and 0 solution containers across all namespaces","scope":"coa.runtime","time":"2025-04-23T02:45:28.197798122Z","type":"log","ver":"0.48.34"}