### PR TITLE
add support for mTLS in the MQTT provider 

### DIFF
--- a/api/symphony-api-no-k8s-secure-mqtt.json
+++ b/api/symphony-api-no-k8s-secure-mqtt.json
@@ -1,0 +1,703 @@
+{
+  "siteInfo": {
+    "siteId": "laptop",
+    "properties": {
+      "name": "My Laptop",
+      "address": "1 Main Street",
+      "city": "Carnation",
+      "state": "WA",
+      "zip": "98014",
+      "country": "USA",
+      "phone": "425-555-1212",
+      "version": "0.45.1"
+    },
+    "currentSite": {
+      "baseUrl": "http://localhost:8082/v1alpha2/",
+      "username": "admin",
+      "password": ""
+    }
+  },
+  "api": {
+    "pubsub": {
+      "shared": true,
+      "provider": {
+        "type": "providers.pubsub.memory",
+        "config": {}
+      }
+    },
+    "keylock": {
+      "shared": true,
+      "provider": {      
+        "type": "providers.keylock.memory",
+        "config": {
+          "mode": "Global",
+          "cleanInterval" : 30,
+          "purgeDuration" : 43200
+        }
+      }
+    },
+    "vendors": [
+      {
+        "type": "vendors.settings",
+        "managers": [
+          {
+            "name": "config-manager",
+            "type": "managers.symphony.configs",
+            "properties": {
+              "singleton": "true"
+            },
+            "providers": {
+              "catalog": {
+                "type": "providers.config.catalog",
+                "config": {
+                  "user": "admin",
+                  "password": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "vendors.stage",
+        "route": "stage",
+        "managers": [
+          {
+            "name": "stage-manager",
+            "type": "managers.symphony.stage",
+            "properties": {   
+              "user": "admin",
+              "password": "",
+              "providers.volatilestate": "memory"        
+            },
+            "providers": {
+              "memory": {
+                "type": "providers.state.memory",
+                "config": {}
+              }
+            }
+          },
+          {
+            "name": "campaigns-manager",
+            "type": "managers.symphony.campaigns",
+            "properties": {
+              "providers.persistentstate": "k8s-state",
+              "singleton": "true"
+            },
+            "providers": {
+              "k8s-state": {
+                "type": "providers.state.memory",
+                "config": {}
+              }
+            }
+          },
+          {
+            "name": "activations-manager",
+            "type": "managers.symphony.activations",
+            "properties": {
+              "providers.persistentstate": "k8s-state",
+              "singleton": "true"
+            },
+            "providers": {
+              "k8s-state": {
+                "type": "providers.state.memory",
+                "config": {}
+              }
+            }
+          }
+        ],
+        "properties": {
+          "wait.user": "admin",
+          "wait.password": "",
+          "wait.wait.interval": "15",
+          "wait.wait.count": "10"
+        }
+      },
+      {
+        "type": "vendors.activations",
+        "route": "activations",
+        "managers": [
+          {
+            "name": "activations-manager",
+            "type": "managers.symphony.activations",
+            "properties": {
+              "providers.persistentstate": "k8s-state",
+              "useJobManager": "true",
+              "singleton": "true"
+            },
+            "providers": {
+              "k8s-state": {
+                "type": "providers.state.memory",
+                "config": {}
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "vendors.backgroundjob",
+        "route": "backgroundjob",
+        "loopInterval": 3600,
+        "managers": [
+          {
+            "name": "activations-cleanup-manager",
+            "type": "managers.symphony.activationscleanup",
+            "properties": {
+              "providers.persistentstate": "k8s-state",
+              "singleton": "true",
+              "RetentionDuration": "4320h"
+            },
+            "providers": {
+              "k8s-state": {
+                "type": "providers.state.memory",
+                "config": {}
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "vendors.campaigns",
+        "route": "campaigns",
+        "managers": [
+          {
+            "name": "campaigns-manager",
+            "type": "managers.symphony.campaigns",
+            "properties": {
+              "providers.persistentstate": "k8s-state",
+              "singleton": "true"
+            },
+            "providers": {
+              "k8s-state": {
+                "type": "providers.state.memory",
+                "config": {}
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "vendors.campaigncontainers",
+        "route": "campaigncontainers",
+        "managers": [
+          {
+            "name": "campaign-container-manager",
+            "type": "managers.symphony.campaigncontainers",
+            "properties": {
+              "providers.persistentstate": "k8s-state"
+            },
+            "providers": {
+              "k8s-state": {
+                "type": "providers.state.memory",
+                "config": {}
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "vendors.echo",
+        "route": "greetings",
+        "managers": []
+      },
+      {
+        "type": "vendors.jobs",
+        "route": "jobs",
+        "loopInterval": 15,
+        "managers": [
+          {
+            "name": "jobs-manager",
+            "type": "managers.symphony.jobs",
+            "properties": {
+              "providers.volatilestate": "mem-state",
+              "providers.persistentstate": "mem-state",
+              "user": "admin",
+              "password": "",
+              "interval": "#15",
+              "poll.enabled": "true",
+              "schedule.enabled": "true"                 
+            },
+            "providers": {
+              "mem-state": {
+                "type": "providers.state.memory",
+                "config": {}
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "vendors.targets",
+        "loopInterval": 15,
+        "route": "targets",
+        "managers": [
+          {
+            "name": "targets-manager",
+            "type": "managers.symphony.targets",
+            "properties": {
+              "providers.persistentstate": "k8s-state"
+            },
+            "providers": {
+              "k8s-state": {
+                "type": "providers.state.memory",
+                "config": {}
+              }
+            }
+          }
+        ],
+        "properties": {
+          "useJobManager": "true"
+        }
+      },
+      {
+        "type": "vendors.solutions",
+        "loopInterval": 15,
+        "route": "solutions",
+        "managers": [
+          {
+            "name": "solutions-manager",
+            "type": "managers.symphony.solutions",
+            "properties": {
+              "providers.persistentstate": "k8s-state"
+            },
+            "providers": {
+              "k8s-state": {
+                "type": "providers.state.memory",
+                "config": {}
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "vendors.instances",
+        "loopInterval": 15,
+        "route": "instances",
+        "managers": [
+          {
+            "name": "instances-manager",
+            "type": "managers.symphony.instances",
+            "properties": {
+              "providers.persistentstate": "k8s-state"
+            },
+            "providers": {
+              "k8s-state": {
+                "type": "providers.state.memory",
+                "config": {}
+              }
+            }
+          }
+        ],
+        "properties": {
+          "useJobManager": "true"
+        }
+      },
+	    {
+        "type": "vendors.solutioncontainers",
+        "route": "solutioncontainers",
+        "managers": [
+          {
+            "name": "solution-container-manager",
+            "type": "managers.symphony.solutioncontainers",
+            "properties": {
+              "providers.persistentstate": "k8s-state"
+            },
+            "providers": {
+              "k8s-state": {
+                "type": "providers.state.memory",
+                "config": {}
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "vendors.devices",
+        "loopInterval": 15,
+        "route": "devices",
+        "managers": [
+          {
+            "name": "devices-manager",
+            "type": "managers.symphony.devices",
+            "properties": {
+              "providers.persistentstate": "k8s-state"
+            },
+            "providers": {
+              "k8s-state": {
+                "type": "providers.state.memory",
+                "config": {}
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "vendors.models",
+        "loopInterval": 15,
+        "route": "models",
+        "managers": [
+          {
+            "name": "models-manager",
+            "type": "managers.symphony.models",
+            "properties": {
+              "providers.persistentstate": "k8s-state"
+            },
+            "providers": {
+              "k8s-state": {
+                "type": "providers.state.memory",
+                "config": {}
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "vendors.skills",
+        "loopInterval": 15,
+        "route": "skills",
+        "managers": [
+          {
+            "name": "skills-manager",
+            "type": "managers.symphony.skills",
+            "properties": {
+              "providers.persistentstate": "k8s-state"
+            },
+            "providers": {
+              "k8s-state": {
+                "type": "providers.state.memory",
+                "config": {}
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "vendors.users",
+        "loopInterval": 15,
+        "route": "users",
+        "properties": {
+          "test-users": "true"
+        },
+        "managers": [
+          {
+            "name": "users-manager",
+            "type": "managers.symphony.users",
+            "properties": {
+              "providers.volatilestate": "mem-state"
+            },
+            "providers": {
+              "mem-state": {
+                "type": "providers.state.memory",
+                "config": {}
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "vendors.solution",
+        "loopInterval": 15,
+        "route": "solution",
+        "managers": [
+          {
+            "name": "solution-manager",
+            "type": "managers.symphony.solution",
+            "properties": {
+              "providers.persistentstate": "mem-state",
+              "providers.config": "mock-config",
+              "providers.secret": "mock-secret",
+              "providers.keylock": "mem-keylock"
+            },
+            "providers": {
+              "mem-state": {
+                "type": "providers.state.memory",
+                "config": {}
+              },
+              "mem-keylock": {
+                "type": "providers.keylock.memory",
+                "config": {
+                  "mode" : "Shared"
+                }
+              },
+              "mock-config": {
+                "type": "providers.config.mock",
+                "config": {}
+              },
+              "mock-secret": {
+                "type": "providers.secret.mock",
+                "config": {}
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "vendors.agent",
+        "loopInterval": 15,
+        "route": "agent",
+        "managers": [
+          {
+            "name": "reference-manager",
+            "type": "managers.symphony.reference",
+            "properties": {
+              "providers.reference": "http-reference",
+              "providers.volatilestate": "memory",
+              "providers.reporter": "http-reporter"
+            },
+            "providers": {
+              "memory": {
+                "type": "providers.state.memory",
+                "config": {}
+              },
+              "http-reference": {
+                "type": "providers.reference.http",
+                "config": {}
+              },
+              "http-reporter": {
+                "type": "providers.reporter.http",
+                "config": {}
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "vendors.federation",
+        "route": "federation",
+        "loopInterval": 15,
+        "managers": [
+          {
+            "name": "trails-manager",
+            "type": "managers.symphony.trails",
+            "providers": {
+              "mock": {
+                "type": "providers.ledger.mock",
+                "config": {}
+              }
+            }
+          },
+          {
+            "name": "sites-manager",
+            "type": "managers.symphony.sites",
+            "properties": {
+              "providers.persistentstate": "memory"              
+            },
+            "providers": {
+              "memory": {
+                "type": "providers.state.memory",
+                "config": {}
+              }
+            }
+          },
+          {
+            "name": "catalogs-manager",
+            "type": "managers.symphony.catalogs",
+            "properties": {
+              "providers.persistentstate": "memory",
+              "singleton": "true"              
+            },
+            "providers": {
+              "memory": {
+                "type": "providers.state.memory",
+                "config": {}
+              }
+            }
+          },
+          {
+            "name": "staging-manager",
+            "type": "managers.symphony.staging",
+            "properties": {
+              "poll.enabled": "true",
+              "interval": "#15",
+              "providers.queue": "memory-queue",
+              "providers.volatilestate": "memory-state"              
+            },
+            "providers": {
+              "memory-queue": {
+                "type": "providers.queue.memory",
+                "config": {}
+              },
+              "memory-state": {
+                "type": "providers.state.memory",
+                "config": {}
+              }
+            }
+          },
+          {
+            "name": "sync-manager",
+            "type": "managers.symphony.sync",
+            "properties": {
+              "baseUrl": "http://localhost:8080/v1alpha2/",
+              "user": "admin",
+              "password": "",
+              "interval": "#15",
+              "sync.enabled": "true"
+            }
+          }
+        ]
+      },
+      {
+        "type": "vendors.catalogs",
+        "route": "catalogs",
+        "managers": [
+          {
+            "name": "catalogs-manager",
+            "type": "managers.symphony.catalogs",
+            "properties": {
+              "providers.persistentstate": "memory",
+              "singleton": "true"
+            },
+            "providers": {
+              "memory": {
+                "type": "providers.state.memory",
+                "config": {}
+              },
+              "graph": {
+                "type": "providers.graph.memory",
+                "config": {}
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "vendors.catalogcontainers",
+        "route": "catalogcontainers",
+        "managers": [
+          {
+            "name": "catalog-container-manager",
+            "type": "managers.symphony.catalogcontainers",
+            "properties": {
+              "providers.persistentstate": "memory",
+              "singleton": "true" 
+            },
+            "providers": {
+              "memory": {
+                "type": "providers.state.memory",
+                "config": {}
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "vendors.visualization",
+        "route": "visualization",
+        "managers": [
+          {
+            "name": "catalogs-manager",
+            "type": "managers.symphony.catalogs",
+            "properties": {
+              "providers.persistentstate": "memory",
+              "singleton": "true"
+            },
+            "providers": {
+              "memory": {
+                "type": "providers.state.memory",
+                "config": {}
+              },
+              "graph": {
+                "type": "providers.graph.memory",
+                "config": {}
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "bindings": [
+    {
+      "type": "bindings.mqtt",
+      "config": {
+        "brokerAddress": "ssl://MQTT_BROKER_ADDRESS:8883",
+        "clientID": "symphony-client",
+        "requestTopic": "symphony-request",
+        "responseTopic": "symphony-response",
+        "useTLS": "true",
+        "caCertPath": "/path/to/ca/cert/ca.crt",
+        "clientCertPath": "/path/to/client/cert/client.crt",
+        "clientKeyPath": "/path/to/client/key/client.key"
+      }
+    }, 
+    {
+      "type": "bindings.http",
+      "config": {
+        "port": 8082,
+        "pipeline": [
+          {
+            "type": "middleware.http.cors",
+            "properties": {
+              "Access-Control-Allow-Headers": "authorization,Content-Type",
+              "Access-Control-Allow-Credentials": "true",
+              "Access-Control-Allow-Methods": "HEAD,GET,POST,PUT,DELETE,OPTIONS",
+              "Access-Control-Allow-Origin": "*"
+            }
+          },
+          {
+            "type": "middleware.http.jwt",
+            "properties": {
+              "ignorePaths": ["/v1alpha2/users/auth", "/v1alpha2/solution/instances", "/v1alpha2/agent/references", "/v1alpha2/greetings"],
+              "verifyKey": "SymphonyKey",
+              "enableRBAC": true,
+              "roles": [
+                {
+                  "role": "administrator",
+                  "claim": "user",
+                  "value": "admin"
+                },
+                {
+                  "role": "reader",
+                  "claim": "user",
+                  "value": "*"
+                },
+                {
+                  "role": "solution-creator",
+                  "claim": "user",
+                  "value": "developer"
+                },
+                {
+                  "role": "target-manager",
+                  "claim": "user",
+                  "value": "device-manager"
+                },
+                {
+                  "role": "operator",
+                  "claim": "user",
+                  "value": "solution-operator"
+                }
+              ],
+              "policy": {
+                "administrator": {
+                  "items": {
+                    "*": "*"
+                  }
+                },
+                "reader": {
+                  "items": {
+                    "*": "GET"
+                  }
+                },
+                "solution-creator": {
+                  "items": {
+                    "/v1alpha2/solutions": "*"
+                  }
+                },
+                "target-manager": {
+                  "items": {
+                    "/v1alpha2/targets": "*"
+                  }
+                },
+                "solution-operator": {
+                  "items": {
+                    "/v1alpha2/instances": "*"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/coa/pkg/apis/v1alpha2/bindings/mqtt/mqtt.go
+++ b/coa/pkg/apis/v1alpha2/bindings/mqtt/mqtt.go
@@ -8,7 +8,12 @@ package mqtt
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
 	"strings"
 	"time"
 
@@ -21,10 +26,21 @@ import (
 var log = logger.NewLogger("coa.runtime")
 
 type MQTTBindingConfig struct {
-	BrokerAddress string `json:"brokerAddress"`
-	ClientID      string `json:"clientID"`
-	RequestTopic  string `json:"requestTopic"`
-	ResponseTopic string `json:"responseTopic"`
+	BrokerAddress      string `json:"brokerAddress"`
+	ClientID           string `json:"clientID"`
+	RequestTopic       string `json:"requestTopic"`
+	ResponseTopic      string `json:"responseTopic"`
+	TimeoutSeconds     int    `json:"timeoutSeconds,omitempty"`
+	KeepAliveSeconds   int    `json:"keepAliveSeconds,omitempty"`
+	PingTimeoutSeconds int    `json:"pingTimeoutSeconds,omitempty"`
+	// TLS/Certificate configuration fields
+	UseTLS             string `json:"useTLS,omitempty"`
+	CACertPath         string `json:"caCertPath,omitempty"`
+	ClientCertPath     string `json:"clientCertPath,omitempty"`
+	ClientKeyPath      string `json:"clientKeyPath,omitempty"`
+	InsecureSkipVerify string `json:"insecureSkipVerify,omitempty"`
+	Username           string `json:"username,omitempty"`
+	Password           string `json:"password,omitempty"`
 }
 
 type MQTTBinding struct {
@@ -44,13 +60,56 @@ func (m *MQTTBinding) Launch(config MQTTBindingConfig, endpoints []v1alpha2.Endp
 		routeTable[route] = endpoint
 	}
 
+	// Set default values
+	if config.KeepAliveSeconds <= 0 {
+		config.KeepAliveSeconds = 2
+	}
+	if config.PingTimeoutSeconds <= 0 {
+		config.PingTimeoutSeconds = 1
+	}
+
 	opts := gmqtt.NewClientOptions().AddBroker(config.BrokerAddress).SetClientID(config.ClientID)
-	opts.SetKeepAlive(2 * time.Second)
-	opts.SetPingTimeout(1 * time.Second)
+	opts.SetKeepAlive(time.Duration(config.KeepAliveSeconds) * time.Second)
+	opts.SetPingTimeout(time.Duration(config.PingTimeoutSeconds) * time.Second)
 	opts.CleanSession = false
+
+	// Configure authentication
+	if config.Username != "" {
+		opts.SetUsername(config.Username)
+	}
+	if config.Password != "" {
+		opts.SetPassword(config.Password)
+	}
+
+	// Configure TLS if enabled
+	if config.UseTLS == "true" {
+		tlsConfig, err := m.createTLSConfig(config)
+		if err != nil {
+			log.Errorf("MQTT Binding: failed to create TLS config - %+v", err)
+			return v1alpha2.NewCOAError(err, "failed to create TLS config", v1alpha2.InternalError)
+		}
+		opts.SetTLSConfig(tlsConfig)
+	}
+
 	m.MQTTClient = gmqtt.NewClient(opts)
 	if token := m.MQTTClient.Connect(); token.Wait() && token.Error() != nil {
-		return v1alpha2.NewCOAError(token.Error(), "failed to connect to MQTT broker", v1alpha2.InternalError)
+		connErr := token.Error()
+		log.Errorf("MQTT Binding: failed to connect to MQTT broker - %+v", connErr)
+		
+		// Provide specific guidance for common TLS errors
+		if strings.Contains(connErr.Error(), "certificate signed by unknown authority") {
+			log.Errorf("MQTT Binding: TLS certificate verification failed. Common solutions:")
+			log.Errorf("MQTT Binding: 1. Set 'caCertPath' to the path of your broker's CA certificate")
+			log.Errorf("MQTT Binding: 2. Set 'insecureSkipVerify' to 'true' for testing (not recommended for production)")
+			log.Errorf("MQTT Binding: 3. Ensure your broker certificate is issued by a trusted CA")
+		} else if strings.Contains(connErr.Error(), "tls:") {
+			log.Errorf("MQTT Binding: TLS connection error. Check your TLS configuration:")
+			log.Errorf("MQTT Binding: - Broker address should use 'ssl://' or 'tls://' prefix for TLS connections")
+			log.Errorf("MQTT Binding: - Verify CA certificate path and format")
+			log.Errorf("MQTT Binding: - Check client certificate and key paths if using mutual TLS")
+		}
+		
+		return v1alpha2.NewCOAError(connErr, "failed to connect to MQTT broker", v1alpha2.InternalError)
 	}
 
 	if token := m.MQTTClient.Subscribe(config.RequestTopic, 0, func(client gmqtt.Client, msg gmqtt.Message) {
@@ -97,6 +156,83 @@ func (m *MQTTBinding) Launch(config MQTTBindingConfig, endpoints []v1alpha2.Endp
 	}
 
 	return nil
+}
+
+// createTLSConfig creates a TLS configuration for MQTT client authentication
+func (m *MQTTBinding) createTLSConfig(config MQTTBindingConfig) (*tls.Config, error) {
+	insecureSkipVerify := config.InsecureSkipVerify == "true"
+	
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: insecureSkipVerify,
+	}
+
+	// Load CA certificate if provided
+	if config.CACertPath != "" {
+		log.Infof("MQTT Binding: attempting to load CA certificate from %s", config.CACertPath)
+
+		caCert, err := ioutil.ReadFile(config.CACertPath)
+		if err != nil {
+			log.Errorf("MQTT Binding: failed to read CA certificate - %+v", err)
+			return nil, fmt.Errorf("failed to read CA certificate: %w", err)
+		}
+
+		// Verify the CA cert content
+		log.Infof("MQTT Binding: CA certificate file size: %d bytes", len(caCert))
+		if len(caCert) == 0 {
+			return nil, fmt.Errorf("CA certificate file is empty")
+		}
+
+		// Validate that the file contains valid PEM data
+		if !isCertificatePEM(caCert) {
+			log.Errorf("MQTT Binding: CA certificate file does not contain valid PEM data")
+			return nil, fmt.Errorf("CA certificate file does not contain valid PEM data")
+		}
+
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			log.Errorf("MQTT Binding: failed to parse CA certificate - invalid PEM format or corrupted certificate")
+			return nil, fmt.Errorf("failed to parse CA certificate - invalid PEM format or corrupted certificate")
+		}
+		tlsConfig.RootCAs = caCertPool
+		log.Infof("MQTT Binding: successfully loaded CA certificate from %s", config.CACertPath)
+	} else {
+		if !insecureSkipVerify {
+			log.Warn("MQTT Binding: no CA certificate path provided - using system CA pool. If connection fails with 'certificate signed by unknown authority', either provide a CA certificate or set insecureSkipVerify to true")
+		} else {
+			log.Infof("MQTT Binding: TLS certificate verification disabled (insecureSkipVerify=true)")
+		}
+	}
+
+	// Load client certificate and key if provided
+	if config.ClientCertPath != "" && config.ClientKeyPath != "" {
+		clientCert, err := tls.LoadX509KeyPair(config.ClientCertPath, config.ClientKeyPath)
+		if err != nil {
+			log.Errorf("MQTT Binding: failed to load client certificate and key - %+v", err)
+			return nil, fmt.Errorf("failed to load client certificate and key: %w", err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{clientCert}
+		log.Infof("MQTT Binding: loaded client certificate from %s and key from %s",
+			config.ClientCertPath, config.ClientKeyPath)
+	} else if config.ClientCertPath != "" || config.ClientKeyPath != "" {
+		// Both cert and key must be provided together
+		return nil, fmt.Errorf("both clientCertPath and clientKeyPath must be provided for client certificate authentication")
+	}
+
+	return tlsConfig, nil
+}
+
+// isCertificatePEM checks if the given data contains valid PEM formatted certificate data
+func isCertificatePEM(data []byte) bool {
+	// Check if the data contains PEM headers
+	dataStr := string(data)
+	if !strings.Contains(dataStr, "-----BEGIN CERTIFICATE-----") || 
+	   !strings.Contains(dataStr, "-----END CERTIFICATE-----") {
+		return false
+	}
+	
+	// Try to decode the PEM block
+	block, _ := pem.Decode(data)
+	return block != nil && block.Type == "CERTIFICATE"
 }
 
 // Shutdown stops the MQTT binding


### PR DESCRIPTION
When compliance or regulatory requirements mandate it, or to strengthen security through mutual authentication and encrypted communication between the Symphony MQTT provider and MQTT brokers, mTLS can be enabled by setting the useTLS configuration property in the Symphony configuration file and specifying the paths to the relevant certificates. For development or testing where certificate verification may not be possible, the insecureSkipVerify option can be set to true (this is not recommended for production use).

TLS/Certificate settings:
- useTLS: Enable TLS connection (default: false)
- caCertPath: Path to CA certificate file for server verification
- clientCertPath: Path to client certificate file for mutual TLS authentication
- clientKeyPath: Path to client private key file for mutual TLS authentication
- insecureSkipVerify: Skip TLS certificate verification (default: false, use with caution)

Example configuration for symphony mqtt provider client certificate authentication:
{
    "brokerAddress": "ssl://mqtt.example.com:8883",
    "clientID": "symphony-client",
    "requestTopic": "symphony_request",
    "responseTopic": "symphony_response",
    "useTLS": "true",
    "caCertPath": "/path/to/ca.crt",
    "clientCertPath": "/path/to/client.crt",
    "clientKeyPath": "/path/to/client.key"
}