### PR TITLE
remove leader-elect for single replica controller manager

### DIFF
--- a/packages/helm/symphony/templates/symphony-core/symphonyk8s-controller.yaml
+++ b/packages/helm/symphony/templates/symphony-core/symphonyk8s-controller.yaml
@@ -21,7 +21,6 @@ spec:
       - args:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
-        - --leader-elect
         - --metrics-config-file=/etc/config/observability/metrics-config.json
         - --logs-config-file=/etc/config/observability/logs-config.json
         command:


### PR DESCRIPTION
leader election is used to ensure only one instance is up for multiple-replica deployment. We need to disable it for single-replica controller pod since it causes extra overhead of lease management, leader election checks and API server load.