### PR TITLE
Fix timeout handling in attemptUpdate and pollResult

### DIFF
--- a/k8s/controllers/metrics/metrics.go
+++ b/k8s/controllers/metrics/metrics.go
@@ -32,6 +32,11 @@ const (
 	// reconciliation result
 	ReconcileSuccessResult ReconciliationResult = "Succeeded"
 	ReconcileFailedResult  ReconciliationResult = "Failed"
+	// operation start time
+	OperationStartTimeUpdateFailed OperationStatus = "OperationStartTimeUpdateFailed"
+	OperationStartTimeParseFailed  OperationStatus = "OperationStartTimeParseFailed"
+	// job id
+	JobIDUpdateFailed OperationStatus = "JobIDUpdateFailed"
 	// operation status
 	StatusNoOp         OperationStatus = "NoOp"
 	StatusUpdateFailed OperationStatus = "StatusUpdateFailed"

--- a/k8s/reconcilers/deployment.go
+++ b/k8s/reconcilers/deployment.go
@@ -204,7 +204,7 @@ func (r *DeploymentReconciler) AttemptUpdate(ctx context.Context, object Reconci
 	}
 	if time.Since(startTime) > timeout {
 		diagnostic.InfoWithCtx(log, ctx, "Requeueing after timeout", "requeueAfter", reconciliationInterval)
-		// need to mark operation status as timeout when no polling thread (reconciling)
+		// need to mark operation status as timeout when no polling thread (not in reconciling state)
 		if utilsmodel.IsTerminalState(object.GetStatus().ProvisioningStatus.Status) {
 			diagnostic.InfoWithCtx(log, ctx, "Current object is terminal state, there's no polling thread to deal with timeout case, update object status with timeout error")
 			if _, err := r.updateObjectStatus(ctx, object, nil, patchStatusOptions{

--- a/k8s/reconcilers/deployment.go
+++ b/k8s/reconcilers/deployment.go
@@ -182,15 +182,17 @@ func (r *DeploymentReconciler) AttemptUpdate(ctx context.Context, object Reconci
 	}
 	// Get reconciliation interval
 	reconciliationInterval, timeout := r.deriveReconcileInterval(log, ctx, object)
+	timeOutErrorMessage := "failed to completely reconcile within the allocated time"
 	if isRemoval {
 		timeout = r.deriveDeletionTimeout(log, ctx, object)
+		timeOutErrorMessage = "failed to completely delete the resource within the allocated time"
 	}
 
 	if object.GetAnnotations()[operationStartTimeKey] == "" || utilsmodel.IsTerminalState(object.GetStatus().ProvisioningStatus.Status) {
 		r.patchOperationStartTime(object, operationStartTimeKey)
 		if err := r.kubeClient.Update(ctx, object); err != nil {
-			diagnostic.ErrorWithCtx(log, ctx, err, "failed to update object status with timeout error")
-			return metrics.StatusUpdateFailed, ctrl.Result{}, err
+			diagnostic.ErrorWithCtx(log, ctx, err, "failed to update operation start time")
+			return metrics.OperationStartTimeUpdateFailed, ctrl.Result{}, err
 		}
 	}
 	// If the object hasn't reached a terminal state and the time since the operation started is greater than the
@@ -198,10 +200,17 @@ func (r *DeploymentReconciler) AttemptUpdate(ctx context.Context, object Reconci
 	startTime, err := time.Parse(time.RFC3339, object.GetAnnotations()[operationStartTimeKey])
 	if err != nil {
 		diagnostic.ErrorWithCtx(log, ctx, err, "failed to parse operation start time")
-		return metrics.StatusUpdateFailed, ctrl.Result{}, err
+		return metrics.OperationStartTimeParseFailed, ctrl.Result{}, err
 	}
 	if time.Since(startTime) > timeout {
 		diagnostic.InfoWithCtx(log, ctx, "Requeueing after timeout", "requeueAfter", reconciliationInterval)
+		// need to mark operation status as timeout
+		if _, err := r.updateObjectStatus(ctx, object, nil, patchStatusOptions{
+			terminalErr: v1alpha2.NewCOAError(nil, timeOutErrorMessage, v1alpha2.TimedOut),
+		}, log, isRemoval, operationStartTimeKey); err != nil {
+			diagnostic.ErrorWithCtx(log, ctx, err, "failed to update object status with timeout error")
+			return metrics.StatusUpdateFailed, ctrl.Result{}, err
+		}
 		return metrics.DeploymentTimedOut, ctrl.Result{RequeueAfter: reconciliationInterval}, nil
 	}
 
@@ -209,7 +218,7 @@ func (r *DeploymentReconciler) AttemptUpdate(ctx context.Context, object Reconci
 	r.updateJobID(object, strconv.FormatInt(r.getCurJobIdInt64(object)+1, 10))
 	if err := r.kubeClient.Update(ctx, object); err != nil {
 		diagnostic.ErrorWithCtx(log, ctx, err, "failed to update jobid")
-		return metrics.StatusUpdateFailed, ctrl.Result{}, err
+		return metrics.JobIDUpdateFailed, ctrl.Result{}, err
 	}
 	// DO NOT REMOVE THIS COMMENT
 	// gofail: var beforeQueueJob string
@@ -262,7 +271,7 @@ func (r *DeploymentReconciler) PollingResult(ctx context.Context, object Reconci
 	startTime, err := time.Parse(time.RFC3339, object.GetAnnotations()[operationStartTimeKey])
 	if err != nil {
 		diagnostic.ErrorWithCtx(log, ctx, err, "failed to parse operation start time")
-		return metrics.StatusUpdateFailed, ctrl.Result{}, err
+		return metrics.OperationStartTimeParseFailed, ctrl.Result{}, err
 	}
 	if time.Since(startTime) > timeout {
 		diagnostic.InfoWithCtx(log, ctx, "Failed to completely poll within the allocated time.", "timeout", timeout)
@@ -272,7 +281,7 @@ func (r *DeploymentReconciler) PollingResult(ctx context.Context, object Reconci
 			diagnostic.ErrorWithCtx(log, ctx, err, "failed to update object status with timeout error")
 			return metrics.StatusUpdateFailed, ctrl.Result{}, err
 		}
-		return metrics.DeploymentTimedOut, ctrl.Result{}, v1alpha2.NewCOAError(nil, timeOutErrorMessage, v1alpha2.TimedOut)
+		return metrics.DeploymentTimedOut, ctrl.Result{}, nil
 	}
 
 	summary, err := r.getDeploymentSummary(ctx, object)

--- a/k8s/reconcilers/deployment.go
+++ b/k8s/reconcilers/deployment.go
@@ -214,6 +214,7 @@ func (r *DeploymentReconciler) AttemptUpdate(ctx context.Context, object Reconci
 			if _, err := r.updateObjectStatus(ctx, object, nil, patchStatusOptions{
 				terminalErr: v1alpha2.NewCOAError(nil, timeOutErrorMessage, v1alpha2.TimedOut),
 			}, log, isRemoval, operationStartTimeKey); err != nil {
+				// if update object status failed, we should return error to requeue the queue event to retry
 				diagnostic.ErrorWithCtx(log, ctx, err, "failed to update object status with timeout error")
 				return metrics.StatusUpdateFailed, ctrl.Result{}, err
 			}
@@ -221,7 +222,7 @@ func (r *DeploymentReconciler) AttemptUpdate(ctx context.Context, object Reconci
 			diagnostic.InfoWithCtx(log, ctx, "Current object is not terminal state, there's another polling thread to update object status with timeout error")
 		}
 
-		// Requeue after reconciliation interval when delete timeout in AttemptUpdate
+		// Always requeue after reconciliation interval when delete timeout in AttemptUpdate
 		diagnostic.InfoWithCtx(log, ctx, "Requeueing after timeout", "requeueAfter", reconciliationInterval)
 		return metrics.DeploymentTimedOut, ctrl.Result{RequeueAfter: reconciliationInterval}, nil
 	}

--- a/k8s/reconcilers/deployment_test.go
+++ b/k8s/reconcilers/deployment_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Testing timeOverDue conditions in deployment reconciler", func
 			})
 
 			It("should return StatusUpdateFailed status", func() {
-				Expect(reconcileResult).To(Equal(metrics.StatusUpdateFailed))
+				Expect(reconcileResult).To(Equal(metrics.OperationStartTimeParseFailed))
 			})
 		})
 	})

--- a/k8s/reconcilers/deployment_test.go
+++ b/k8s/reconcilers/deployment_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
-	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/mock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -82,12 +81,8 @@ var _ = Describe("Testing timeOverDue conditions in deployment reconciler", func
 				reconcileResult, _, reconcileError = reconciler.PollingResult(ctx, object, false, logr.Discard(), targetOperationStartTimeKey, constants.ActivityOperation_Write)
 			})
 
-			It("should return TimedOut error", func() {
-				Expect(reconcileError).To(HaveOccurred())
-				coaError, ok := reconcileError.(v1alpha2.COAError)
-				Expect(ok).To(BeTrue())
-				Expect(coaError.State).To(Equal(v1alpha2.TimedOut))
-				Expect(coaError.Message).To(ContainSubstring("failed to completely reconcile within the allocated time"))
+			It("should not return error", func() {
+				Expect(reconcileError).NotTo(HaveOccurred())
 			})
 
 			It("should return DeploymentTimedOut status", func() {

--- a/k8s/reconcilers/deployment_test.go
+++ b/k8s/reconcilers/deployment_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Testing timeOverDue conditions in deployment reconciler", func
 				Expect(reconcileError).To(HaveOccurred())
 			})
 
-			It("should return StatusUpdateFailed status", func() {
+			It("should return OperationStartTimeParseFailed status", func() {
 				Expect(reconcileResult).To(Equal(metrics.OperationStartTimeParseFailed))
 			})
 		})


### PR DESCRIPTION
Reference: https://github.com/msftcoderdjw/eclipse-symphony/pull/41

When attemptUpdate (queue) detect timeout, it should mark the timeout status by itself since updateJobId will be skipped and pollResult won't be triggered.
When pollRequest (poll) detect timeout, it should not return error to controller runtime. It can directly terminate reconciliation loop and wait for next queue.

@msftcoderdjw 