### PR TITLE
fix regression to allow extra config properties to be carried into provider

### DIFF
--- a/api/pkg/apis/v1alpha1/providers/target/rust/rust.go
+++ b/api/pkg/apis/v1alpha1/providers/target/rust/rust.go
@@ -50,35 +50,12 @@ type RustTargetProvider struct {
 	Context  *contexts.ManagerContext
 }
 
-func RustTargetProviderConfigFromMap(properties map[string]string) (RustTargetProviderConfig, error) {
-	ret := RustTargetProviderConfig{}
-	if v, ok := properties["name"]; ok {
-		ret.Name = v
-	}
-	if v, ok := properties["libFile"]; ok {
-		ret.LibFile = v
-	} else {
-		return ret, v1alpha2.NewCOAError(nil, "'libFile' is missing in Rust provider config", v1alpha2.BadConfig)
-	}
-	if v, ok := properties["libHash"]; ok {
-		ret.LibHash = v
-	} else {
-		return ret, v1alpha2.NewCOAError(nil, "'libHash' is missing in Rust provider config", v1alpha2.BadConfig)
-	}
-	return ret, nil
-}
-
 func (s *RustTargetProvider) SetContext(ctx *contexts.ManagerContext) {
 	s.Context = ctx
 }
 
 func (i *RustTargetProvider) InitWithMap(properties map[string]string) error {
-	config, err := RustTargetProviderConfigFromMap(properties)
-	if err != nil {
-		log.Errorf("  P (HTTP Target): expected HttpTargetProviderConfig: %+v", err)
-		return err
-	}
-	return i.Init(config)
+	return i.Init(properties)
 }
 
 func toRustProviderConfig(config providers.IProviderConfig) (RustTargetProviderConfig, error) {


### PR DESCRIPTION
When we deserialize into RustTargetProvider, we are ignoring all extra fields. However, custom rust provider developers may rely on these extra fields to be passed into the provider as additional configurations. 