### PR TITLE
Fix unbounded recursion in expression evaluation via circular reference detection

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/stage/stage-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/stage/stage-manager_test.go
@@ -2051,6 +2051,9 @@ func TestActivationSelfReferencingInput_FailsButSurvives(t *testing.T) {
 		Stages: map[string]model.StageSpec{
 			"test": {
 				Provider: "providers.stage.mock",
+				Inputs: map[string]interface{}{
+					"jersey24": "${{$input(jersey24)}}",
+				},
 			},
 		},
 	}
@@ -2062,9 +2065,6 @@ func TestActivationSelfReferencingInput_FailsButSurvives(t *testing.T) {
 		Activation:           "test-activation",
 		Stage:                "test",
 		ActivationGeneration: "1",
-		Inputs: map[string]interface{}{
-			"jersey24": "${{$input(jersey24)}}",
-		},
 		Provider:  "providers.stage.mock",
 		Namespace: "fakens",
 	})
@@ -2074,6 +2074,9 @@ func TestActivationSelfReferencingInput_FailsButSurvives(t *testing.T) {
 	assert.False(t, status.IsActive)
 
 	// The manager survives and keeps processing later activations.
+	campaignversion.Stages["test"] = model.StageSpec{
+		Provider: "providers.stage.mock",
+	}
 	var status2 model.StageStatus
 	activation2 := &v1alpha2.ActivationData{
 		CampaignVersion:             "test-campaignversion",

--- a/api/pkg/apis/v1alpha1/managers/stage/stage-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/stage/stage-manager_test.go
@@ -2027,3 +2027,70 @@ func InitializeMockSymphonyAPI() *httptest.Server {
 	}))
 	return ts
 }
+func TestActivationSelfReferencingInput_FailsButSurvives(t *testing.T) {
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	manager := StageManager{
+		StateProvider: stateProvider,
+	}
+	manager.VendorContext = &contexts.VendorContext{
+		EvaluationContext: &coa_utils.EvaluationContext{},
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+		},
+	}
+	manager.Context = &contexts.ManagerContext{
+		VencorContext: manager.VendorContext,
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+		},
+	}
+	campaignversion := model.CampaignVersionSpec{
+		SelfDriving: true,
+		FirstStage:  "test",
+		Stages: map[string]model.StageSpec{
+			"test": {
+				Provider: "providers.stage.mock",
+			},
+		},
+	}
+
+	// A self-referencing input must fail the stage with an error
+	// instead of recursing until the process runs out of stack.
+	status, _ := manager.HandleTriggerEvent(context.Background(), campaignversion, v1alpha2.ActivationData{
+		CampaignVersion:             "test-campaignversion",
+		Activation:           "test-activation",
+		Stage:                "test",
+		ActivationGeneration: "1",
+		Inputs: map[string]interface{}{
+			"jersey24": "${{$input(jersey24)}}",
+		},
+		Provider:  "providers.stage.mock",
+		Namespace: "fakens",
+	})
+	assert.Equal(t, v1alpha2.InternalError, status.Status)
+	assert.True(t, v1alpha2.InternalError.EqualsWithString(status.StatusMessage))
+	assert.Contains(t, status.ErrorMessage, "circular dependency")
+	assert.False(t, status.IsActive)
+
+	// The manager survives and keeps processing later activations.
+	var status2 model.StageStatus
+	activation2 := &v1alpha2.ActivationData{
+		CampaignVersion:             "test-campaignversion",
+		Activation:           "test-activation-2",
+		Stage:                "test",
+		ActivationGeneration: "2",
+		Inputs: map[string]interface{}{
+			"sprite": "qiaolezi",
+		},
+		Provider:  "providers.stage.mock",
+		Namespace: "fakens",
+	}
+	for {
+		status2, activation2 = manager.HandleTriggerEvent(context.Background(), campaignversion, *activation2)
+		if activation2 == nil {
+			break
+		}
+	}
+	assert.Equal(t, v1alpha2.Done, status2.Status)
+}

--- a/api/pkg/apis/v1alpha1/utils/parser.go
+++ b/api/pkg/apis/v1alpha1/utils/parser.go
@@ -605,7 +605,13 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 			if err != nil {
 				return nil, err
 			}
-			property, err := readProperty(context.Properties, FormatAsString(key), context)
+			propRef := FormatAsString(key)
+			if utils.HasCircularDependency("property", propRef, context) {
+				return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("Detect circular dependency, object: %s, field: %s", "property", propRef), v1alpha2.BadConfig)
+			}
+			dependencies := utils.DeepCopyDependencyList(context.ParentConfigs)
+			context.ParentConfigs = utils.UpdateDependencyList("property", propRef, dependencies)
+			property, err := readProperty(context.Properties, propRef, context)
 			if err != nil {
 				return nil, err
 			}
@@ -621,7 +627,13 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 			if err != nil {
 				return nil, err
 			}
-			property, err := readPropertyInterface(context.Inputs, FormatAsString(key), context)
+			inputRef := FormatAsString(key)
+			if utils.HasCircularDependency("input", inputRef, context) {
+				return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("Detect circular dependency, object: %s, field: %s", "input", inputRef), v1alpha2.BadConfig)
+			}
+			dependencies := utils.DeepCopyDependencyList(context.ParentConfigs)
+			context.ParentConfigs = utils.UpdateDependencyList("input", inputRef, dependencies)
+			property, err := readPropertyInterface(context.Inputs, inputRef, context)
 			if err != nil {
 				return nil, err
 			}
@@ -645,7 +657,14 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 			if _, ok := context.Outputs[FormatAsString(step)]; !ok {
 				return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("step %s is not found in output collection", FormatAsString(step)), v1alpha2.BadConfig)
 			}
-			property, err := readPropertyInterface(context.Outputs[FormatAsString(step)], FormatAsString(key), context)
+			outputRef := FormatAsString(key)
+			outputObject := fmt.Sprintf("output:%s", FormatAsString(step))
+			if utils.HasCircularDependency(outputObject, outputRef, context) {
+				return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("Detect circular dependency, object: %s, field: %s", outputObject, outputRef), v1alpha2.BadConfig)
+			}
+			dependencies := utils.DeepCopyDependencyList(context.ParentConfigs)
+			context.ParentConfigs = utils.UpdateDependencyList(outputObject, outputRef, dependencies)
+			property, err := readPropertyInterface(context.Outputs[FormatAsString(step)], outputRef, context)
 			if err != nil {
 				return nil, err
 			}
@@ -665,7 +684,13 @@ func (n *FunctionNode) Eval(context utils.EvaluationContext) (interface{}, error
 			if context.Triggers == nil {
 				return defaultVal, nil
 			}
-			property, err := readPropertyInterface(context.Triggers, FormatAsString(key), context)
+			triggerRef := FormatAsString(key)
+			if utils.HasCircularDependency("trigger", triggerRef, context) {
+				return nil, v1alpha2.NewCOAError(nil, fmt.Sprintf("Detect circular dependency, object: %s, field: %s", "trigger", triggerRef), v1alpha2.BadConfig)
+			}
+			dependencies := utils.DeepCopyDependencyList(context.ParentConfigs)
+			context.ParentConfigs = utils.UpdateDependencyList("trigger", triggerRef, dependencies)
+			property, err := readPropertyInterface(context.Triggers, triggerRef, context)
 			if err != nil {
 				return defaultVal, nil
 			}

--- a/api/pkg/apis/v1alpha1/utils/parser_test.go
+++ b/api/pkg/apis/v1alpha1/utils/parser_test.go
@@ -3143,3 +3143,67 @@ func TestRecursiveUnsupported(t *testing.T) {
 	})
 	assert.NotNil(t, err)
 }
+func TestMambaOut_SelfReferenceReturnsError(t *testing.T) {
+	// A self-referencing input must fail with an error instead of
+	// recursing until the process runs out of stack.
+	inputs := map[string]interface{}{
+		"jersey24": "${{$input(jersey24)}}",
+	}
+	_, err := NewParser("${{$input(jersey24)}}").Eval(utils.EvaluationContext{
+		Context: ctx,
+		Inputs:  inputs,
+	})
+	assert.NotNil(t, err)
+	cErr, ok := err.(v1alpha2.COAError)
+	assert.True(t, ok)
+	assert.Equal(t, v1alpha2.BadConfig, cErr.State)
+	assert.Contains(t, err.Error(), "circular dependency")
+}
+func TestTreadmill_MutualReferenceReturnsError(t *testing.T) {
+	// Mutually referencing inputs would chase each other on a treadmill
+	// forever; the circular dependency check must reject them.
+	inputs := map[string]interface{}{
+		"sprite":   "${{$input(qiaolezi)}}",
+		"qiaolezi": "${{$input(sprite)}}",
+	}
+	_, err := NewParser("${{$input(sprite)}}").Eval(utils.EvaluationContext{
+		Context: ctx,
+		Inputs:  inputs,
+	})
+	assert.NotNil(t, err)
+	cErr, ok := err.(v1alpha2.COAError)
+	assert.True(t, ok)
+	assert.Equal(t, v1alpha2.BadConfig, cErr.State)
+}
+func TestLegitimateNestingNoCycle(t *testing.T) {
+	// Nested references without cycles still evaluate normally.
+	inputs := map[string]interface{}{
+		"mamba8":  "${{$input(mamba24)}}",
+		"mamba24": "Man! What can I say? Mamba out.",
+	}
+	res, err := NewParser("${{$input(mamba8)}}").Eval(utils.EvaluationContext{
+		Context: ctx,
+		Inputs:  inputs,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "Man! What can I say? Mamba out.", res)
+}
+func TestCircularErrorIsBadConfig(t *testing.T) {
+	// A key already on the resolution path is rejected on first access.
+	inputs := map[string]interface{}{
+		"sprite": "qiaolezi",
+	}
+	_, err := NewParser("${{$input(sprite)}}").Eval(utils.EvaluationContext{
+		Context: ctx,
+		Inputs:  inputs,
+		ParentConfigs: map[string]map[string]bool{
+			"input": {
+				"sprite": true,
+			},
+		},
+	})
+	assert.NotNil(t, err)
+	cErr, ok := err.(v1alpha2.COAError)
+	assert.True(t, ok)
+	assert.Equal(t, v1alpha2.BadConfig, cErr.State)
+}


### PR DESCRIPTION
Fixes #850

## Root cause

When the stage manager evaluates an activation's inputs, any stored value that looks like an expression is evaluated again (`readProperty` / `readPropertyInterface` in `api/pkg/apis/v1alpha1/utils/parser.go`): a value wrapped in `${{...}}` is fed back into `NewParser(v).Eval(evalCtx)` with no cycle detection. A self-referencing input such as `a: "${{$input(a)}}"` (or mutual references `a` → `b` → `a`) recurses until the process runs out of stack — a fatal, unrecoverable error in Go that takes symphony-api down.

## Fix

Apply the same circular dependency guard that #433 introduced for `$config` to the other expression sources. Every recursion cycle necessarily passes through one of the `$property` / `$input` / `$output` / `$trigger` function branches, so the check is placed at those four call sites:

- before re-reading a stored value, `HasCircularDependency(object, key, context)` rejects a key that is already on the current resolution path, with the same error shape as the catalog provider (`BadConfig`, "Detect circular dependency, object: %s, field: %s")
- otherwise the key is recorded on the path via the existing `UpdateDependencyList` + `DeepCopyDependencyList` helpers and carried down through the by-value `EvaluationContext`, so sibling branches never see each other's path

No changes to the coa module — the machinery from #433 is reused as-is.

## Tests

- `parser_test.go`: self-referencing input returns a `BadConfig` error instead of recursing; mutually referencing inputs likewise; legitimate nested references without cycles still evaluate; a pre-seeded resolution path is rejected on first access
- `stage-manager_test.go`: an activation with a self-referencing input fails the stage with the circular dependency error while the manager survives and processes subsequent activations normally
