### PR TITLE
Free more disk space in CI workflows to fix minikube storage failures

### DIFF
--- a/.github/workflows/fault.yml
+++ b/.github/workflows/fault.yml
@@ -80,10 +80,19 @@ jobs:
 
     - name: Free up disk space
       run: |
+        df -h /
         sudo apt-get clean
         sudo rm -rf /usr/local/lib/android
         sudo rm -rf /usr/share/dotnet
         sudo rm -rf /usr/share/swift
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/.ghcup
+        sudo rm -rf /usr/local/lib/node_modules
+        sudo rm -rf /usr/lib/jvm
+        sudo rm -rf /opt/microsoft/powershell
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo rm -rf /opt/hostedtoolcache/Ruby
+        df -h /
 
     - name: Login to Docker Hub
       uses: docker/login-action@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -115,10 +115,19 @@ jobs:
 
     - name: Free up disk space
       run: |
+        df -h /
         sudo apt-get clean
         sudo rm -rf /usr/local/lib/android
         sudo rm -rf /usr/share/dotnet
         sudo rm -rf /usr/share/swift
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/.ghcup
+        sudo rm -rf /usr/local/lib/node_modules
+        sudo rm -rf /usr/lib/jvm
+        sudo rm -rf /opt/microsoft/powershell
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo rm -rf /opt/hostedtoolcache/Ruby
+        df -h /
     
     - name: COA Test
       run: cd coa && mage cleanTest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -105,10 +105,19 @@ jobs:
 
     - name: Free up disk space
       run: |
+        df -h /
         sudo apt-get clean
         sudo rm -rf /usr/local/lib/android
         sudo rm -rf /usr/share/dotnet
         sudo rm -rf /usr/share/swift
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/.ghcup
+        sudo rm -rf /usr/local/lib/node_modules
+        sudo rm -rf /usr/lib/jvm
+        sudo rm -rf /opt/microsoft/powershell
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo rm -rf /opt/hostedtoolcache/Ruby
+        df -h /
 
     - name: Build docker images
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,10 +113,19 @@ jobs:
 
       - name: Free up disk space
         run: |
+          df -h /
           sudo apt-get clean
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /usr/share/swift
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/local/lib/node_modules
+          sudo rm -rf /usr/lib/jvm
+          sudo rm -rf /opt/microsoft/powershell
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /opt/hostedtoolcache/Ruby
+          df -h /
 
       - name: Increment Version
         id: increment_version

--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -80,10 +80,19 @@ jobs:
 
     - name: Free up disk space
       run: |
+        df -h /
         sudo apt-get clean
         sudo rm -rf /usr/local/lib/android
         sudo rm -rf /usr/share/dotnet
         sudo rm -rf /usr/share/swift
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/.ghcup
+        sudo rm -rf /usr/local/lib/node_modules
+        sudo rm -rf /usr/lib/jvm
+        sudo rm -rf /opt/microsoft/powershell
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo rm -rf /opt/hostedtoolcache/Ruby
+        df -h /
 
     - name: Install Ginkgo
       run: |


### PR DESCRIPTION
## Problem

CI jobs that run minikube plus a full image build keep flaking on disk space:

```
X Exiting due to RSRC_DOCKER_STORAGE: Docker is out of disk space! (/var is at 99% of capacity)
```

- integration `test (04.workflow-false)` on main, 2026-07-23 (original attempt; the run was later re-run and passed): https://github.com/eclipse-symphony/symphony/actions/runs/30039594967/attempts/1
- suite `build` job, same error: https://github.com/eclipse-symphony/symphony/actions/runs/26763226111

`minikube start` pulls the kicbase image, `mage build:all` builds all images, and `mage cluster:up` loads them into minikube — the images end up stored twice under `/var/lib/docker`. These jobs pass sometimes and flake other times, so the disk headroom is right at the edge.

## Fix

The `Free up disk space` step is identical in 5 workflows (integration.yml, go.yml, fault.yml, suite.yml, release.yaml). suite.yml and fault.yml have the same minikube + full image build profile as integration.yml and will hit the same wall eventually; release.yaml builds multi-arch images where a failure becomes a release incident. This PR extends all five copies uniformly, following the standard list from https://github.com/jlumbroso/free-disk-space while keeping the existing hand-written `rm` style (no external action):

- `/opt/ghc` (~5 GB), `/opt/hostedtoolcache/CodeQL` (~2-3 GB)
- `/usr/lib/jvm`, `/opt/microsoft/powershell`, `/usr/local/lib/node_modules`, `/usr/local/.ghcup`, `/opt/hostedtoolcache/Ruby` (~0.5-1 GB each)

`df -h /` is printed before and after so the freed amount is visible in the logs. `/opt/hostedtoolcache` is not removed wholesale since setup-go installs Go there. No workflow in this repo uses CodeQL, setup-java, setup-node, or maven/gradle, so these deletions are safe everywhere.

## Verification

The before/after `df` output from this PR's integration `04.workflow-false` job is posted in a comment below. release.yaml only runs on release so it cannot be exercised here, but its change is identical to the other four files.
