### PR TITLE
Deflake CI: wait for manager shutdown in envtest teardown, raise scenario 04 timeout, and retry image builds

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -122,7 +122,17 @@ jobs:
     - name: Build docker images
       run: |
         cd test/localenv/
-        mage build:all
+        for attempt in 1 2 3; do
+          if mage build:all; then
+            break
+          fi
+          if [ "$attempt" -eq 3 ]; then
+            echo "mage build:all failed after 3 attempts"
+            exit 1
+          fi
+          echo "mage build:all failed (attempt $attempt/3), retrying in 30s..."
+          sleep 30
+        done
         mage cluster:up
     
     - name: Go work init

--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -109,7 +109,17 @@ jobs:
     - name: Build docker images
       run: |
         cd test/localenv/
-        mage build:all
+        for attempt in 1 2 3; do
+          if mage build:all; then
+            break
+          fi
+          if [ "$attempt" -eq 3 ]; then
+            echo "mage build:all failed after 3 attempts"
+            exit 1
+          fi
+          echo "mage build:all failed (attempt $attempt/3), retrying in 30s..."
+          sleep 30
+        done
         mage cluster:up
     
     - name: Go work init

--- a/k8s/controllers/fabric/suite_test.go
+++ b/k8s/controllers/fabric/suite_test.go
@@ -55,12 +55,13 @@ func TestAPIs(t *testing.T) {
 // a manager and full operator pattern should be tested in the integration tests
 var _ = Describe("Legacy testing with envtest", Ordered, func() {
 	var (
-		cancel    context.CancelFunc
-		cfg       *rest.Config
-		k8sClient client.Client
-		testEnv   *envtest.Environment
-		ctx       context.Context
-		apiClient *MockApiClient
+		cancel      context.CancelFunc
+		cfg         *rest.Config
+		k8sClient   client.Client
+		testEnv     *envtest.Environment
+		ctx         context.Context
+		apiClient   *MockApiClient
+		managerDone chan struct{}
 	)
 
 	BeforeAll(func() {
@@ -119,7 +120,11 @@ var _ = Describe("Legacy testing with envtest", Ordered, func() {
 			}}).SetupWithManager(k8sManager)
 		Expect(err).ToNot(HaveOccurred())
 
+		managerDone = make(chan struct{})
 		go func() {
+			// Register close before GinkgoRecover so the channel is closed
+			// even if the Expect below panics (defers run LIFO).
+			defer close(managerDone)
 			defer GinkgoRecover()
 			err = k8sManager.Start(ctx)
 			Expect(err).ToNot(HaveOccurred(), "failed to run manager")
@@ -129,6 +134,8 @@ var _ = Describe("Legacy testing with envtest", Ordered, func() {
 
 	AfterAll(func() {
 		cancel()
+		By("waiting for the manager to shut down")
+		Eventually(managerDone, 30*time.Second, 250*time.Millisecond).Should(BeClosed())
 		By("tearing down the test environment")
 		err := testEnv.Stop()
 		Expect(err).NotTo(HaveOccurred())

--- a/k8s/controllers/solution/suite_test.go
+++ b/k8s/controllers/solution/suite_test.go
@@ -93,12 +93,13 @@ spec:
 // a manager and full operator pattern should be tested in the integration tests
 var _ = Describe("Legacy testing with envtest", Ordered, func() {
 	var (
-		cancel    context.CancelFunc
-		cfg       *rest.Config
-		k8sClient client.Client
-		testEnv   *envtest.Environment
-		ctx       context.Context
-		apiClient *MockApiClient
+		cancel      context.CancelFunc
+		cfg         *rest.Config
+		k8sClient   client.Client
+		testEnv     *envtest.Environment
+		ctx         context.Context
+		apiClient   *MockApiClient
+		managerDone chan struct{}
 	)
 
 	BeforeAll(func() {
@@ -163,7 +164,11 @@ var _ = Describe("Legacy testing with envtest", Ordered, func() {
 			}}).SetupWithManager(k8sManager)
 		Expect(err).ToNot(HaveOccurred())
 
+		managerDone = make(chan struct{})
 		go func() {
+			// Register close before GinkgoRecover so the channel is closed
+			// even if the Expect below panics (defers run LIFO).
+			defer close(managerDone)
 			defer GinkgoRecover()
 			err = k8sManager.Start(ctx)
 			Expect(err).ToNot(HaveOccurred(), "failed to run manager")
@@ -173,6 +178,8 @@ var _ = Describe("Legacy testing with envtest", Ordered, func() {
 
 	AfterAll(func() {
 		cancel()
+		By("waiting for the manager to shut down")
+		Eventually(managerDone, 30*time.Second, 250*time.Millisecond).Should(BeClosed())
 		By("tearing down the test environment")
 		err := testEnv.Stop()
 		Expect(err).NotTo(HaveOccurred())

--- a/test/integration/scenarios/04.workflow/magefile.go
+++ b/test/integration/scenarios/04.workflow/magefile.go
@@ -23,7 +23,7 @@ import (
 // Test config
 const (
 	TEST_NAME    = "workflow test"
-	TEST_TIMEOUT = "4m"
+	TEST_TIMEOUT = "10m"
 )
 
 var (


### PR DESCRIPTION
Fixes three recurring flaky CI failures:

1. **envtest teardown race** — `fabric`/`solution` suite_test.go stopped the test environment immediately after `cancel()`, killing the apiserver while the manager still had requests in flight (race examples: [run 30262762190](https://github.com/eclipse-symphony/symphony/actions/runs/30262762190), [run 30264744627](https://github.com/eclipse-symphony/symphony/actions/runs/30264744627)). Now waits for the manager to fully shut down before `testEnv.Stop()`. Only these two suites start a manager, so only they change.
2. **04.workflow timeout panic** — `TestBasic_ActivationStatus` hit the 4m `go test` timeout under runner load ([run 27049725809](https://github.com/eclipse-symphony/symphony/actions/runs/27049725809)). Raised `TEST_TIMEOUT` to 10m, matching the other scenarios. 08/10/11 also use 4m but have no recorded failures, so they're untouched.
3. **Transient registry failures during image build** — `mage build:all` occasionally fails on MCR mirror metadata resolution ([run 26776691340](https://github.com/eclipse-symphony/symphony/actions/runs/26776691340)). Wrapped it in a 3-attempt retry (30s backoff, still exits 1 after 3 failures) in `integration.yml` and `suite.yml`. `mage cluster:up` is not retried.

Test infrastructure and workflow YAML only; no product logic changed. The fault workflow's failures are a separate problem domain, out of scope here.