### PR TITLE
Fix fault test flakiness: helm release race, webhook readiness probe, missing failpoints, and failpoint health check

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/solutionversion/solutionversion-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/solutionversion/solutionversion-manager.go
@@ -256,6 +256,8 @@ func (s *SolutionVersionManager) Reconcile(ctx context.Context, deployment model
 	defer func() {
 		if r := recover(); r == nil {
 			log.DebugfCtx(ctx, " M (SolutionVersion): Reconcile conclude Summary. Namespace: %v, deployment instance: %v, summary message: %v", namespace, deployment.Instance, summary.SummaryMessage)
+			// DO NOT REMOVE THIS COMMENT
+			// gofail: var beforeConcludeSummary string
 			s.concludeSummary(ctx, deployment.Instance.ObjectMeta.Name, summaryId, deployment.Generation, deployment.Hash, summary, namespace)
 		} else {
 			log.ErrorfCtx(ctx, " M (SolutionVersion): panic happens: %v", debug.Stack())

--- a/api/pkg/apis/v1alpha1/vendors/stage-vendor.go
+++ b/api/pkg/apis/v1alpha1/vendors/stage-vendor.go
@@ -191,6 +191,9 @@ func (s *StageVendor) Init(config vendors.VendorConfig, factories []managers.IMa
 
 			status, activation := s.StageManager.HandleTriggerEvent(ctx, *campaignversion.Spec, triggerData)
 
+			// DO NOT REMOVE THIS COMMENT
+			// gofail: var afterRunTrigger string
+
 			if triggerData.NeedsReport {
 				sLog.DebugfCtx(ctx, "V (Stage): reporting status: %v", status)
 				s.Vendor.Context.Publish("report", v1alpha2.Event{

--- a/test/integration/lib/testhelpers/helpers.go
+++ b/test/integration/lib/testhelpers/helpers.go
@@ -89,16 +89,42 @@ func SetupCluster() error {
 		return err
 	}
 
-	// Wait a few secs for symphony cert to be ready;
-	// otherwise we will see error when creating symphony manifests in the cluster
-	// <Error from server (InternalError): error when creating
-	// "/mnt/vss/_work/1/s/test/integration/scenarios/basic/manifest/target.yaml":
-	// Internal error occurred: failed calling webhook "mtarget.kb.io": failed to
-	// call webhook: Post
-	// "https://symphony-webhook-service.default.svc:443/mutate-symphony-microsoft-com-v1-target?timeout=10s":
-	// x509: certificate signed by unknown authority>
-	time.Sleep(time.Second * 10)
-	return nil
+	// Wait until the admission webhooks are actually serving. cert-manager's
+	// cainjector updates the webhook caBundle asynchronously; a fixed sleep is
+	// not enough on a loaded runner (observed as "InternalError: failed calling
+	// webhook" on the first CR apply after deploy).
+	return waitForWebhooksReady()
+}
+
+// waitForWebhooksReady probes the admission webhooks with a server dry-run
+// apply of a minimal Target. Output containing "failed calling webhook" or
+// "InternalError" means the webhook/caBundle is not ready yet; anything else
+// (including a validation rejection, which proves the webhook answered) is
+// treated as ready. The dry-run persists nothing.
+func waitForWebhooksReady() error {
+	probeManifest := `apiVersion: fabric.symphony/v1
+kind: Target
+metadata:
+  name: webhook-readiness-probe
+  namespace: default
+spec:
+  displayName: probe
+`
+	probeFile := filepath.Join(os.TempDir(), "symphony-webhook-probe.yaml")
+	if err := os.WriteFile(probeFile, []byte(probeManifest), 0644); err != nil {
+		return err
+	}
+	defer os.Remove(probeFile)
+
+	ctx := context.Background()
+	for i := 0; i < 24; i++ {
+		out, _ := shell.Output(ctx, fmt.Sprintf("kubectl apply --dry-run=server -f %s 2>&1", probeFile))
+		if !strings.Contains(string(out), "failed calling webhook") && !strings.Contains(string(out), "InternalError") {
+			return nil
+		}
+		time.Sleep(5 * time.Second)
+	}
+	return fmt.Errorf("timed out waiting for admission webhooks to become ready")
 }
 
 // Clean up

--- a/test/integration/scenarios/faultTests/README.md
+++ b/test/integration/scenarios/faultTests/README.md
@@ -16,6 +16,8 @@ Add a comment line like example blow. Gofail package will translate it to the fa
 // gofail: var beforeProviders string
 ```
 
+> **Note**: every failpoint referenced by a test case must have a matching marker in the code. A missing marker does not fail the scenario — the injection silently no-ops (`failpoint does not exist` in the logs) and the test passes without testing anything. After adding a case, check the scenario logs for `failpoint does not exist` to confirm the injection is real.
+
 2. Add a new fault test case
 
 There are already two fault tests - solutionversion upgrade and workflow materialize in the faultTests folder. You can add a new case in the [constants.go](./utils/constants.go) you want to use existing fault tests with new failpoint.
@@ -31,6 +33,10 @@ For example, you can specify the test, the pod to inject failure, the failpoint 
 ```
 
 You can also add new fault tests under faultTests if the existing ones don't hit the new failpoints.
+
+# How injection works
+
+For every probe and injection, the test process dials a fresh port-forward to the current live pod for the case's label and talks to the failpoint server (`localhost:22381` inside the pod) over plain HTTP. Retries re-resolve the pod each time, so the channel recovers when a `panic` fault restarts the pod. Nothing needs to be installed in the target image (no `curl`).
 
 # Run tests
 

--- a/test/integration/scenarios/faultTests/magefile.go
+++ b/test/integration/scenarios/faultTests/magefile.go
@@ -41,17 +41,12 @@ func FaultTestHelper(test utils.FaultTestCase) error {
 	if err != nil {
 		return err
 	}
-	// Step 2.2: enable port forward on specific pod
-	stopChan := make(chan struct{}, 1)
-	defer close(stopChan)
-	err = testhelpers.EnablePortForward(test.PodLabel, utils.LocalPortForward, stopChan)
-	if err != nil {
-		return err
-	}
-
-	InjectCommand := fmt.Sprintf("curl localhost:%s/%s -XPUT -d'%s'", utils.LocalPortForward, test.Fault, test.FaultType)
-	os.Setenv(utils.InjectFaultEnvKey, InjectCommand)
+	// Step 2.2: pass the fault info to the test process. Each injection dials
+	// a fresh port-forward to the live pod; a long-lived port-forward set up
+	// here does not survive the pod restarting after a panic fault.
 	os.Setenv(utils.PodEnvKey, test.PodLabel)
+	os.Setenv(utils.FaultNameEnvKey, test.Fault)
+	os.Setenv(utils.FaultTypeEnvKey, test.FaultType)
 
 	err = Verify(test.TestCase)
 	return err

--- a/test/integration/scenarios/faultTests/solution/update/verify/manifest_test.go
+++ b/test/integration/scenarios/faultTests/solution/update/verify/manifest_test.go
@@ -160,7 +160,10 @@ func Scenario_Update(t *testing.T, namespace string) {
 				continue
 			}
 
-			for i := 0; i < 10; i++ {
+			// The injected panic faults restart the api/controller-manager pod,
+			// which also takes the admission webhooks offline for up to a
+			// minute; keep retrying until the webhook endpoint is back.
+			for i := 0; i < 24; i++ {
 				err = shellcmd.Command(fmt.Sprintf("kubectl apply -f %s -n %s", fullPath, namespace)).Run()
 				if err == nil {
 					break

--- a/test/integration/scenarios/faultTests/utils/constants.go
+++ b/test/integration/scenarios/faultTests/utils/constants.go
@@ -9,9 +9,10 @@ package utils
 const (
 	TEST_TIMEOUT      = "30m"
 	LocalPortForward  = "22381"
-	InjectFaultEnvKey = "InjectFaultCommand"
 	DeleteFaultEnvKey = "DeleteFaultCommand"
 	PodEnvKey         = "InjectPodLabel"
+	FaultNameEnvKey   = "InjectFaultName"
+	FaultTypeEnvKey   = "InjectFaultType"
 )
 
 type FaultTestCase struct {

--- a/test/integration/scenarios/faultTests/utils/constants.go
+++ b/test/integration/scenarios/faultTests/utils/constants.go
@@ -64,12 +64,6 @@ var (
 		},
 		{
 			TestCase:  TestCases["solutionversionUpdate"],
-			PodLabel:  PodLabels["api"],
-			Fault:     "beforeConcludeSummary",
-			FaultType: DefaultFaultType,
-		},
-		{
-			TestCase:  TestCases["solutionversionUpdate"],
 			PodLabel:  PodLabels["k8s"],
 			Fault:     "beforePollingResult",
 			FaultType: DefaultFaultType,

--- a/test/integration/scenarios/faultTests/utils/helpers.go
+++ b/test/integration/scenarios/faultTests/utils/helpers.go
@@ -9,88 +9,160 @@ package utils
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
 
 	"github.com/eclipse-symphony/symphony/test/integration/lib/testhelpers"
-	"github.com/princjef/mageutil/shellcmd"
 )
 
-func WaitFailpointServer(podlabel string) error {
+// failpointBaseURL dials a fresh port-forward to the current running pod for
+// the label and returns the base URL of its failpoint server plus a cleanup
+// func. The port-forward created at scenario start does not survive the pod
+// restarting after a panic fault, so every probe/injection dials a new one
+// against the live pod.
+func failpointBaseURL(podLabel string) (string, func(), error) {
+	config, err := testhelpers.RestConfig()
+	if err != nil {
+		return "", nil, err
+	}
 	clientset, err := testhelpers.KubeClient()
 	if err != nil {
-		return err
+		return "", nil, err
 	}
-	err = testhelpers.WaitPodOnline(podlabel)
+	podList, err := clientset.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{
+		LabelSelector: podLabel,
+	})
 	if err != nil {
+		return "", nil, err
+	}
+	podName := ""
+	for _, pod := range podList.Items {
+		if pod.Status.Phase == corev1.PodRunning {
+			podName = pod.Name
+			break
+		}
+	}
+	if podName == "" {
+		return "", nil, fmt.Errorf("no running pod for label %s", podLabel)
+	}
+
+	url := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Namespace("default").
+		Name(podName).
+		SubResource("portforward").
+		URL()
+	transport, upgrader, err := spdy.RoundTripperFor(config)
+	if err != nil {
+		return "", nil, err
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", url)
+	stopChan := make(chan struct{})
+	readyChan := make(chan struct{})
+	// Local port 0: let the OS pick a free port
+	forwarder, err := portforward.New(dialer, []string{"0:" + LocalPortForward}, stopChan, readyChan, io.Discard, io.Discard)
+	if err != nil {
+		return "", nil, err
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- forwarder.ForwardPorts()
+	}()
+	select {
+	case <-readyChan:
+	case err := <-errCh:
+		return "", nil, err
+	case <-time.After(15 * time.Second):
+		close(stopChan)
+		return "", nil, fmt.Errorf("timeout waiting for port-forwarding to be ready")
+	}
+	ports, err := forwarder.GetPorts()
+	if err != nil {
+		close(stopChan)
+		return "", nil, err
+	}
+	return fmt.Sprintf("http://127.0.0.1:%d", ports[0].Local), func() { close(stopChan) }, nil
+}
+
+// requestFailpoint issues a request to the pod's failpoint server, retrying
+// with a fresh port-forward each time while the pod recovers from a previous
+// fault (e.g. a panic restart).
+func requestFailpoint(podLabel string, method string, path string, body string) error {
+	var lastErr error
+	for i := 0; i < 18; i++ {
+		base, cleanup, err := failpointBaseURL(podLabel)
+		if err == nil {
+			var resp *http.Response
+			req, err := http.NewRequest(method, strings.TrimSuffix(base, "/")+"/"+path, strings.NewReader(body))
+			if err == nil {
+				client := &http.Client{Timeout: 10 * time.Second}
+				resp, err = client.Do(req)
+			}
+			if err == nil {
+				_, _ = io.Copy(io.Discard, resp.Body)
+				resp.Body.Close()
+				if resp.StatusCode < 300 {
+					cleanup()
+					return nil
+				}
+				err = fmt.Errorf("failpoint server returned %s", resp.Status)
+			}
+			cleanup()
+		}
+		lastErr = err
+		fmt.Println("failed to connect to failpoint server, waiting...")
+		time.Sleep(10 * time.Second)
+	}
+	return fmt.Errorf("timeout waiting for failpoint server of %s: %v", podLabel, lastErr)
+}
+
+// WaitFailpointServer waits until the pod's failpoint server answers. GET /
+// lists the registered failpoints, which doubles as a readiness check.
+func WaitFailpointServer(podlabel string) error {
+	if err := testhelpers.WaitPodOnline(podlabel); err != nil {
 		return err
 	}
-	pods := clientset.CoreV1().Pods("default")
-	for i := 0; i < 10; i++ {
-		podList, err := pods.List(context.Background(), metav1.ListOptions{
-			LabelSelector: podlabel,
-		})
-		if err != nil {
-			return err
-		}
-		if len(podList.Items) > 0 {
-			pod := podList.Items[0]
-			if pod.Status.Phase == corev1.PodRunning {
-				// Probe from the host: a port-forward to the failpoint server
-				// is already set up for this pod label, so localhost:22381
-				// reaches the pod regardless of whether the image ships curl.
-				err = testhelpers.ShellExec("curl -sf -o /dev/null localhost:22381")
-				if err == nil {
-					return nil
-				} else {
-					fmt.Println("failed to connect to failpoint server, waiting...")
-				}
-			} else {
-				fmt.Println("pod not ready yet, waiting..." + pod.Status.Phase)
-			}
-		}
-		time.Sleep(time.Second * 10)
-	}
-	return fmt.Errorf("timeout waiting for pod to be ready")
+	return requestFailpoint(podlabel, http.MethodGet, "", "")
 }
 
 func InjectPodFailure() error {
-	InjectCommand := os.Getenv(InjectFaultEnvKey)
 	PodLabel := os.Getenv(PodEnvKey)
-	if InjectCommand == "" || PodLabel == "" {
-		fmt.Println("InjectCommand is ", InjectCommand, "and InjectPodLabel is ", PodLabel, ", skip error injection")
+	Fault := os.Getenv(FaultNameEnvKey)
+	FaultType := os.Getenv(FaultTypeEnvKey)
+	if Fault == "" || PodLabel == "" {
+		fmt.Println("Fault is ", Fault, "and InjectPodLabel is ", PodLabel, ", skip error injection")
 		return nil
 	}
 
-	if err := WaitFailpointServer(PodLabel); err != nil {
+	if err := requestFailpoint(PodLabel, http.MethodPut, Fault, FaultType); err != nil {
+		fmt.Println("Failed to inject pod failure: " + err.Error())
 		return err
 	}
-	err := shellcmd.Command(InjectCommand).Run()
-	if err != nil {
-		fmt.Println("Failed to inject pod failure: " + err.Error())
-	}
 	fmt.Println("Injected fault")
-	return err
+	return nil
 }
 
 func DeletePodFailure() error {
 	DeleteCommand := os.Getenv(DeleteFaultEnvKey)
 	PodLabel := os.Getenv(PodEnvKey)
-	if DeleteCommand == "" || PodLabel == "" {
-		fmt.Println("DeleteCommand is ", DeleteCommand, "and PodLabel is ", PodLabel, ", skip error injection")
+	Fault := os.Getenv(FaultNameEnvKey)
+	if DeleteCommand == "" || Fault == "" || PodLabel == "" {
+		fmt.Println("DeleteCommand is ", DeleteCommand, "and InjectPodLabel is ", PodLabel, ", skip error injection")
 		return nil
 	}
 
-	if err := WaitFailpointServer(PodLabel); err != nil {
+	if err := requestFailpoint(PodLabel, http.MethodDelete, Fault, ""); err != nil {
+		fmt.Println("Failed to delete pod failure: " + err.Error())
 		return err
 	}
-	err := shellcmd.Command(DeleteCommand).Run()
-	if err != nil {
-		fmt.Println("Failed to delete pod failure: " + err.Error())
-	}
 	fmt.Println("Deleted fault")
-	return err
+	return nil
 }

--- a/test/integration/scenarios/faultTests/utils/helpers.go
+++ b/test/integration/scenarios/faultTests/utils/helpers.go
@@ -39,7 +39,10 @@ func WaitFailpointServer(podlabel string) error {
 		if len(podList.Items) > 0 {
 			pod := podList.Items[0]
 			if pod.Status.Phase == corev1.PodRunning {
-				err = testhelpers.ShellExec(fmt.Sprintf("kubectl exec %s -- curl localhost:22381", pod.Name))
+				// Probe from the host: a port-forward to the failpoint server
+				// is already set up for this pod label, so localhost:22381
+				// reaches the pod regardless of whether the image ships curl.
+				err = testhelpers.ShellExec("curl -sf -o /dev/null localhost:22381")
 				if err == nil {
 					return nil
 				} else {
@@ -62,7 +65,9 @@ func InjectPodFailure() error {
 		return nil
 	}
 
-	WaitFailpointServer(PodLabel)
+	if err := WaitFailpointServer(PodLabel); err != nil {
+		return err
+	}
 	err := shellcmd.Command(InjectCommand).Run()
 	if err != nil {
 		fmt.Println("Failed to inject pod failure: " + err.Error())
@@ -79,7 +84,9 @@ func DeletePodFailure() error {
 		return nil
 	}
 
-	WaitFailpointServer(PodLabel)
+	if err := WaitFailpointServer(PodLabel); err != nil {
+		return err
+	}
 	err := shellcmd.Command(DeleteCommand).Run()
 	if err != nil {
 		fmt.Println("Failed to delete pod failure: " + err.Error())

--- a/test/localenv/magefile.go
+++ b/test/localenv/magefile.go
@@ -159,6 +159,10 @@ func (Cluster) Deploy() error {
 	fmt.Printf("Deploying symphony to minikube\n")
 	mg.Deps(ensureMinikubeUp)
 
+	if err := waitForReleaseCleanup(); err != nil {
+		return err
+	}
+
 	if enableTlsOtelSetup() {
 		err := ensureSecureOtelCollectorPrereqs()
 		if err != nil {
@@ -181,6 +185,10 @@ func (Cluster) Deploy() error {
 func (Cluster) DeployWithSettings(values string) error {
 	fmt.Printf("Deploying symphony to minikube with settings, %s\n", values)
 	mg.Deps(ensureMinikubeUp)
+
+	if err := waitForReleaseCleanup(); err != nil {
+		return err
+	}
 
 	if enableTlsOtelSetup() {
 		err := ensureSecureOtelCollectorPrereqs()
@@ -402,7 +410,28 @@ func Destroy(flags string) error {
 		}
 	}
 
-	return nil
+	return waitForReleaseCleanup()
+}
+
+// waitForReleaseCleanup waits until no helm release record (in any status)
+// remains for the chart. A leftover release in "uninstalling" or "failed"
+// state makes the next `helm upgrade --install` fail with
+// "UPGRADE FAILED: <name> has no deployed releases".
+func waitForReleaseCleanup() error {
+	for i := 0; i < 18; i++ {
+		out, err := shellcmd.Command(fmt.Sprintf("helm list -a -n %s -f '^%s$' -o json", getChartNamespace(), getReleaseName())).Output()
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(string(out)) == "[]" {
+			return nil
+		}
+		// Nudge a stuck release towards deletion; ignore errors since it may
+		// already be uninstalling
+		_ = shellcmd.Command(fmt.Sprintf("helm uninstall %s -n %s --wait", getReleaseName(), getChartNamespace())).Run()
+		time.Sleep(10 * time.Second)
+	}
+	return fmt.Errorf("timed out waiting for helm release %s to be removed", getReleaseName())
 }
 
 // Build builds all containers


### PR DESCRIPTION
Fix four recurring fault-workflow flakes seen on main:

- **Helm release race**: after `mage destroy all,nowait`, the next scenario's deploy fails with `UPGRADE FAILED: "ecosystem" has no deployed releases` ([run 30286223337](https://github.com/eclipse-symphony/symphony/actions/runs/30286223337), [run 28533807779](https://github.com/eclipse-symphony/symphony/actions/runs/28533807779)). `Destroy` never confirms the helm release record is gone. Now both `Destroy` paths wait for it, and `Cluster.Deploy`/`DeployWithSettings` check defensively before install.
- **Webhook not ready**: first CR apply after deploy is rejected with `InternalError: failed calling webhook` ([run 28959256178](https://github.com/eclipse-symphony/symphony/actions/runs/28959256178)). cert-manager injects the caBundle asynchronously, so the fixed 10s sleep isn't always enough. `SetupCluster` now probes with a server dry-run apply until the webhooks answer.
- **Rotten failpoints**: `beforeConcludeSummary` (listed twice) and `afterRunTrigger` never had gofail markers in the code, so those scenarios inject nothing (`failpoint does not exist` in run 30286223337 logs). Added the two markers and deduped the list (14 → 13 scenarios). The markers are inert comments in normal builds.
- **Stale failpoint channel**: the probe used `kubectl exec ... curl` (the controller-manager image has no curl — 10x exit 127 per k8s scenario), and both probe and injection went through a single port-forward that does not survive the pod restarting after a panic fault. Probe and injection now run from the test process over a freshly dialed port-forward to the live pod, with retries while the pod recovers. Mid-test applies also now retry for 2 minutes so they outlast the webhook downtime caused by an intentional controller-manager panic.

**Validation**: full fault workflow passed on my fork ([run 30633235988](https://github.com/lirenjie95/symphony/actions/runs/30633235988)) — all 13 scenarios green, none of the four signatures in the logs, and the two previously-missing failpoints inject for real. The helm race is timing-dependent, so a single green run can't fully prove it out, but the destroy→deploy cycle ran 13 times without hitting it.
