### PR TITLE
Add shared HTTP request helper and stage-level retry support

### DIFF
--- a/api/pkg/apis/v1alpha1/managers/stage/stage-manager.go
+++ b/api/pkg/apis/v1alpha1/managers/stage/stage-manager.go
@@ -14,7 +14,9 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	symproviders "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/stage"
@@ -346,6 +348,50 @@ func (p *GoRoutineTaskProcessor) Process(ctx context.Context, tasks []model.Task
 	}
 
 	return taskProcessor.TaskResults, nil
+}
+
+// processWithRetry executes fn and retries on error according to the stage's
+// retry spec. A nil spec or MaxRetries <= 0 means fn is called exactly once.
+// Interval (duration format, e.g. "10s") uses a fixed delay between attempts;
+// empty Interval falls back to exponential backoff. Panics from fn are not
+// handled; only returned errors trigger a retry.
+func processWithRetry(ctx context.Context, retry *model.RetrySpec, fn func() (map[string]interface{}, bool, error)) (map[string]interface{}, bool, error) {
+	outputs, pause, err := fn()
+	if err == nil || retry == nil || retry.MaxRetries <= 0 {
+		return outputs, pause, err
+	}
+
+	useBackoff := true
+	var fixedInterval time.Duration
+	if retry.Interval != "" {
+		if d, pErr := time.ParseDuration(retry.Interval); pErr == nil {
+			fixedInterval = d
+			useBackoff = false
+		} else {
+			log.WarnfCtx(ctx, " M (Stage): invalid retry interval %q, falling back to exponential backoff: %v", retry.Interval, pErr)
+		}
+	}
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = 2 * time.Second // Initial retry interval.
+	b.MaxInterval = 30 * time.Second    // Maximum retry interval.
+
+	for attempt := 1; attempt <= retry.MaxRetries; attempt++ {
+		wait := fixedInterval
+		if useBackoff {
+			wait = b.NextBackOff()
+		}
+		log.InfofCtx(ctx, " M (Stage): retrying stage process after error (attempt %d/%d): %v", attempt, retry.MaxRetries, err)
+		select {
+		case <-ctx.Done():
+			return outputs, pause, ctx.Err()
+		case <-time.After(wait):
+		}
+		outputs, pause, err = fn()
+		if err == nil {
+			return outputs, pause, nil
+		}
+	}
+	return outputs, pause, err
 }
 
 func (s *StageManager) processTasks(ctx context.Context, currentStage model.StageSpec, inputCopy map[string]interface{}, triggerData v1alpha2.ActivationData, triggers map[string]interface{}, siteName string) (map[string]interface{}, error) {
@@ -1099,9 +1145,13 @@ func (s *StageManager) HandleTriggerEvent(ctx context.Context, campaignversion m
 						}
 						triggerDataForProxy.Inputs = proxyInputs
 
-						outputs, pause, iErr = proxyProvider.(stage.IProxyStageProvider).Process(ctx, *s.Manager.Context, triggerDataForProxy)
+						outputs, pause, iErr = processWithRetry(ctx, currentStage.Retry, func() (map[string]interface{}, bool, error) {
+							return proxyProvider.(stage.IProxyStageProvider).Process(ctx, *s.Manager.Context, triggerDataForProxy)
+						})
 					} else {
-						outputs, pause, iErr = provider.(stage.IStageProvider).Process(ctx, *s.Manager.Context, inputCopy)
+						outputs, pause, iErr = processWithRetry(ctx, currentStage.Retry, func() (map[string]interface{}, bool, error) {
+							return provider.(stage.IStageProvider).Process(ctx, *s.Manager.Context, inputCopy)
+						})
 					}
 					if iErr != nil {
 						log.ErrorfCtx(ctx, " M (Stage): failed to process stage %s for site %s: %v", triggerData.Stage, site, iErr)

--- a/api/pkg/apis/v1alpha1/managers/stage/stage-manager_test.go
+++ b/api/pkg/apis/v1alpha1/managers/stage/stage-manager_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/eclipse-symphony/symphony/api/constants"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
+	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/stage/flaky"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
@@ -2096,4 +2097,114 @@ func TestActivationSelfReferencingInput_FailsButSurvives(t *testing.T) {
 		}
 	}
 	assert.Equal(t, v1alpha2.Done, status2.Status)
+}
+
+func TestStageRetryEventuallySucceeds(t *testing.T) {
+	flaky.ResetCallCount("retry-success")
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	manager := StageManager{
+		StateProvider: stateProvider,
+	}
+	manager.VendorContext = &contexts.VendorContext{
+		EvaluationContext: &coa_utils.EvaluationContext{},
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+		},
+	}
+	manager.Context = &contexts.ManagerContext{
+		VencorContext: manager.VendorContext,
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+		},
+	}
+	var status model.StageStatus
+	activation := &v1alpha2.ActivationData{
+		CampaignVersion:             "test-campaignversion",
+		Activation:           "test-activation",
+		Stage:                "test",
+		ActivationGeneration: "1",
+		Outputs:              nil,
+		Provider:             "providers.stage.flaky",
+		Config: flaky.FlakyStageProviderConfig{
+			ID:        "retry-success",
+			FailTimes: 2,
+		},
+		Namespace: "fakens",
+	}
+	for {
+		status, activation = manager.HandleTriggerEvent(context.Background(), model.CampaignVersionSpec{
+			SelfDriving: true,
+			FirstStage:  "test",
+			Stages: map[string]model.StageSpec{
+				"test": {
+					Provider: "providers.stage.flaky",
+					Retry: &model.RetrySpec{
+						MaxRetries: 2,
+						Interval:   "1ms",
+					},
+				},
+			},
+		}, *activation)
+
+		if activation == nil {
+			break
+		}
+	}
+	assert.Equal(t, v1alpha2.Done, status.Status)
+	assert.True(t, v1alpha2.Done.EqualsWithString(status.StatusMessage))
+	// 2 failures + 1 success
+	assert.Equal(t, 3, flaky.GetCallCount("retry-success"))
+}
+
+func TestStageWithoutRetryFailsImmediately(t *testing.T) {
+	flaky.ResetCallCount("retry-none")
+	stateProvider := &memorystate.MemoryStateProvider{}
+	stateProvider.Init(memorystate.MemoryStateProviderConfig{})
+	manager := StageManager{
+		StateProvider: stateProvider,
+	}
+	manager.VendorContext = &contexts.VendorContext{
+		EvaluationContext: &coa_utils.EvaluationContext{},
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+		},
+	}
+	manager.Context = &contexts.ManagerContext{
+		VencorContext: manager.VendorContext,
+		SiteInfo: v1alpha2.SiteInfo{
+			SiteId: "fake",
+		},
+	}
+	var status model.StageStatus
+	activation := &v1alpha2.ActivationData{
+		CampaignVersion:             "test-campaignversion",
+		Activation:           "test-activation",
+		Stage:                "test",
+		ActivationGeneration: "1",
+		Outputs:              nil,
+		Provider:             "providers.stage.flaky",
+		Config: flaky.FlakyStageProviderConfig{
+			ID:        "retry-none",
+			FailTimes: 5,
+		},
+		Namespace: "fakens",
+	}
+	for {
+		status, activation = manager.HandleTriggerEvent(context.Background(), model.CampaignVersionSpec{
+			SelfDriving: true,
+			FirstStage:  "test",
+			Stages: map[string]model.StageSpec{
+				"test": {
+					Provider: "providers.stage.flaky",
+				},
+			},
+		}, *activation)
+
+		if activation == nil {
+			break
+		}
+	}
+	assert.Equal(t, v1alpha2.InternalError, status.Status)
+	assert.Equal(t, 1, flaky.GetCallCount("retry-none"))
 }

--- a/api/pkg/apis/v1alpha1/model/campaignversion.go
+++ b/api/pkg/apis/v1alpha1/model/campaignversion.go
@@ -73,6 +73,15 @@ type TaskSpec struct {
 	Target   string                 `json:"target,omitempty"`
 }
 
+// +kubebuilder:object:generate=true
+type RetrySpec struct {
+	// MaxRetries is the number of additional attempts after the first failure
+	MaxRetries int `json:"maxRetries,omitempty"`
+	// Interval is the delay between retries in duration format (e.g. "10s", "1m");
+	// empty means exponential backoff
+	Interval string `json:"interval,omitempty"`
+}
+
 type StageSpec struct {
 	Name          string                 `json:"name,omitempty"`
 	Contexts      string                 `json:"contexts,omitempty"`
@@ -82,6 +91,7 @@ type StageSpec struct {
 	Inputs        map[string]interface{} `json:"inputs,omitempty"`
 	HandleErrors  bool                   `json:"handleErrors,omitempty"`
 	Schedule      string                 `json:"schedule,omitempty"`
+	Retry         *RetrySpec             `json:"retry,omitempty"`
 	Proxy         *v1alpha2.ProxySpec    `json:"proxy,omitempty"`
 	Target        string                 `json:"target,omitempty"`
 	Tasks         []TaskSpec             `json:"tasks,omitempty"`

--- a/api/pkg/apis/v1alpha1/providers/providerfactory.go
+++ b/api/pkg/apis/v1alpha1/providers/providerfactory.go
@@ -16,6 +16,7 @@ import (
 	counterstage "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/stage/counter"
 	symphonystage "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/stage/create"
 	delaystage "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/stage/delay"
+	flakystage "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/stage/flaky"
 	httpstage "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/stage/http"
 	liststage "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/stage/list"
 	materialize "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/stage/materialize"
@@ -171,6 +172,12 @@ func (s SymphonyProviderFactory) CreateProvider(providerType string, config cp.I
 		}
 	case "providers.stage.counter":
 		mProvider := &counterstage.CounterStageProvider{}
+		err = mProvider.Init(config)
+		if err == nil {
+			return mProvider, nil
+		}
+	case "providers.stage.flaky":
+		mProvider := &flakystage.FlakyStageProvider{}
 		err = mProvider.Init(config)
 		if err == nil {
 			return mProvider, nil

--- a/api/pkg/apis/v1alpha1/providers/stage/flaky/flaky.go
+++ b/api/pkg/apis/v1alpha1/providers/stage/flaky/flaky.go
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package flaky
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/providers"
+	"github.com/eclipse-symphony/symphony/coa/pkg/logger"
+)
+
+var fLog = logger.NewLogger("coa.runtime")
+
+// callCounts tracks Process invocations per provider ID across instances,
+// since the stage manager creates a new provider instance per trigger.
+var (
+	callCounts     = make(map[string]int)
+	callCountsLock sync.Mutex
+)
+
+// GetCallCount returns how many times Process was called for the given ID.
+func GetCallCount(id string) int {
+	callCountsLock.Lock()
+	defer callCountsLock.Unlock()
+	return callCounts[id]
+}
+
+// ResetCallCount clears the invocation counter for the given ID.
+func ResetCallCount(id string) {
+	callCountsLock.Lock()
+	defer callCountsLock.Unlock()
+	delete(callCounts, id)
+}
+
+type FlakyStageProviderConfig struct {
+	ID string `json:"id"`
+	// FailTimes is the number of initial Process calls that return an error
+	FailTimes int `json:"failTimes"`
+}
+
+type FlakyStageProvider struct {
+	Config  FlakyStageProviderConfig
+	Context *contexts.ManagerContext
+}
+
+func (f *FlakyStageProvider) Init(config providers.IProviderConfig) error {
+	flakyConfig, err := toFlakyStageProviderConfig(config)
+	if err != nil {
+		return err
+	}
+	f.Config = flakyConfig
+	return nil
+}
+
+func (f *FlakyStageProvider) SetContext(ctx *contexts.ManagerContext) {
+	f.Context = ctx
+}
+
+func toFlakyStageProviderConfig(config providers.IProviderConfig) (FlakyStageProviderConfig, error) {
+	ret := FlakyStageProviderConfig{}
+	data, err := json.Marshal(config)
+	if err != nil {
+		return ret, err
+	}
+	err = json.Unmarshal(data, &ret)
+	return ret, err
+}
+
+func (f *FlakyStageProvider) Process(ctx context.Context, mgrContext contexts.ManagerContext, inputs map[string]interface{}) (map[string]interface{}, bool, error) {
+	callCountsLock.Lock()
+	callCounts[f.Config.ID]++
+	calls := callCounts[f.Config.ID]
+	callCountsLock.Unlock()
+
+	if calls <= f.Config.FailTimes {
+		fLog.InfofCtx(ctx, "  P (Flaky Stage): failing attempt %d/%d for %s", calls, f.Config.FailTimes, f.Config.ID)
+		return nil, false, fmt.Errorf("flaky stage provider %s failed on attempt %d", f.Config.ID, calls)
+	}
+
+	outputs := make(map[string]interface{})
+	for k, v := range inputs {
+		outputs[k] = v
+	}
+	return outputs, false, nil
+}

--- a/api/pkg/apis/v1alpha1/providers/target/azure/iotedge/iotedge.go
+++ b/api/pkg/apis/v1alpha1/providers/target/azure/iotedge/iotedge.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"regexp"
 	"strings"
@@ -563,17 +562,7 @@ func (i *IoTEdgeTargetProvider) getIoTEdgeModuleTwin(ctx context.Context, id str
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", sasToken)
-	resp, err := client.Do(req)
-	if err != nil {
-		sLog.ErrorfCtx(ctx, "  P (IoT Edge Target): failed to get IoT Edge modules: %v", err)
-		return module, v1alpha2.NewCOAError(err, "failed to get IoT Edge modules", v1alpha2.InternalError)
-	}
-	if resp.StatusCode != http.StatusOK {
-		sLog.ErrorfCtx(ctx, "  P (IoT Edge Target): failed to get IoT Edge modules: %v", resp)
-		//return module, v1alpha1.NewCOAError(nil, "failed to get IoT Edge modules", v1alpha1.InternalError) //TODO: carry over HTTP status code
-	}
-	defer resp.Body.Close()
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := utils.DoHTTPRequest(client, req, 3, "get IoT Edge modules")
 	if err != nil {
 		sLog.ErrorfCtx(ctx, "  P (IoT Edge Target): failed to get IoT Edge modules: %v", err)
 		return module, v1alpha2.NewCOAError(err, "failed to get IoT Edge modules", v1alpha2.InternalError)

--- a/api/pkg/apis/v1alpha1/providers/target/helm/auth.go
+++ b/api/pkg/apis/v1alpha1/providers/target/helm/auth.go
@@ -108,19 +108,20 @@ func getHostFromOCIRef(ref string) (string, error) {
 // exchangeToken exchanges an Azure AD token for an ACR refresh token.
 // This is used by the Helm registry client to authenticate to ACR.
 func exchangeToken(host, token string) (string, error) {
-	form := tokenExchangeRequest{
+	req := tokenExchangeRequest{
 		GrantType:   "access_token",
 		Service:     host,
 		AccessToken: token,
-	}.ToFormValues()
+	}
+	form := req.ToFormValues()
 
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf(exchangeURLFormat, host), strings.NewReader(form.Encode()))
+	httpReq, err := http.NewRequest(http.MethodPost, fmt.Sprintf(exchangeURLFormat, host), strings.NewReader(form.Encode()))
 	if err != nil {
 		return "", err
 	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	body, err := apiutils.DoHTTPRequest(nil, req, 3, "exchange ACR token")
+	body, err := apiutils.DoHTTPRequest(nil, httpReq, 3, "exchange ACR token")
 	if err != nil {
 		return "", err
 	}

--- a/api/pkg/apis/v1alpha1/providers/target/helm/auth.go
+++ b/api/pkg/apis/v1alpha1/providers/target/helm/auth.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	apiutils "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"helm.sh/helm/v3/pkg/registry"
 	"oras.land/oras-go/v2/registry/remote/errcode"
 )
@@ -107,20 +108,25 @@ func getHostFromOCIRef(ref string) (string, error) {
 // exchangeToken exchanges an Azure AD token for an ACR refresh token.
 // This is used by the Helm registry client to authenticate to ACR.
 func exchangeToken(host, token string) (string, error) {
-	req := tokenExchangeRequest{
+	form := tokenExchangeRequest{
 		GrantType:   "access_token",
 		Service:     host,
 		AccessToken: token,
+	}.ToFormValues()
+
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf(exchangeURLFormat, host), strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
 	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	res := tokenExchangeResponse{}
-
-	jsonResponse, err := http.PostForm(fmt.Sprintf(exchangeURLFormat, host), req.ToFormValues())
+	body, err := apiutils.DoHTTPRequest(nil, req, 3, "exchange ACR token")
 	if err != nil {
 		return "", err
 	}
 
-	if err := json.NewDecoder(jsonResponse.Body).Decode(&res); err != nil {
+	res := tokenExchangeResponse{}
+	if err := json.Unmarshal(body, &res); err != nil {
 		return "", err
 	}
 

--- a/api/pkg/apis/v1alpha1/providers/target/helm/helm.go
+++ b/api/pkg/apis/v1alpha1/providers/target/helm/helm.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"reflect"
@@ -23,6 +22,7 @@ import (
 	"github.com/eclipse-symphony/symphony/api/constants"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/metrics"
+	apiutils "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils/metahelper"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
@@ -392,22 +392,19 @@ func isDownloadableUri(uri string) bool {
 	return strings.HasSuffix(uri, ".tgz") || strings.HasSuffix(uri, ".tar.gz")
 }
 
-// downloadFile will download a url to a local file. It's efficient because it will
+// downloadFile will download a url to a local file, with status-code checking
+// and retry on transient failures.
 func downloadFile(url string, fileName string) error {
-	resp, err := http.Get(url)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
-
-	fileHandle, err := os.OpenFile(fileName, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0644)
+	body, err := apiutils.DoHTTPRequest(nil, req, 3, "download helm chart")
 	if err != nil {
 		return err
 	}
-	defer fileHandle.Close()
 
-	_, err = io.Copy(fileHandle, resp.Body)
-	return err
+	return os.WriteFile(fileName, body, 0644)
 }
 
 // Apply deploys the helm chart for a given deployment

--- a/api/pkg/apis/v1alpha1/providers/target/kubectl/kubectl.go
+++ b/api/pkg/apis/v1alpha1/providers/target/kubectl/kubectl.go
@@ -23,6 +23,7 @@ import (
 	"github.com/eclipse-symphony/symphony/api/constants"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/model"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/providers/metrics"
+	apiutils "github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils"
 	"github.com/eclipse-symphony/symphony/api/pkg/apis/v1alpha1/utils/metahelper"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
 	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2/contexts"
@@ -918,14 +919,12 @@ func readYaml(yaml string) (<-chan []byte, <-chan error) {
 		chanBytes = make(chan []byte)
 	)
 	go func() {
-		response, err := http.Get(yaml)
+		req, err := http.NewRequest(http.MethodGet, yaml, nil)
 		if err != nil {
 			chanErr <- err
 			return
 		}
-		defer response.Body.Close()
-
-		data, err := io.ReadAll(response.Body)
+		data, err := apiutils.DoHTTPRequest(nil, req, 3, "download yaml")
 		if err != nil {
 			chanErr <- err
 			return

--- a/api/pkg/apis/v1alpha1/utils/httputil.go
+++ b/api/pkg/apis/v1alpha1/utils/httputil.go
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package utils
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+)
+
+// DoHTTPRequest executes an HTTP request with status-code checking and
+// optional retry on transient failures (network errors and 5xx).
+// It always closes the response body and returns the body bytes on success.
+//
+// client may be nil, in which case http.DefaultClient is used.
+// maxRetries is the number of additional attempts after the first failure;
+// 0 means the request is only tried once. Retries use exponential backoff.
+// The operation string is included in returned error messages to help
+// locate the failing call site.
+func DoHTTPRequest(client *http.Client, req *http.Request, maxRetries int, operation string) ([]byte, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = 2 * time.Second // Initial retry interval.
+	b.MaxInterval = 30 * time.Second    // Maximum retry interval.
+
+	var bodyBytes []byte
+	attempt := 0
+	err := backoff.Retry(func() error {
+		// Replay the request body on retries. Requests built with
+		// http.NewRequest and a bytes/strings reader get GetBody for free.
+		if attempt > 0 && req.Body != nil {
+			if req.GetBody == nil {
+				// The body was consumed by the first attempt and cannot be
+				// replayed, so retrying is pointless.
+				return backoff.Permanent(v1alpha2.NewCOAError(nil, fmt.Sprintf("%s: request body cannot be replayed for retry", operation), v1alpha2.InternalError))
+			}
+			body, bErr := req.GetBody()
+			if bErr != nil {
+				return backoff.Permanent(v1alpha2.NewCOAError(bErr, fmt.Sprintf("%s: failed to replay request body", operation), v1alpha2.InternalError))
+			}
+			req.Body = body
+		}
+		attempt++
+
+		resp, dErr := client.Do(req)
+		if dErr != nil {
+			return maybePermanent(dErr, attempt, maxRetries)
+		}
+		defer resp.Body.Close()
+
+		bodyBytes, dErr = io.ReadAll(resp.Body)
+		if dErr != nil {
+			return maybePermanent(dErr, attempt, maxRetries)
+		}
+
+		if resp.StatusCode >= 500 {
+			// 5xx is transient, retry if attempts remain
+			return maybePermanent(httpError(resp.StatusCode, bodyBytes, operation), attempt, maxRetries)
+		}
+		if resp.StatusCode >= 400 {
+			// 4xx is not retriable
+			return backoff.Permanent(httpError(resp.StatusCode, bodyBytes, operation))
+		}
+		return nil
+	}, b)
+	if err != nil {
+		return nil, err
+	}
+	return bodyBytes, nil
+}
+
+// maybePermanent wraps err as permanent once all retries are exhausted, so
+// backoff.Retry stops and returns the error to the caller.
+func maybePermanent(err error, attempt int, maxRetries int) error {
+	if attempt > maxRetries {
+		return backoff.Permanent(err)
+	}
+	return err
+}
+
+// httpError builds a COAError from an HTTP status code, carrying the
+// operation name and response body in the message.
+func httpError(statusCode int, body []byte, operation string) error {
+	coaErr := v1alpha2.FromHTTPResponseCode(statusCode, body)
+	return v1alpha2.NewCOAError(nil, fmt.Sprintf("%s: http status %d: %s", operation, statusCode, coaErr.Message), coaErr.State)
+}

--- a/api/pkg/apis/v1alpha1/utils/httputil_test.go
+++ b/api/pkg/apis/v1alpha1/utils/httputil_test.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
+ */
+
+package utils
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/eclipse-symphony/symphony/coa/pkg/apis/v1alpha2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDoHTTPRequestRetriesOn5xx(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, "boom")
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "ok")
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	assert.Nil(t, err)
+	body, err := DoHTTPRequest(nil, req, 1, "test op")
+	assert.Nil(t, err)
+	assert.Equal(t, "ok", string(body))
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls))
+}
+
+func TestDoHTTPRequestNoRetryOn4xx(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, "missing")
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	assert.Nil(t, err)
+	_, err = DoHTTPRequest(nil, req, 3, "test op")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "404")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+	// 4xx maps to the corresponding COA state
+	coaErr, ok := err.(v1alpha2.COAError)
+	assert.True(t, ok)
+	assert.Equal(t, v1alpha2.NotFound, coaErr.State)
+}
+
+func TestDoHTTPRequestNoRetriesConfigured(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "boom")
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	assert.Nil(t, err)
+	_, err = DoHTTPRequest(nil, req, 0, "test op")
+	assert.NotNil(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+}

--- a/packages/helm/symphony/templates/symphony-core/symphonyk8s.yaml
+++ b/packages/helm/symphony/templates/symphony-core/symphonyk8s.yaml
@@ -231,6 +231,13 @@ spec:
                         provider:
                           type: string
                       type: object
+                    retry:
+                      properties:
+                        interval:
+                          type: string
+                        maxRetries:
+                          type: integer
+                      type: object
                     schedule:
                       type: string
                     stageSelector:


### PR DESCRIPTION
Fixes #381

This PR implements the two long-term items from the issue:

**1. A shared util for HTTP requests.** New `utils.DoHTTPRequest` (`api/pkg/apis/v1alpha1/utils/httputil.go`) centralizes status-code checking and retry on transient failures (network errors and 5xx, exponential backoff; 4xx fails immediately). Four call sites are migrated to it:
- helm target provider `downloadFile`
- kubectl target provider yaml download
- helm ACR token exchange (also fixes a response body that was never closed)
- IoT Edge `getIoTEdgeModuleTwin` (a non-200 status was previously only logged; it now correctly returns an error)

Not migrated in this pass (can be moved over incrementally later): `symphony-api.go` `callRestAPI` (has its own 403 token-refresh flow), `apiclient.go` (already has backoff), the stage/target http providers (status codes are business output there), and the model router (pass-through semantics).

**2. Retries as a common setting on StageSpec.** `StageSpec` gains a `retry` field (`maxRetries`, plus an optional `interval` in duration format — empty means exponential backoff), next to `schedule`. The stage manager honors it in one central place, wrapping both the regular and the proxy `Process` calls in `HandleTriggerEvent`. `HandleDirectTriggerEvent` is not covered (no StageSpec context there) and neither is task-level retry on `TaskSpec` — both can be discussed separately. The campaignversions CRD schema is updated accordingly.

**Tests:** unit tests for `DoHTTPRequest` (5xx retried, 4xx not retried, maxRetries=0) and stage-manager tests with a new counting `providers.stage.flaky` provider (stage with `retry: {maxRetries: 2}` succeeds on the 3rd attempt; stage without retry fails on the 1st).